### PR TITLE
Add total news count indicator to home page

### DIFF
--- a/src/app/actions.ts
+++ b/src/app/actions.ts
@@ -68,6 +68,18 @@ export const countMonthlyNews = withResult(async (): Promise<number> => {
   return result.found
 })
 
+export const countTotalNews = withResult(async (): Promise<number> => {
+  const result = await typesense
+    .collections<ArticleRow>('news')
+    .documents()
+    .search({
+      q: '*',
+      limit: 0
+    })
+
+  return result.found
+})
+
 export const getLatestByTheme = withResult(
   async (theme: string, limit: number | null): Promise<ArticleRow[]> => {
     if (!theme) return []

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -5,6 +5,7 @@ import {
   getLatestArticles,
   getThemes,
   countMonthlyNews,
+  countTotalNews,
   getLatestByTheme,
 } from './actions'
 import { ArrowRight } from 'lucide-react'
@@ -16,10 +17,11 @@ export const revalidate = 600
 
 export default async function Home() {
   // ===== Fetch principal =====
-  const [latestNewsResult, themesResult, newsThisMonth] = await Promise.all([
+  const [latestNewsResult, themesResult, newsThisMonth, totalNews] = await Promise.all([
     getLatestArticles(),
     getThemes(),
     countMonthlyNews(),
+    countTotalNews(),
   ])
 
   if (themesResult.type !== 'ok') return <div>Erro ao carregar os temas.</div>
@@ -342,13 +344,21 @@ export default async function Home() {
             </Link>
           </div>
 
-          <div className="grid grid-cols-1 md:grid-cols-3 gap-8 text-center">
+          <div className="grid grid-cols-1 md:grid-cols-4 gap-8 text-center">
             <div>
               <div className="text-3xl font-bold text-government-red mb-1">
                 {new Intl.NumberFormat('pt-BR').format(newsThisMonth.data ?? 0)}
               </div>
               <div className="text-sm text-muted-foreground">
                 Notícias publicadas este mês
+              </div>
+            </div>
+            <div className="border-l md:border-l md:pl-8">
+              <div className="text-3xl font-bold text-government-blue mb-1">
+                {new Intl.NumberFormat('pt-BR').format(totalNews.data ?? 0)}
+              </div>
+              <div className="text-sm text-muted-foreground">
+                Total de notícias no portal
               </div>
             </div>
             <div className="border-l md:border-l md:pl-8">


### PR DESCRIPTION
## Summary
- Add new stats indicator showing total number of news articles in the portal (~300k)
- Implement `countTotalNews` server action to query Typesense for total document count
- Expand home page stats section from 3 to 4 columns

## Changes
- **src/app/actions.ts**: Add `countTotalNews()` function that queries Typesense with `limit: 0` to get total count
- **src/app/page.tsx**: 
  - Import and call `countTotalNews` in Promise.all
  - Change grid from `md:grid-cols-3` to `md:grid-cols-4`
  - Add new stat card displaying total news with pt-BR formatted number

## Preview
The new indicator appears between "Notícias publicadas este mês" and "Ministérios ativos", showing the total count formatted as "300.327" (Brazilian number format).

## Test plan
- [x] Tested locally with production Typesense data
- [x] Verified number formatting displays correctly in pt-BR locale
- [x] Confirmed responsive grid layout works on mobile and desktop
- [ ] Deploy to production and verify stats display correctly