### PR TITLE
feat: Display publication time when available

### DIFF
--- a/src/app/admin/preview/page.tsx
+++ b/src/app/admin/preview/page.tsx
@@ -19,6 +19,7 @@ import type { ArticleRow } from '@/lib/article-row'
 import type { ScoredArticle } from '@/lib/prioritization'
 import type { PrioritizationConfig, ThemeFocusMode } from '@/lib/prioritization-config'
 import { PlayIcon, DownloadIcon, RefreshCwIcon } from 'lucide-react'
+import { formatDateTime } from '@/lib/utils'
 
 export default function PreviewPage() {
   // Config state
@@ -509,7 +510,7 @@ function ArticleList({
                   <>
                     <span>•</span>
                     <span>
-                      {new Date(article.published_at * 1000).toLocaleDateString('pt-BR')}
+                      {formatDateTime(article.published_at)}
                     </span>
                   </>
                 )}
@@ -559,7 +560,7 @@ function ScoredArticleList({
                   <>
                     <span>•</span>
                     <span>
-                      {new Date(article.published_at * 1000).toLocaleDateString('pt-BR')}
+                      {formatDateTime(article.published_at)}
                     </span>
                   </>
                 )}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -10,7 +10,7 @@ import {
 } from './actions'
 import { ArrowRight } from 'lucide-react'
 import THEME_ICONS from '@/lib/themes'
-import { getExcerpt } from '@/lib/utils'
+import { getExcerpt, formatDateTime } from '@/lib/utils'
 
 // Revalidate every 10 minutes (600 seconds)
 export const revalidate = 600
@@ -210,7 +210,7 @@ export default async function Home() {
                         </Link>
                         {a.published_at && (
                           <span className="ml-2 text-muted-foreground">
-                            · {new Date(a.published_at * 1000).toLocaleDateString('pt-BR')}
+                            · {formatDateTime(a.published_at)}
                           </span>
                         )}
                       </li>

--- a/src/components/ClientArticle.tsx
+++ b/src/components/ClientArticle.tsx
@@ -7,6 +7,7 @@ import { Button } from '@/components/ui/button'
 import { useState, useMemo } from 'react'
 import { MarkdownRenderer } from './MarkdownRenderer'
 import { ArticleRow } from '@/lib/article-row'
+import { formatDateTime } from '@/lib/utils'
 
 export default function ClientArticle({ article, baseUrl, pageUrl }: { article: ArticleRow; baseUrl: string; pageUrl: string }) {
   const [copied, setCopied] = useState(false)
@@ -64,11 +65,7 @@ export default function ClientArticle({ article, baseUrl, pageUrl }: { article: 
             {article.published_at && (
               <div className="flex items-center">
                 <Calendar className="w-4 h-4 mr-1 text-primary/60" />
-                {new Date(article.published_at * 1000).toLocaleDateString('pt-BR', {
-                  day: '2-digit',
-                  month: 'short',
-                  year: 'numeric',
-                })}
+                {formatDateTime(article.published_at)}
               </div>
             )}
 

--- a/src/components/NewsCard.tsx
+++ b/src/components/NewsCard.tsx
@@ -3,6 +3,7 @@ import Link from 'next/link'
 import type { Ref } from 'react'
 import { Badge } from '@/components/ui/badge'
 import { Card, CardContent, CardHeader } from '@/components/ui/card'
+import { formatDateTime } from '@/lib/utils'
 
 export interface NewsCardProps {
   title: string
@@ -94,13 +95,7 @@ const NewsCard = ({
           {date && (
             <div className="flex items-center text-xs text-primary/70">
               <Calendar className="w-3 h-3 mr-1 text-primary/60" />
-              <span>
-                {new Date(date * 1000).toLocaleDateString('pt-BR', {
-                  day: '2-digit',
-                  month: 'short',
-                  year: 'numeric',
-                })}
-              </span>
+              <span>{formatDateTime(date)}</span>
             </div>
           )}
         </CardContent>

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -60,3 +60,40 @@ export function getExcerpt(content: string, maxLength: number = 200): string {
 
   return excerpt + '...'
 }
+
+/**
+ * Format Unix timestamp to display date and time (if not midnight)
+ * @param timestamp - Unix timestamp in seconds
+ * @returns Formatted date string, with time if not 00:00
+ *
+ * Examples:
+ * - 2024-01-15 00:00:00 → "15 de jan de 2024"
+ * - 2024-01-15 19:24:43 → "15 de jan de 2024 às 19h24"
+ */
+export function formatDateTime(timestamp: number | null): string {
+  if (!timestamp) return ''
+
+  const date = new Date(timestamp * 1000)
+
+  // Check if time is midnight (00:00)
+  const hours = date.getHours()
+  const minutes = date.getMinutes()
+  const isMidnight = hours === 0 && minutes === 0
+
+  // Format date
+  const dateStr = date.toLocaleDateString('pt-BR', {
+    day: '2-digit',
+    month: 'short',
+    year: 'numeric',
+  })
+
+  // If midnight, return only date
+  if (isMidnight) {
+    return dateStr
+  }
+
+  // Format time (HH:MM in Brazilian format)
+  const timeStr = `${hours.toString().padStart(2, '0')}h${minutes.toString().padStart(2, '0')}`
+
+  return `${dateStr} às ${timeStr}`
+}


### PR DESCRIPTION
## Summary

Add intelligent datetime formatting to display publication time for articles with precise timestamps, while showing only dates for historical data.

## Changes

### New Utility Function
- Added `formatDateTime()` in [lib/utils.ts](src/lib/utils.ts)
  - Detects midnight (00:00) timestamps
  - Shows only date for midnight (historical/backfilled data)
  - Shows "DD de MMM de YYYY às HHhMM" for timestamped articles

### Updated Components
- [NewsCard.tsx](src/components/NewsCard.tsx) - Article cards
- [ClientArticle.tsx](src/components/ClientArticle.tsx) - Article detail page
- [page.tsx](src/app/page.tsx) - Homepage latest news section
- [admin/preview/page.tsx](src/app/admin/preview/page.tsx) - Admin preview

## Examples

- Historical data (midnight): `2024-01-15 00:00:00` → **"15 de jan de 2024"**
- Recent articles: `2024-01-15 19:24:43` → **"15 de jan de 2024 às 19h24"**

## Context

This is part of the published_at migration from date to datetime:
- ✅ Scraper updated: nitaibezerra/govbrnews-scraper#49
- ✅ Dataset migrated on HuggingFace
- ✅ Typesense Docker: destaquesgovbr/destaquesgovbr-typesense#2
- ✅ Typesense Infra: destaquesgovbr/destaquesgovbr-infra#3
- ✅ Portal (this PR)

## Testing

✅ Function correctly handles both timestamp types
✅ UI components updated consistently
✅ Backward compatible with midnight timestamps

## Screenshots

*After merge and reindex, users will see precise publication times for recent articles.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)