### PR TITLE
feat: display subtitle and editorial_lead in article page

### DIFF
--- a/src/components/ClientArticle.tsx
+++ b/src/components/ClientArticle.tsx
@@ -89,10 +89,24 @@ export default function ClientArticle({ article, baseUrl, pageUrl }: { article: 
             </Button>
           </div>
 
+          {/* Editorial Lead - aparece como tag acima do título */}
+          {article.editorial_lead && (
+            <p className="text-sm font-semibold text-primary/70 uppercase tracking-wide mb-2">
+              {article.editorial_lead}
+            </p>
+          )}
+
           {/* Título */}
           <h1 className="text-3xl md:text-4xl font-bold text-primary leading-tight mb-4">
             {article.title}
           </h1>
+
+          {/* Subtítulo */}
+          {article.subtitle && (
+            <p className="text-base md:text-lg text-primary/70 mb-6 max-w-3xl mx-auto leading-relaxed">
+              {article.subtitle}
+            </p>
+          )}
 
           {/* Linha divisória SVG */}
           <div className="mx-auto mt-3 w-40">

--- a/src/lib/article-row.ts
+++ b/src/lib/article-row.ts
@@ -8,6 +8,8 @@ export type ArticleRow = {
   category: string | null
   content: string | null
   summary: string | null
+  subtitle: string | null
+  editorial_lead: string | null
   extracted_at: number | null
   theme_1_level_1_code: string | null
   theme_1_level_1_label: string | null


### PR DESCRIPTION
## Summary
- Display `subtitle` field below the article title
- Display `editorial_lead` field as a category tag above the title
- Add both fields to the ArticleRow TypeScript type

## Layout
Following the gov.br original article structure:
```
[Editorial Lead - uppercase tag]
       TÍTULO
    Subtítulo
```

## Changes
- **ArticleRow type**: Added `subtitle` and `editorial_lead` fields
- **ClientArticle component**: Added UI elements for both fields with proper styling

## Related PRs
- destaquesgovbr-typesense: schema changes for local development
- destaquesgovbr-infra: schema changes for production