### PR TITLE
fix: prevent drop cap style from applying to list items

### DIFF
--- a/src/components/ClientArticle.tsx
+++ b/src/components/ClientArticle.tsx
@@ -137,7 +137,7 @@ export default function ClientArticle({ article, baseUrl, pageUrl }: { article: 
         {/* Corpo do artigo */}
         <article className="prose prose-lg mx-auto max-w-3xl text-primary/90 leading-relaxed article-content">
           <style>{`
-            .article-content.prose p:first-of-type::first-letter {
+            .article-content > .prose > p:first-of-type::first-letter {
               float: left !important;
               font-size: 4em !important;
               line-height: 0.85 !important;


### PR DESCRIPTION
## Summary
Fix CSS selector to prevent the drop cap (first letter) styling from being applied to list items.

## Problem
The `p:first-of-type::first-letter` selector was matching the first `<p>` inside any parent element, including `<li>` elements, causing the large drop cap to appear on list items.

## Solution
Changed selector to use direct child combinators that respect the component structure:

```css
/* Before */
.article-content.prose p:first-of-type::first-letter

/* After */
.article-content > .prose > p:first-of-type::first-letter
```

This ensures the drop cap only applies to the first paragraph that is a direct child of the MarkdownRenderer wrapper.