### PR TITLE
feat: adicionar suporte a tags no portal

### DIFF
--- a/src/app/artigos/page.tsx
+++ b/src/app/artigos/page.tsx
@@ -1,10 +1,14 @@
 import { getAgenciesList } from '@/lib/agencies-utils'
 import { getThemesWithHierarchy } from '@/lib/themes-utils'
+import { getPopularTags } from './actions'
 import ArticlesPageClient from './ArticlesPageClient'
 
 export default async function ArticlesPage() {
-  const agencies = await getAgenciesList()
-  const themes = await getThemesWithHierarchy()
+  const [agencies, themes, popularTags] = await Promise.all([
+    getAgenciesList(),
+    getThemesWithHierarchy(),
+    getPopularTags(),
+  ])
 
-  return <ArticlesPageClient agencies={agencies} themes={themes} />
+  return <ArticlesPageClient agencies={agencies} themes={themes} popularTags={popularTags} />
 }

--- a/src/components/ArticleFilters.tsx
+++ b/src/components/ArticleFilters.tsx
@@ -4,8 +4,10 @@ import { Input } from '@/components/ui/input'
 import { X } from 'lucide-react'
 import { AgencyMultiSelect } from '@/components/AgencyMultiSelect'
 import { ThemeMultiSelect } from '@/components/ThemeMultiSelect'
+import { TagFilter } from '@/components/TagFilter'
 import { AgencyOption } from '@/lib/agencies-utils'
 import { ThemeOption } from '@/lib/themes-utils'
+import type { TagFacet } from '@/app/artigos/actions'
 import { useState, useRef, useEffect } from 'react'
 import { Portal } from '@/components/Portal'
 
@@ -86,41 +88,49 @@ function Tooltip({ content, children }: TooltipProps) {
 type ArticleFiltersProps = {
   agencies?: AgencyOption[]
   themes?: ThemeOption[]
+  popularTags?: TagFacet[]
   startDate: Date | undefined
   endDate: Date | undefined
   selectedAgencies?: string[]
   selectedThemes?: string[]
+  selectedTags?: string[]
   onStartDateChange: (date: Date | undefined) => void
   onEndDateChange: (date: Date | undefined) => void
   onAgenciesChange?: (agencies: string[]) => void
   onThemesChange?: (themes: string[]) => void
+  onTagsChange?: (tags: string[]) => void
   getAgencyName?: (key: string) => string
   getThemeName?: (key: string) => string
   getThemeHierarchyPath?: (key: string) => string
   showAgencyFilter?: boolean
   showThemeFilter?: boolean
+  showTagFilter?: boolean
 }
 
 export function ArticleFilters({
   agencies = [],
   themes = [],
+  popularTags = [],
   startDate,
   endDate,
   selectedAgencies = [],
   selectedThemes = [],
+  selectedTags = [],
   onStartDateChange,
   onEndDateChange,
   onAgenciesChange,
   onThemesChange,
+  onTagsChange,
   getAgencyName,
   getThemeName,
   getThemeHierarchyPath,
   showAgencyFilter = true,
   showThemeFilter = true,
+  showTagFilter = true,
 }: ArticleFiltersProps) {
   return (
     <aside className="lg:w-80 flex-shrink-0 lg:border-r lg:border-border lg:pr-8 relative z-[98]">
-      <div className="sticky top-[160px] md:top-[200px]">
+      <div>
         <h3 className="text-lg font-semibold text-primary mb-6">Filtros</h3>
 
         <div className="space-y-6">
@@ -245,6 +255,20 @@ export function ArticleFilters({
                 </div>
               )}
             </>
+          )}
+
+          {/* Tag Filter */}
+          {showTagFilter && onTagsChange && popularTags.length > 0 && (
+            <div className="flex flex-col gap-2">
+              <label className="text-sm font-semibold text-primary">
+                Tags
+              </label>
+              <TagFilter
+                popularTags={popularTags}
+                selectedTags={selectedTags}
+                onSelectedTagsChange={onTagsChange}
+              />
+            </div>
           )}
         </div>
       </div>

--- a/src/components/ClientArticle.tsx
+++ b/src/components/ClientArticle.tsx
@@ -152,6 +152,25 @@ export default function ClientArticle({ article, baseUrl, pageUrl }: { article: 
           <MarkdownRenderer content={article.content ?? ''}/>
         </article>
 
+        {/* Tags */}
+        {article.tags && article.tags.length > 0 && (
+          <section className="mt-12 mb-8 max-w-3xl mx-auto">
+            <h2 className="text-sm font-semibold text-primary/70 uppercase tracking-wide mb-3">
+              Tags
+            </h2>
+            <div className="flex flex-wrap gap-2">
+              {article.tags.map((tag) => (
+                <Link key={tag} href={`/artigos?tags=${encodeURIComponent(tag)}`}>
+                  <Badge className="bg-white text-primary font-medium hover:bg-primary/5 transition-colors cursor-pointer">
+                    <Tag className="w-3 h-3 mr-1 text-primary/70" />
+                    {tag}
+                  </Badge>
+                </Link>
+              ))}
+            </div>
+          </section>
+        )}
+
         {/* Rodapé */}
         <footer className="mt-16 border-t pt-8 text-primary/70 text-sm space-y-4">
           <div>

--- a/src/components/TagFilter.tsx
+++ b/src/components/TagFilter.tsx
@@ -1,0 +1,169 @@
+'use client'
+
+import * as React from 'react'
+import { X, Tag, Search, ChevronDown, ChevronUp } from 'lucide-react'
+import type { TagFacet } from '@/app/artigos/actions'
+
+type TagFilterProps = {
+  popularTags: TagFacet[]
+  selectedTags: string[]
+  onSelectedTagsChange: (tags: string[]) => void
+}
+
+export function TagFilter({
+  popularTags,
+  selectedTags,
+  onSelectedTagsChange,
+}: TagFilterProps) {
+  const [isOpen, setIsOpen] = React.useState(false)
+  const [searchTerm, setSearchTerm] = React.useState('')
+  const [showAll, setShowAll] = React.useState(false)
+  const dropdownRef = React.useRef<HTMLDivElement>(null)
+
+  // Filter tags by search term
+  const filteredTags = React.useMemo(() => {
+    if (!searchTerm) return popularTags
+    const searchLower = searchTerm.toLowerCase()
+    return popularTags.filter((tag) =>
+      tag.value.toLowerCase().includes(searchLower)
+    )
+  }, [searchTerm, popularTags])
+
+  // Limit displayed tags unless showAll is true
+  const displayedTags = showAll ? filteredTags : filteredTags.slice(0, 20)
+
+  const toggleTag = React.useCallback(
+    (tagValue: string) => {
+      onSelectedTagsChange(
+        selectedTags.includes(tagValue)
+          ? selectedTags.filter((t) => t !== tagValue)
+          : [...selectedTags, tagValue]
+      )
+    },
+    [selectedTags, onSelectedTagsChange]
+  )
+
+  // Close dropdown when clicking outside
+  React.useEffect(() => {
+    function handleClickOutside(event: MouseEvent) {
+      if (
+        dropdownRef.current &&
+        !dropdownRef.current.contains(event.target as Node)
+      ) {
+        setIsOpen(false)
+      }
+    }
+    document.addEventListener('mousedown', handleClickOutside)
+    return () => document.removeEventListener('mousedown', handleClickOutside)
+  }, [])
+
+  return (
+    <div className="relative" ref={dropdownRef}>
+      {/* Input trigger */}
+      <button
+        type="button"
+        onClick={() => setIsOpen(!isOpen)}
+        className="w-full flex items-center justify-between px-3 py-2 border border-border rounded-md bg-white hover:bg-primary/5 transition-colors text-sm"
+      >
+        <span className="text-primary/70">
+          {selectedTags.length > 0
+            ? `${selectedTags.length} tag${selectedTags.length > 1 ? 's' : ''} selecionada${selectedTags.length > 1 ? 's' : ''}`
+            : 'Selecionar tags'}
+        </span>
+        {isOpen ? (
+          <ChevronUp className="w-4 h-4 text-primary/50" />
+        ) : (
+          <ChevronDown className="w-4 h-4 text-primary/50" />
+        )}
+      </button>
+
+      {/* Dropdown */}
+      {isOpen && (
+        <div className="absolute z-50 mt-1 w-full bg-white border border-border rounded-md shadow-lg max-h-80 overflow-hidden">
+          {/* Search input */}
+          <div className="p-2 border-b border-border">
+            <div className="relative">
+              <Search className="absolute left-2 top-1/2 -translate-y-1/2 w-4 h-4 text-primary/40" />
+              <input
+                type="text"
+                placeholder="Buscar tags..."
+                value={searchTerm}
+                onChange={(e) => setSearchTerm(e.target.value)}
+                className="w-full pl-8 pr-3 py-1.5 text-sm border border-border rounded focus:outline-none focus:ring-1 focus:ring-primary/30"
+              />
+            </div>
+          </div>
+
+          {/* Tags list */}
+          <div className="overflow-y-auto max-h-52 p-2">
+            {displayedTags.length > 0 ? (
+              <div className="flex flex-wrap gap-1.5">
+                {displayedTags.map((tag) => {
+                  const isSelected = selectedTags.includes(tag.value)
+                  return (
+                    <button
+                      key={tag.value}
+                      type="button"
+                      onClick={() => toggleTag(tag.value)}
+                      className={`inline-flex items-center gap-1 px-2 py-1 text-xs rounded-full transition-colors ${
+                        isSelected
+                          ? 'bg-primary text-white'
+                          : 'bg-primary/5 text-primary/80 hover:bg-primary/10'
+                      }`}
+                    >
+                      <Tag className="w-3 h-3" />
+                      <span className="truncate max-w-[150px]">{tag.value}</span>
+                      <span className="text-[10px] opacity-70">({tag.count})</span>
+                    </button>
+                  )
+                })}
+              </div>
+            ) : (
+              <p className="text-sm text-primary/50 text-center py-4">
+                Nenhuma tag encontrada
+              </p>
+            )}
+          </div>
+
+          {/* Show more/less button */}
+          {filteredTags.length > 20 && (
+            <div className="p-2 border-t border-border">
+              <button
+                type="button"
+                onClick={() => setShowAll(!showAll)}
+                className="w-full text-xs text-primary/70 hover:text-primary"
+              >
+                {showAll
+                  ? 'Mostrar menos'
+                  : `Ver todas (${filteredTags.length} tags)`}
+              </button>
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* Selected tags badges */}
+      {selectedTags.length > 0 && (
+        <div className="mt-2 flex flex-wrap gap-1.5">
+          {selectedTags.map((tag) => (
+            <span
+              key={tag}
+              className="inline-flex items-center gap-1 px-2 py-1 text-xs bg-primary/10 text-primary rounded-full"
+            >
+              <Tag className="w-3 h-3" />
+              <span className="truncate max-w-[120px]">{tag}</span>
+              <button
+                type="button"
+                onClick={() => toggleTag(tag)}
+                className="hover:text-red-600 transition-colors"
+                aria-label={`Remover ${tag}`}
+              >
+                <X className="w-3 h-3" />
+              </button>
+            </span>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/lib/article-row.ts
+++ b/src/lib/article-row.ts
@@ -22,6 +22,7 @@ export type ArticleRow = {
   published_year: number | null
   published_month: number | null
   published_week: number | null
+  tags: string[] | null
   // Manter theme_1_level_1 como alias para compatibilidade
   theme_1_level_1?: string | null
 }


### PR DESCRIPTION
## Resumo

Adiciona suporte completo a tags no portal, integrando com o campo `tags` do Typesense.

## Mudanças

### Página /artigos - Filtro de Tags
- Novo componente `TagFilter` com dropdown, busca e badges removíveis
- Tags populares carregadas via facet do Typesense
- Sincronização com query params (`?tags=tag1,tag2`)
- Integração no sidebar de filtros

### Página /artigos/[id] - Exibição de Tags
- Tags exibidas após o conteúdo do artigo
- Cada tag é clicável e redireciona para `/artigos?tags=TAG`

### Outras mudanças
- Campo `tags: string[] | null` adicionado ao tipo `ArticleRow`
- Função `getPopularTags()` para buscar tags via facet
- Filtro de tags na query do Typesense
- Removido sticky do sidebar para melhor navegação em mobile

## Arquivos modificados

- `src/lib/article-row.ts` - tipo ArticleRow
- `src/app/artigos/actions.ts` - filtro e facet de tags
- `src/app/artigos/page.tsx` - fetch de tags populares
- `src/app/artigos/ArticlesPageClient.tsx` - estado e handlers
- `src/components/ArticleFilters.tsx` - integração TagFilter
- `src/components/TagFilter.tsx` - novo componente
- `src/components/ClientArticle.tsx` - exibição de tags

## Teste

1. Acesse `/artigos` e use o filtro de tags no sidebar
2. Clique em uma notícia e veja as tags no final do artigo
3. Clique em uma tag para filtrar por ela