### PR TITLE
docs: atualiza referências aos repositórios renomeados

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,7 +37,7 @@ Portal de notícias do Governo Federal brasileiro, desenvolvido com Next.js 15, 
 ## Estrutura de Diretórios
 
 ```
-/destaquesgovbr-portal
+/portal
 ├── src/
 │   ├── app/                    # App Router (Next.js 15)
 │   │   ├── page.tsx           # Homepage principal

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-
 ## Getting Started
 
 First, run the typesense locally:
-In this repository you'll find a docker container and a script `run-typesense-server.sh` that runs the container and load the news dataset taken from Huggingface: https://github.com/destaquesgovbr/destaquesgovbr-typesense
+In this repository you'll find a docker container and a script `run-typesense-server.sh` that runs the container and load the news dataset taken from Huggingface: https://github.com/destaquesgovbr/typesense
 
 
 Then, run the development server:
@@ -171,4 +171,4 @@ See [.github/workflows/deploy-production.yml](.github/workflows/deploy-productio
 
 ### Infrastructure
 
-The infrastructure (Typesense VM, secrets, IAM bindings) is managed via Terraform in the [destaquesgovbr-infra](https://github.com/destaquesgovbr/destaquesgovbr-infra) repository.
+The infrastructure (Typesense VM, secrets, IAM bindings) is managed via Terraform in the [infra](https://github.com/destaquesgovbr/infra) repository.


### PR DESCRIPTION
## Summary
- Atualiza referências aos repositórios renomeados:
  - `destaquesgovbr-typesense` → `typesense`
  - `destaquesgovbr-infra` → `infra`

## Test plan
- [ ] Verificar se os links na documentação funcionam