### PR TITLE
fix: update workflows to use typesense-read-conn secret

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,23 +18,12 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Authenticate to Google Cloud
-        uses: google-github-actions/auth@v2
+      - name: Fetch Typesense Config
+        id: typesense
+        uses: destaquesgovbr/reusable-workflows/actions/fetch-typesense-config@v1
         with:
           workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
-
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
-
-      - name: Fetch Typesense API Key from Secret Manager
-        id: secrets
-        run: |
-          TYPESENSE_KEY=$(gcloud secrets versions access latest \
-            --secret=typesense-search-only-api-key \
-            --project=${{ env.PROJECT_ID }})
-          echo "::add-mask::$TYPESENSE_KEY"
-          echo "typesense_api_key=$TYPESENSE_KEY" >> $GITHUB_OUTPUT
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -51,5 +40,6 @@ jobs:
       - name: Build
         run: npm run build
         env:
-          NEXT_PUBLIC_TYPESENSE_HOST: ${{ secrets.NEXT_PUBLIC_TYPESENSE_HOST }}
-          NEXT_PUBLIC_TYPESENSE_SEARCH_ONLY_API_KEY: ${{ steps.secrets.outputs.typesense_api_key }}
+          NEXT_PUBLIC_TYPESENSE_HOST: ${{ steps.typesense.outputs.host }}
+          NEXT_PUBLIC_TYPESENSE_PORT: ${{ steps.typesense.outputs.port }}
+          NEXT_PUBLIC_TYPESENSE_SEARCH_ONLY_API_KEY: ${{ steps.typesense.outputs.api_key }}

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -23,23 +23,12 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Authenticate to Google Cloud
-        uses: google-github-actions/auth@v2
+      - name: Fetch Typesense Config
+        id: typesense
+        uses: destaquesgovbr/reusable-workflows/actions/fetch-typesense-config@v1
         with:
           workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
-
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
-
-      - name: Fetch Typesense API Key from Secret Manager
-        id: secrets
-        run: |
-          TYPESENSE_KEY=$(gcloud secrets versions access latest \
-            --secret=typesense-search-only-api-key \
-            --project=${{ env.PROJECT_ID }})
-          echo "::add-mask::$TYPESENSE_KEY"
-          echo "typesense_api_key=$TYPESENSE_KEY" >> $GITHUB_OUTPUT
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -51,8 +40,9 @@ jobs:
         run: |
           docker buildx build \
             --platform linux/amd64 \
-            --build-arg NEXT_PUBLIC_TYPESENSE_HOST="${{ secrets.NEXT_PUBLIC_TYPESENSE_HOST }}" \
-            --build-arg NEXT_PUBLIC_TYPESENSE_SEARCH_ONLY_API_KEY="${{ steps.secrets.outputs.typesense_api_key }}" \
+            --build-arg NEXT_PUBLIC_TYPESENSE_HOST="${{ steps.typesense.outputs.host }}" \
+            --build-arg NEXT_PUBLIC_TYPESENSE_PORT="${{ steps.typesense.outputs.port }}" \
+            --build-arg NEXT_PUBLIC_TYPESENSE_SEARCH_ONLY_API_KEY="${{ steps.typesense.outputs.api_key }}" \
             -t ${{ env.REGISTRY }}/${{ env.PROJECT_ID }}/${{ env.REPOSITORY }}/portal:${{ github.sha }} \
             -t ${{ env.REGISTRY }}/${{ env.PROJECT_ID }}/${{ env.REPOSITORY }}/portal:latest \
             --load \
@@ -70,7 +60,7 @@ jobs:
             --region ${{ env.REGION }} \
             --platform managed \
             --allow-unauthenticated \
-            --set-env-vars "NODE_ENV=production,NEXT_PUBLIC_TYPESENSE_HOST=${{ secrets.NEXT_PUBLIC_TYPESENSE_HOST }}" \
+            --set-env-vars "NODE_ENV=production" \
             --quiet
 
       - name: Show deployment URL


### PR DESCRIPTION
## Problem

Production deployment failing with error:
```
ERROR: (gcloud.secrets.versions.access) NOT_FOUND: 
Secret [projects/990583792367/secrets/typesense-search-only-api-key] not found
```

**Failed run**: https://github.com/destaquesgovbr/portal/actions/runs/20352690907

## Root Cause

The secret `typesense-search-only-api-key` was **deleted** and replaced with:
- `typesense-read-conn` (for portal/read-only access)
- `typesense-write-conn` (for data loaders/write access)

This change was made in [destaquesgovbr/infra#36](https://github.com/destaquesgovbr/infra/pull/36).

The fix (PR #30) was merged to `development` branch but **never ported to `main`**, causing production deploys to fail.

## Solution

Update workflows in `main` branch to use the reusable action `fetch-typesense-config@v1`:

### Benefits
✅ Uses correct secret: `typesense-read-conn`  
✅ Backwards compatible: supports both `apiKey` and `searchOnlyApiKey` formats  
✅ Structured outputs: `host`, `port`, `protocol`, `api_key`  
✅ Handles auth automatically  
✅ Masks sensitive values in logs  

## Changes

### `deploy-production.yml`
**Before**:
```yaml
- name: Fetch Typesense API Key from Secret Manager
  run: |
    TYPESENSE_KEY=$(gcloud secrets versions access latest \
      --secret=typesense-search-only-api-key \  # ❌ Deleted secret
      --project=${{ env.PROJECT_ID }})
```

**After**:
```yaml
- name: Fetch Typesense Config
  id: typesense
  uses: destaquesgovbr/reusable-workflows/actions/fetch-typesense-config@v1
  with:
    workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
    service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
    # secret_name defaults to 'typesense-read-conn' ✅
```

### `ci.yml`
Same pattern - replace manual secret fetch with reusable action.

## Testing Plan

1. ✅ Merge this PR to `main`
2. ✅ Run production deploy via `workflow_dispatch`
3. ✅ Verify build succeeds
4. ✅ Verify portal loads with Typesense data

## Related

- Infra PR: [destaquesgovbr/infra#36](https://github.com/destaquesgovbr/infra/pull/36) - Created new secrets
- Portal PR: [#30](https://github.com/destaquesgovbr/portal/pull/30) - Fixed `development` branch (merged)
- This PR: Ports fix to `main` branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)