### PR TITLE
fix: add missing TYPESENSE_PROTOCOL build arg to deploy workflows

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -42,6 +42,7 @@ jobs:
             --platform linux/amd64 \
             --build-arg NEXT_PUBLIC_TYPESENSE_HOST="${{ steps.typesense.outputs.host }}" \
             --build-arg NEXT_PUBLIC_TYPESENSE_PORT="${{ steps.typesense.outputs.port }}" \
+            --build-arg NEXT_PUBLIC_TYPESENSE_PROTOCOL="${{ steps.typesense.outputs.protocol }}" \
             --build-arg NEXT_PUBLIC_TYPESENSE_SEARCH_ONLY_API_KEY="${{ steps.typesense.outputs.api_key }}" \
             -t ${{ env.REGISTRY }}/${{ env.PROJECT_ID }}/${{ env.REPOSITORY }}/portal:${{ github.sha }} \
             -t ${{ env.REGISTRY }}/${{ env.PROJECT_ID }}/${{ env.REPOSITORY }}/portal:latest \

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -42,6 +42,7 @@ jobs:
             --platform linux/amd64 \
             --build-arg NEXT_PUBLIC_TYPESENSE_HOST="${{ steps.typesense.outputs.host }}" \
             --build-arg NEXT_PUBLIC_TYPESENSE_PORT="${{ steps.typesense.outputs.port }}" \
+            --build-arg NEXT_PUBLIC_TYPESENSE_PROTOCOL="${{ steps.typesense.outputs.protocol }}" \
             --build-arg NEXT_PUBLIC_TYPESENSE_SEARCH_ONLY_API_KEY="${{ steps.typesense.outputs.api_key }}" \
             -t ${{ env.REGISTRY }}/${{ env.PROJECT_ID }}/${{ env.REPOSITORY }}/portal:staging-${{ github.sha }} \
             -t ${{ env.REGISTRY }}/${{ env.PROJECT_ID }}/${{ env.REPOSITORY }}/portal:staging-latest \


### PR DESCRIPTION
## Summary
- Add missing `NEXT_PUBLIC_TYPESENSE_PROTOCOL` build argument to both staging and production deploy workflows
- Fixes ERR_INVALID_URL error during Next.js static page generation

## Root Cause
The Docker build was failing during Next.js static page generation because `NEXT_PUBLIC_TYPESENSE_PROTOCOL` was not being passed as a build argument.

This caused the Typesense URL to be constructed as `://host:port/...` instead of `http://host:port/...`, resulting in `ERR_INVALID_URL`:

```
input: '://34.39.186.38:8108/collections/news/documents/search'
```

The `fetch-typesense-config` action already outputs the `protocol` value, but the deploy workflows were not passing it to the Docker build.

## Test plan
- [ ] Merge this PR and verify the staging deploy workflow succeeds
- [ ] Verify production deploy workflow also succeeds on next push to main

🤖 Generated with [Claude Code](https://claude.com/claude-code)