### PR TITLE
chore: run tests only on PR, not on push

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,8 +1,6 @@
 name: Tests
 
 on:
-  push:
-    branches: [main, development]
   pull_request:
     branches: [main, development]
   workflow_dispatch:


### PR DESCRIPTION
## Summary
- Remove `push` trigger from test workflow
- Tests now only run on pull request events (opened, synchronize, reopened)
- Keeps `workflow_dispatch` for manual triggering when needed

## Rationale
Avoid redundant test runs. Since we run tests on PRs, there's no need to re-run them on push to main/development after merge.

## Test plan
- [ ] Verify tests run when a PR is opened
- [ ] Verify tests don't run on direct push to development/main

🤖 Generated with [Claude Code](https://claude.com/claude-code)