### PR TITLE
sec: migra AUTH_SECRET para Secret Manager

### DIFF
--- a/.github/workflows/deploy-preview-update.yml
+++ b/.github/workflows/deploy-preview-update.yml
@@ -114,7 +114,8 @@ jobs:
             --platform managed \
             --service-account ${{ env.STAGING_SA }} \
             --allow-unauthenticated \
-            --set-env-vars "NODE_ENV=preview,AUTH_URL=${{ steps.check.outputs.url }},AUTH_SECRET=${{ secrets.AUTH_SECRET }},AUTH_GOOGLE_ID=${{ secrets.AUTH_GOOGLE_ID }},AUTH_GOOGLE_SECRET=${{ secrets.AUTH_GOOGLE_SECRET }}" \
+            --set-env-vars "NODE_ENV=preview,AUTH_URL=${{ steps.check.outputs.url }},AUTH_GOOGLE_ID=${{ secrets.AUTH_GOOGLE_ID }},AUTH_GOOGLE_SECRET=${{ secrets.AUTH_GOOGLE_SECRET }}" \
+            --set-secrets "AUTH_SECRET=auth-secret:latest" \
             --port 3000 \
             --memory 512Mi \
             --cpu 1 \

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -105,7 +105,8 @@ jobs:
             --platform managed \
             --service-account ${{ env.STAGING_SA }} \
             --allow-unauthenticated \
-            --set-env-vars "NODE_ENV=preview,AUTH_SECRET=${{ secrets.AUTH_SECRET }},AUTH_GOOGLE_ID=${{ secrets.AUTH_GOOGLE_ID }},AUTH_GOOGLE_SECRET=${{ secrets.AUTH_GOOGLE_SECRET }}" \
+            --set-env-vars "NODE_ENV=preview,AUTH_GOOGLE_ID=${{ secrets.AUTH_GOOGLE_ID }},AUTH_GOOGLE_SECRET=${{ secrets.AUTH_GOOGLE_SECRET }}" \
+            --set-secrets "AUTH_SECRET=auth-secret:latest" \
             --port 3000 \
             --memory 512Mi \
             --cpu 1 \

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -63,6 +63,7 @@ jobs:
             --platform managed \
             --allow-unauthenticated \
             --set-env-vars "NODE_ENV=production" \
+            --set-secrets "AUTH_SECRET=auth-secret:latest" \
             --quiet
 
       - name: Show deployment URL

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -62,6 +62,7 @@ jobs:
             --platform managed \
             --allow-unauthenticated \
             --set-env-vars "NODE_ENV=staging" \
+            --set-secrets "AUTH_SECRET=auth-secret:latest" \
             --quiet
 
       - name: Show deployment URL


### PR DESCRIPTION
## Summary

- Remove AUTH_SECRET de `--set-env-vars` (plain text exposto em logs/revisões do Cloud Run)
- Usa `--set-secrets AUTH_SECRET=auth-secret:latest` para montar direto do GCP Secret Manager
- Afeta 4 workflows: production, staging, preview, preview-update

## Contexto

O secret `auth-secret` já existe no GCP Secret Manager (provisionado via Terraform em `secrets.tf`), com IAM para as SAs de portal, portal-staging e github-actions. A mudança é apenas nos workflows — o valor nunca mais transita como env var.

## Test plan

- [ ] Deploy preview funciona (auth-secret montado corretamente)
- [ ] Login continua funcionando após deploy
- [ ] `gcloud run services describe` não mostra AUTH_SECRET em env vars

cc @LucaasMa