### PR TITLE
fix: substituir agência ebc por agencia_brasil e tvbrasil

### DIFF
--- a/src/config/agencies.yaml
+++ b/src/config/agencies.yaml
@@ -282,11 +282,16 @@ sources:
     parent: mdr
     type: Autarquia
     url: https://www.gov.br/dnocs/pt-br/assuntos/noticias
-  ebc:
-    name: Empresa Brasil de Comunicação
+  agencia_brasil:
+    name: Agência Brasil
     parent: secom
     type: Empresa Pública
-    url: https://memoria.ebc.com.br/noticias
+    url: https://agenciabrasil.ebc.com.br/ultimas
+  tvbrasil:
+    name: TV Brasil
+    parent: secom
+    type: Empresa Pública
+    url: https://tvbrasil.ebc.com.br/ultimas
   ebserh:
     name: Empresa Brasileira de Serviços Hospitalares
     parent: mec

--- a/src/config/hierarchy.yaml
+++ b/src/config/hierarchy.yaml
@@ -157,7 +157,8 @@ presidencia:
     - iec
     - inca
   - secom:
-    - ebc
+    - agencia_brasil
+    - tvbrasil
   - secretariageral
   - sri
   - trabalho-e-emprego:


### PR DESCRIPTION
## Summary

- Substitui entrada `ebc` em `agencies.yaml` por `agencia_brasil` e `tvbrasil` com nomes e URLs corretos
- Atualiza `hierarchy.yaml` para listar ambos como filhos de SECOM

O scraper migrou de um agency_key único `ebc` para keys separados (`agencia_brasil`, `tvbrasil`). Sem essa correção, `getAgencyField("tvbrasil", "name")` retorna `undefined`, quebrando filtros e exibição de nomes de órgão.

## Test plan

- [x] 131 testes passando
- [ ] Verificar página de artigo da TV Brasil — nome do órgão exibido corretamente
- [ ] Verificar filtro de agências em /busca — "Agência Brasil" e "TV Brasil" como opções legíveis

Closes #91