### PR TITLE
feature: migra autenticação para Keycloak SSO

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -64,8 +64,8 @@ jobs:
             --region ${{ env.REGION }} \
             --platform managed \
             --allow-unauthenticated \
-            --set-env-vars "NODE_ENV=production,AUTH_GOOGLE_ID=${{ secrets.AUTH_GOOGLE_ID }},AUTH_GOOGLE_SECRET=${{ secrets.AUTH_GOOGLE_SECRET }}" \
-            --set-secrets "AUTH_SECRET=auth-secret:latest" \
+            --set-env-vars "NODE_ENV=production,AUTH_GOVBR_ID=portal,AUTH_GOVBR_ISSUER=https://destaquesgovbr-keycloak-klvx64dufq-rj.a.run.app/realms/destaquesgovbr" \
+            --set-secrets "AUTH_SECRET=auth-secret:latest,AUTH_GOVBR_SECRET=keycloak-portal-client-secret:latest" \
             --quiet
 
       - name: Set AUTH_URL

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -63,8 +63,18 @@ jobs:
             --region ${{ env.REGION }} \
             --platform managed \
             --allow-unauthenticated \
-            --set-env-vars "NODE_ENV=staging" \
-            --set-secrets "AUTH_SECRET=auth-secret:latest" \
+            --set-env-vars "NODE_ENV=staging,AUTH_GOVBR_ID=portal,AUTH_GOVBR_ISSUER=https://destaquesgovbr-keycloak-klvx64dufq-rj.a.run.app/realms/destaquesgovbr" \
+            --set-secrets "AUTH_SECRET=auth-secret:latest,AUTH_GOVBR_SECRET=keycloak-portal-client-secret:latest" \
+            --quiet
+
+      - name: Set AUTH_URL
+        run: |
+          URL=$(gcloud run services describe ${{ env.SERVICE_NAME }} \
+            --region ${{ env.REGION }} \
+            --format 'value(status.url)')
+          gcloud run services update ${{ env.SERVICE_NAME }} \
+            --region ${{ env.REGION }} \
+            --update-env-vars "AUTH_URL=$URL" \
             --quiet
 
       - name: Show deployment URL


### PR DESCRIPTION
## Summary

- Migra autenticação do portal de Google OAuth direto para **Keycloak SSO centralizado**
- Staging e produção passam a usar `AUTH_GOVBR_ID=portal` + `AUTH_GOVBR_ISSUER` apontando para o Keycloak DGB
- Secret `keycloak-portal-client-secret` do Secret Manager substitui `AUTH_GOOGLE_ID`/`AUTH_GOOGLE_SECRET` inline
- Adiciona step `Set AUTH_URL` ao staging (já existia em produção, necessário para redirects NextAuth)

## Contexto

O Keycloak DGB (`destaquesgovbr-keycloak`) foi deployado no Cloud Run (PRs infra#120, infra#121) com Google como Identity Provider. O `auth.ts` do portal já suporta OIDC genérico via `AUTH_GOVBR_ISSUER` — zero mudanças de código necessárias.

**Fluxo após migração:**
```
Usuário → Portal → NextAuth → Keycloak (OIDC) → Google (upstream IdP) → Keycloak → Portal
```

## Test plan

- [ ] Merge para `main` dispara deploy staging (via workflow_dispatch) e produção
- [ ] Verificar login no staging: botão "Entrar" redireciona para tela Keycloak com botão Google
- [ ] Após login, sessão ativa no portal com avatar/nome correto
- [ ] Logout limpa sessão no portal e no Keycloak
- [ ] Rollback: reverter `AUTH_GOVBR_ISSUER` para `https://sso.acesso.gov.br` se necessário

🤖 Generated with [Claude Code](https://claude.com/claude-code)