### PR TITLE
feat: view de notícia com resumo, CTA e notícias similares

### DIFF
--- a/src/app/(public)/artigos/[articleId]/actions.ts
+++ b/src/app/(public)/artigos/[articleId]/actions.ts
@@ -32,3 +32,30 @@ export const getArticleById = withResult(
   },
   {} as GetArticleError,
 )
+
+export async function getSimilarArticles(
+  article: ArticleRow,
+  limit = 4,
+): Promise<ArticleRow[]> {
+  const filters: string[] = [`unique_id:!=${article.unique_id}`]
+
+  if (article.most_specific_theme_code) {
+    filters.push(
+      `(theme_1_level_1_code:=${article.most_specific_theme_code} || theme_1_level_2_code:=${article.most_specific_theme_code} || theme_1_level_3_code:=${article.most_specific_theme_code})`,
+    )
+  } else if (article.theme_1_level_1_code) {
+    filters.push(`theme_1_level_1_code:=${article.theme_1_level_1_code}`)
+  }
+
+  const result = await typesense
+    .collections<ArticleRow>('news')
+    .documents()
+    .search({
+      q: '*',
+      filter_by: filters.join(' && '),
+      sort_by: 'published_at:desc',
+      limit,
+    })
+
+  return result.hits?.map((hit) => hit.document) ?? []
+}

--- a/src/app/(public)/artigos/[articleId]/page.tsx
+++ b/src/app/(public)/artigos/[articleId]/page.tsx
@@ -1,6 +1,6 @@
 import { notFound } from 'next/navigation'
 import ClientArticle from '@/components/articles/ClientArticle'
-import { getArticleById } from './actions'
+import { getArticleById, getSimilarArticles } from './actions'
 
 interface Props {
   params: Promise<{ articleId: string }>
@@ -72,6 +72,14 @@ export default async function ArticlePage({ params }: Props) {
   const articleUrl = new URL(article.url || '', 'https://www.gov.br')
   const baseUrl = articleUrl.hostname.replace('www.', '')
   const pageUrl = `${process.env.NEXT_PUBLIC_SITE_URL!}/artigos/${article.unique_id}`
+  const similarArticles = await getSimilarArticles(article)
 
-  return <ClientArticle article={article} baseUrl={baseUrl} pageUrl={pageUrl} />
+  return (
+    <ClientArticle
+      article={article}
+      baseUrl={baseUrl}
+      pageUrl={pageUrl}
+      similarArticles={similarArticles}
+    />
+  )
 }

--- a/src/components/articles/ClientArticle.tsx
+++ b/src/components/articles/ClientArticle.tsx
@@ -10,8 +10,8 @@ import {
 } from 'lucide-react'
 import Link from 'next/link'
 import { useMemo, useState } from 'react'
+import NewsCard from '@/components/articles/NewsCard'
 import { VideoPlayer } from '@/components/articles/VideoPlayer'
-import { MarkdownRenderer } from '@/components/common/MarkdownRenderer'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { formatDateTime } from '@/lib/utils'
@@ -21,10 +21,12 @@ export default function ClientArticle({
   article,
   baseUrl,
   pageUrl,
+  similarArticles,
 }: {
   article: ArticleRow
   baseUrl: string
   pageUrl: string
+  similarArticles: ArticleRow[]
 }) {
   const [copied, setCopied] = useState(false)
   const [coverImageBroken, setCoverImageBroken] = useState(false)
@@ -165,10 +167,27 @@ export default function ClientArticle({
           )
         )}
 
-        {/* Corpo do artigo */}
-        <article className="prose prose-lg mx-auto max-w-3xl text-primary/90 leading-relaxed article-content">
-          <MarkdownRenderer content={article.content ?? ''} />
-        </article>
+        {/* Resumo da notícia */}
+        {article.summary && (
+          <article className="prose prose-lg mx-auto max-w-3xl text-primary/90 leading-relaxed mb-10">
+            <p>{article.summary}</p>
+          </article>
+        )}
+
+        {/* Botão CTA para notícia original */}
+        {article.url && (
+          <div className="flex justify-center mb-16">
+            <a href={article.url} target="_blank" rel="noopener noreferrer">
+              <Button
+                size="lg"
+                className="bg-[#0D4C92] hover:bg-[#0D4C92]/90 text-white text-base px-8 py-6 rounded-lg shadow-md"
+              >
+                <ExternalLink className="w-5 h-5 mr-2" />
+                Ler notícia completa em {baseUrl}
+              </Button>
+            </a>
+          </div>
+        )}
 
         {/* Tags */}
         {article.tags && article.tags.length > 0 && (
@@ -192,26 +211,34 @@ export default function ClientArticle({
           </section>
         )}
 
+        {/* Notícias similares */}
+        {similarArticles.length > 0 && (
+          <section className="mt-16 border-t pt-10">
+            <h2 className="text-xl font-semibold text-primary mb-6">
+              Notícias relacionadas
+            </h2>
+            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
+              {similarArticles.map((similar) => (
+                <NewsCard
+                  key={similar.unique_id}
+                  title={similar.title || ''}
+                  summary={similar.summary || undefined}
+                  theme={similar.most_specific_theme_label || ''}
+                  internalUrl={`/artigos/${similar.unique_id}`}
+                  date={similar.published_at}
+                  imageUrl={similar.image || undefined}
+                  trackingOrigin="similar"
+                />
+              ))}
+            </div>
+          </section>
+        )}
+
         {/* Rodapé */}
         <footer className="mt-16 border-t pt-8 text-primary/70 text-sm space-y-4">
           <div>
             <strong>Fonte:</strong> {article.agency}
           </div>
-
-          {article.url && (
-            <div className="flex items-center gap-2">
-              <span className="font-medium">Fonte oficial:</span>
-              <a
-                href={article.url}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="inline-flex items-center gap-1 text-primary hover:underline"
-              >
-                {baseUrl}
-                <ExternalLink className="w-3 h-3" />
-              </a>
-            </div>
-          )}
 
           <p className="text-xs text-primary/60 pt-4">
             Esta notícia foi publicada no portal oficial do Governo Federal do

--- a/src/types/analytics.ts
+++ b/src/types/analytics.ts
@@ -16,4 +16,10 @@ export interface WindowWithAnalytics extends Window {
 /**
  * Valid tracking origins for article clicks
  */
-export type TrackingOrigin = 'home' | 'search' | 'theme' | 'agency' | 'articles'
+export type TrackingOrigin =
+  | 'home'
+  | 'search'
+  | 'theme'
+  | 'agency'
+  | 'articles'
+  | 'similar'


### PR DESCRIPTION
## Summary
- Substitui exibição do `content` completo pelo `summary` da notícia
- Adiciona botão CTA em destaque para redirecionar à notícia original
- Adiciona seção de notícias relacionadas (mesmo tema) com cards menores
- Adiciona `similar` como tracking origin para analytics

## Test plan
- [ ] Abrir uma notícia e verificar que exibe o resumo em vez do conteúdo completo
- [ ] Verificar que o botão "Ler notícia completa" redireciona para a fonte original
- [ ] Verificar que a seção de notícias relacionadas aparece com cards do mesmo tema
- [ ] Verificar layout responsivo (mobile e desktop)
- [ ] Verificar notícia sem resumo (campo null) — deve exibir apenas o CTA

Closes #100