### PR TITLE
fix: importação dinâmica do firebase-admin para edge runtime

### DIFF
--- a/src/auth.ts
+++ b/src/auth.ts
@@ -1,6 +1,5 @@
 import NextAuth from 'next-auth'
 import Google from 'next-auth/providers/google'
-import { resolveStableUserId } from '@/lib/resolve-stable-user-id'
 
 const providers = []
 
@@ -59,6 +58,9 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
         // across providers/deployments (token.sub changes, email doesn't)
         const email = token.email ?? profile?.email
         if (email) {
+          const { resolveStableUserId } = await import(
+            '@/lib/resolve-stable-user-id'
+          )
           token.stableUserId = await resolveStableUserId(
             email as string,
             token.sub ?? '',


### PR DESCRIPTION
## Summary
- Corrige erro "The edge runtime does not support Node.js 'process' module" ao rodar `pnpm dev`
- Troca o import estático de `resolveStableUserId` (que depende de `firebase-admin`) por um `import()` dinâmico dentro do callback `jwt`
- O middleware (edge runtime) deixa de carregar o Firebase Admin SDK na avaliação do módulo `auth.ts`

## Test plan
- [ ] Rodar `pnpm dev` e verificar que o erro de edge runtime não aparece mais
- [ ] Fazer login e confirmar que a resolução de `stableUserId` continua funcionando