### PR TITLE
fix: crash no edge runtime por import estático de firebase-admin

### DIFF
--- a/src/auth.ts
+++ b/src/auth.ts
@@ -1,6 +1,5 @@
 import NextAuth from 'next-auth'
 import Google from 'next-auth/providers/google'
-import { resolveStableUserId } from '@/lib/resolve-stable-user-id'
 
 const providers = []
 
@@ -57,8 +56,12 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
 
         // Resolve stable user ID based on email to avoid duplicates
         // across providers/deployments (token.sub changes, email doesn't)
+        // Dynamic import to avoid pulling firebase-admin into edge runtime (middleware)
         const email = token.email ?? profile?.email
         if (email) {
+          const { resolveStableUserId } = await import(
+            '@/lib/resolve-stable-user-id'
+          )
           token.stableUserId = await resolveStableUserId(
             email as string,
             token.sub ?? '',


### PR DESCRIPTION
## Problema

O middleware do Next.js roda no edge runtime. O `auth.ts` importava `resolveStableUserId` (que importa `firebase-admin`) estaticamente, puxando módulos Node.js para o edge e causando:

> Error: The edge runtime does not support Node.js 'process' module

Isso fazia toda revisão nova retornar 500 na homepage, falhando a startup probe.

## Fix

`await import('@/lib/resolve-stable-user-id')` dinâmico dentro do callback JWT, que só executa no Node.js runtime.

## Test plan
- [ ] `pnpm build` sem erros
- [ ] Deploy não crasha na startup probe
- [ ] Login funciona end-to-end