### PR TITLE
fix: convites admin, responsividade mobile, estimativa de recorte vazio

### DIFF
--- a/src/app/(public)/convites/actions.ts
+++ b/src/app/(public)/convites/actions.ts
@@ -46,7 +46,7 @@ export const getUserInvites = withResult(async (): Promise<UserInvitesData> => {
 
   return {
     inviteCount,
-    maxInvites: admin ? Infinity : MAX_INVITES_PER_USER,
+    maxInvites: admin ? -1 : MAX_INVITES_PER_USER,
     codes,
   }
 })
@@ -83,9 +83,13 @@ export const createInviteCode = withResult(async (): Promise<string> => {
     usedAt: null,
   })
 
-  batch.update(userRef, {
-    inviteCount: currentCount + 1,
-  })
+  batch.set(
+    userRef,
+    {
+      inviteCount: currentCount + 1,
+    },
+    { merge: true },
+  )
 
   await batch.commit()
   return code

--- a/src/components/invite/GenerateInviteButton.tsx
+++ b/src/components/invite/GenerateInviteButton.tsx
@@ -19,7 +19,7 @@ export function GenerateInviteButton({
   onSuccess,
 }: GenerateInviteButtonProps) {
   const [isPending, setIsPending] = useState(false)
-  const unlimited = !Number.isFinite(maxInvites)
+  const unlimited = maxInvites < 0
   const remaining = unlimited ? Infinity : maxInvites - currentCount
   const isDisabled = remaining <= 0 || isPending
 
@@ -32,6 +32,8 @@ export function GenerateInviteButton({
         onSuccess?.()
       } else if (result.type === 'err') {
         toast.error(result.error as string)
+      } else {
+        toast.error('Erro ao gerar convite. Tente novamente.')
       }
     } finally {
       setIsPending(false)

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -104,6 +104,15 @@ const Header = () => {
 
           {/* Mobile icons - right side */}
           <div className="flex md:hidden ml-auto items-center gap-1">
+            {session && (
+              <Link
+                href="/minha-conta/clipping"
+                className="inline-flex items-center justify-center rounded-md h-10 w-10 hover:bg-accent hover:text-accent-foreground transition-colors"
+                title="Meus Clippings"
+              >
+                <Scissors className="h-5 w-5" />
+              </Link>
+            )}
             <PushSubscriber />
             <AuthButton />
             <Button

--- a/src/lib/__tests__/estimate-recorte-count.test.ts
+++ b/src/lib/__tests__/estimate-recorte-count.test.ts
@@ -1,6 +1,18 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import type { Recorte } from '@/types/clipping'
-import { buildFilterBy } from '../estimate-recorte-count'
+
+const mockSearch = vi.fn()
+vi.mock('@/services/typesense/client', () => ({
+  typesense: {
+    collections: () => ({
+      documents: () => ({
+        search: mockSearch,
+      }),
+    }),
+  },
+}))
+
+import { buildFilterBy, estimateRecorteCount } from '../estimate-recorte-count'
 
 function recorte(overrides: Partial<Omit<Recorte, 'id'>> = {}): Recorte {
   return { id: 'r1', themes: [], agencies: [], keywords: [], ...overrides }
@@ -79,5 +91,35 @@ describe('buildFilterBy', () => {
       const result = buildFilterBy(recorte(), 42)
       expect(result).toBe('published_at:>=42')
     })
+  })
+})
+
+describe('estimateRecorteCount', () => {
+  it('returns 0 for empty recorte without calling Typesense', async () => {
+    mockSearch.mockClear()
+    const count = await estimateRecorteCount(recorte())
+    expect(count).toBe(0)
+    expect(mockSearch).not.toHaveBeenCalled()
+  })
+
+  it('calls Typesense when recorte has theme filter', async () => {
+    mockSearch.mockResolvedValue({ found: 42 })
+    const count = await estimateRecorteCount(recorte({ themes: ['08'] }))
+    expect(count).toBe(42)
+    expect(mockSearch).toHaveBeenCalled()
+  })
+
+  it('calls Typesense when recorte has agency filter', async () => {
+    mockSearch.mockResolvedValue({ found: 10 })
+    const count = await estimateRecorteCount(recorte({ agencies: ['mec'] }))
+    expect(count).toBe(10)
+  })
+
+  it('calls Typesense when recorte has keyword filter', async () => {
+    mockSearch.mockResolvedValue({ found: 5 })
+    const count = await estimateRecorteCount(
+      recorte({ keywords: ['educação'] }),
+    )
+    expect(count).toBe(5)
   })
 })

--- a/src/lib/estimate-recorte-count.ts
+++ b/src/lib/estimate-recorte-count.ts
@@ -30,10 +30,20 @@ export function buildFilterBy(
   return parts.join(' && ')
 }
 
+export function hasFilters(recorte: Recorte): boolean {
+  return (
+    recorte.themes.length > 0 ||
+    recorte.agencies.length > 0 ||
+    recorte.keywords.length > 0
+  )
+}
+
 export async function estimateRecorteCount(
   recorte: Recorte,
   sinceHours = 24,
 ): Promise<number> {
+  if (!hasFilters(recorte)) return 0
+
   const sinceTimestamp = Math.floor(Date.now() / 1000) - sinceHours * 3600
   const filterBy = buildFilterBy(recorte, sinceTimestamp)
 


### PR DESCRIPTION
## Summary
- **Convites**: `batch.update` → `batch.set(merge)` para evitar crash se doc não tem `inviteCount`; `Infinity` → `-1` como sentinel (RSC não serializa Infinity); trata `unknown_err` com toast
- **Mobile**: Adiciona ícone "Meus Clippings" (tesoura) no container mobile do Header
- **Estimativa**: `estimateRecorteCount` retorna 0 para recortes sem filtros — evita query que retorna ~300 artigos

## Test plan
- [x] 4 novos testes para estimateRecorteCount (vazio, theme, agency, keyword)
- [ ] Gerar convite como admin no preview
- [ ] Verificar ícone tesoura no mobile (DevTools < 768px)
- [ ] Adicionar recorte vazio no wizard — estimativa deve ser 0