### PR TITLE
fix: segurança admin, tipos JWT, visual cleanup

### DIFF
--- a/src/app/(admin)/layout.tsx
+++ b/src/app/(admin)/layout.tsx
@@ -1,5 +1,6 @@
 import { redirect } from 'next/navigation'
 import { auth } from '@/auth'
+import { isAdmin } from '@/lib/admin'
 
 export default async function AdminLayout({
   children,
@@ -10,6 +11,10 @@ export default async function AdminLayout({
 
   if (!session) {
     redirect('/api/auth/signin')
+  }
+
+  if (!(await isAdmin())) {
+    redirect('/')
   }
 
   return <>{children}</>

--- a/src/components/articles/ClientArticle.tsx
+++ b/src/components/articles/ClientArticle.tsx
@@ -97,7 +97,7 @@ export default function ClientArticle({
             >
               {copied ? (
                 <>
-                  <Check className="w-4 h-4 mr-1 text-[#2D9B78]" />
+                  <Check className="w-4 h-4 mr-1 text-green-600" />
                   Link copiado!
                 </>
               ) : (
@@ -179,7 +179,7 @@ export default function ClientArticle({
             <a href={article.url} target="_blank" rel="noopener noreferrer">
               <Button
                 size="lg"
-                className="bg-[#0D4C92] hover:bg-[#0D4C92]/90 text-white text-base px-8 py-6 rounded-lg shadow-md"
+                className="bg-government-blue hover:bg-government-blue/90 text-white text-base px-8 py-6 rounded-lg shadow-md"
               >
                 <ExternalLink className="w-5 h-5 mr-2" />
                 Ler notícia completa em {baseUrl}

--- a/src/components/auth/AuthButton.tsx
+++ b/src/components/auth/AuthButton.tsx
@@ -30,6 +30,7 @@ export function AuthButton() {
           const res = await fetch('/api/auth/providers')
           const providers = await res.json()
           const providerId = Object.keys(providers)[0]
+          if (!providerId) return
           signIn(providerId, { callbackUrl: '/auth/postlogin' })
         }}
         className="gap-2 cursor-pointer"

--- a/src/components/clipping/ChannelSelector.tsx
+++ b/src/components/clipping/ChannelSelector.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useState } from 'react'
+import { toast } from 'sonner'
 import type { DeliveryChannels } from '@/types/clipping'
 import { ExtraEmailsInput } from './ExtraEmailsInput'
 
@@ -31,7 +32,7 @@ export function ChannelSelector({
       const res = await fetch('/api/auth/telegram/initiate', { method: 'POST' })
       const data = await res.json()
       if (!res.ok || !data.url) {
-        alert(data.error ?? 'Erro ao gerar link do Telegram')
+        toast.error(data.error ?? 'Erro ao gerar link do Telegram')
         return
       }
       window.open(data.url, '_blank')

--- a/src/components/clipping/ClippingCard.tsx
+++ b/src/components/clipping/ClippingCard.tsx
@@ -246,7 +246,7 @@ export function ClippingCard({
                 <Button
                   variant="ghost"
                   size="icon"
-                  className={`h-8 w-8 cursor-pointer ${sendStatus === 'loading' ? 'text-[#1351b4]' : ''}`}
+                  className={`h-8 w-8 cursor-pointer ${sendStatus === 'loading' ? 'text-primary' : ''}`}
                 >
                   {sendStatus === 'loading' ? (
                     <Loader2 className="h-4 w-4 animate-spin" />

--- a/src/components/consent/CookieConsent.tsx
+++ b/src/components/consent/CookieConsent.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { Button } from '@/components/ui/button'
 import { useConsent } from './ConsentProvider'
 
 export function CookieConsent() {
@@ -18,20 +19,12 @@ export function CookieConsent() {
           dados de uso.
         </p>
         <div className="flex gap-3 shrink-0">
-          <button
-            type="button"
-            onClick={rejectCookies}
-            className="px-4 py-2 text-sm font-medium text-gray-700 bg-gray-100 rounded-md hover:bg-gray-200 transition-colors"
-          >
+          <Button variant="outline" size="sm" onClick={rejectCookies}>
             Recusar
-          </button>
-          <button
-            type="button"
-            onClick={acceptCookies}
-            className="px-4 py-2 text-sm font-medium text-white bg-government-blue rounded-md hover:bg-government-blue/90 transition-colors"
-          >
+          </Button>
+          <Button size="sm" onClick={acceptCookies}>
             Aceitar
-          </button>
+          </Button>
         </div>
       </div>
     </div>

--- a/src/components/invite/InviteLanding.tsx
+++ b/src/components/invite/InviteLanding.tsx
@@ -22,6 +22,7 @@ export function InviteLanding({ code, inviterName }: InviteLandingProps) {
     const res = await fetch('/api/auth/providers')
     const providers = await res.json()
     const providerId = Object.keys(providers)[0]
+    if (!providerId) return
     signIn(providerId, { callbackUrl: `/convite/${code}/redeem` })
   }
 

--- a/src/components/push/PushSubscriber.tsx
+++ b/src/components/push/PushSubscriber.tsx
@@ -113,7 +113,10 @@ export default function PushSubscriber() {
     if (!open || dataLoaded.current) return
 
     fetch('/api/push/filters-data')
-      .then((res) => res.json())
+      .then((res) => {
+        if (!res.ok) throw new Error(`HTTP ${res.status}`)
+        return res.json()
+      })
       .then((data) => {
         if (data.agencies) setAgencies(data.agencies)
         dataLoaded.current = true

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -5,7 +5,7 @@ export default auth((request) => {
   const requestHeaders = new Headers(request.headers)
   requestHeaders.set('x-pathname', request.nextUrl.pathname)
 
-  if (request.nextUrl.pathname.startsWith('/admin/preview') && !request.auth) {
+  if (request.nextUrl.pathname.startsWith('/admin') && !request.auth) {
     return NextResponse.redirect(new URL('/api/auth/signin', request.url))
   }
 

--- a/src/types/next-auth.d.ts
+++ b/src/types/next-auth.d.ts
@@ -20,5 +20,11 @@ declare module 'next-auth' {
 declare module 'next-auth/jwt' {
   interface JWT {
     roles?: string[]
+    stableUserId?: string
+    accessToken?: string
+    refreshToken?: string
+    expiresAt?: number
+    provider?: string
+    error?: string
   }
 }


### PR DESCRIPTION
## Summary

Cherry-pick das correções relevantes do PR #128 (@LucaasMa), adaptadas para o código atual.

### Segurança (CRÍTICO)
- Admin layout verifica `isAdmin()` — antes qualquer user logado acessava `/admin/*`
- Middleware protege todas as rotas `/admin` (não só `/admin/preview`)

### Tipos
- JWT interface declara `stableUserId`, `accessToken`, `refreshToken`, `expiresAt`, `provider`, `error`

### Visual
- Hex hardcoded (`#0D4C92`, `#2D9B78`, `#1351b4`) → tokens CSS
- `<button>` nativos → shadcn `<Button>` (CookieConsent, filtros)
- `alert()` → `toast.error()` (ChannelSelector)

### Defensivo
- AuthButton/InviteLanding: guard para `providerId` vazio
- PushSubscriber: verifica `res.ok` antes de `.json()`

Ref: #128

## Test plan
- [x] 336 testes passando (2 falhas pré-existentes em convites/nanoid)