### PR TITLE
fix: corrige testes falhando no CI

### DIFF
--- a/src/app/(public)/convites/__tests__/actions.test.ts
+++ b/src/app/(public)/convites/__tests__/actions.test.ts
@@ -14,6 +14,10 @@ vi.mock('@/auth', () => ({
   auth: vi.fn(),
 }))
 
+vi.mock('@/lib/invite', () => ({
+  generateInviteCode: () => 'TEST1234',
+}))
+
 describe('convites actions', () => {
   beforeEach(() => {
     vi.resetModules()
@@ -136,7 +140,7 @@ describe('convites actions', () => {
 
       expect(result.type).toBe('ok')
       expect(mockBatch.set).toHaveBeenCalled()
-      expect(mockBatch.update).toHaveBeenCalled()
+      expect(mockBatch.set).toHaveBeenCalledTimes(2)
       expect(mockBatch.commit).toHaveBeenCalled()
     })
 

--- a/src/components/push/__tests__/PushSubscriber.test.tsx
+++ b/src/components/push/__tests__/PushSubscriber.test.tsx
@@ -143,7 +143,7 @@ describe('PushSubscriber', () => {
     await user.click(screen.getByRole('button'))
 
     await waitFor(() => {
-      expect(screen.getByText('Notificações')).toBeInTheDocument()
+      expect(screen.getByText('Notificações WebPush')).toBeInTheDocument()
     })
   })
 


### PR DESCRIPTION
## Summary
Corrige 3 testes que falhavam no CI:
- PushSubscriber: título do Sheet mudou para "Notificações WebPush"
- convites/actions: `batch.update` → `batch.set` (alinhado com fix anterior)
- convites/actions: mock de `nanoid` via `@/lib/invite` (ESM-only)

338 testes passando, 0 falhas.