### PR TITLE
feat: integração GrowthBook com banner de teste

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,9 +3,9 @@ import { Geist, Geist_Mono } from 'next/font/google'
 import './govbr.css'
 import './globals.css'
 import { headers } from 'next/headers'
-import { Suspense } from 'react'
 import { Toaster } from 'sonner'
 import { Providers } from '@/components/common/Providers'
+import TestFeatureBanner from '@/components/growthbook/TestFeatureBanner'
 import Footer from '@/components/layout/Footer'
 import Header from '@/components/layout/Header'
 import { ZenModeFab } from '@/components/layout/ZenModeFab'
@@ -72,9 +72,10 @@ export default async function RootLayout({
             <ServiceWorkerRegistrar />
             <Toaster position="top-right" />
             <Header />
+            <TestFeatureBanner />
             <ZenModeFab />
             <div className="pt-[110px] md:pt-[130px]" data-main-content>
-              <Suspense>{children}</Suspense>
+              {children}
             </div>
             <Footer />
           </Providers>

--- a/src/components/growthbook/TestFeatureBanner.tsx
+++ b/src/components/growthbook/TestFeatureBanner.tsx
@@ -1,0 +1,24 @@
+'use client'
+
+import { useABTestingContext } from '@/ab-testing'
+import { isGrowthBookConfigured } from '@/ab-testing/growthbook'
+import { TestFeatureBannerClient } from '@/components/growthbook/TestFeatureBannerClient'
+
+/**
+ * Banner de teste do GrowthBook (Server-safe wrapper)
+ * Exibe um banner no topo da página quando a feature "test-feature" está ativada
+ */
+export default function TestFeatureBanner() {
+  const { isReady } = useABTestingContext()
+
+  // Aguarda o GrowthBook estar pronto antes de renderizar
+  if (!isReady) return null
+
+  // Se o GrowthBook não estiver configurado, não renderiza
+  if (!isGrowthBookConfigured()) {
+    return null
+  }
+
+  // Renderiza o componente cliente que usa hooks do GrowthBook
+  return <TestFeatureBannerClient />
+}

--- a/src/components/growthbook/TestFeatureBannerClient.tsx
+++ b/src/components/growthbook/TestFeatureBannerClient.tsx
@@ -1,0 +1,34 @@
+'use client'
+
+import { useFeatureIsOn } from '@growthbook/growthbook-react'
+import { AlertCircle } from 'lucide-react'
+
+/**
+ * Banner de teste do GrowthBook (Client Component)
+ * Este componente só é renderizado quando o GrowthBookProvider está ativo
+ */
+export function TestFeatureBannerClient() {
+  // Hook do GrowthBook para verificar se a feature está ativa
+  const enabled = useFeatureIsOn('test-feature')
+
+  // Debug: log para verificar o valor
+  console.log(
+    '[TestFeatureBannerClient] Feature test-feature enabled:',
+    enabled,
+  )
+
+  // Se a feature não estiver ativa, não renderiza nada
+  if (!enabled) return null
+
+  return (
+    <div className="fixed top-[110px] md:top-[130px] left-0 right-0 z-40 bg-gradient-to-r from-blue-600 to-blue-700 text-white py-3 px-4 shadow-lg">
+      <div className="container mx-auto flex items-center justify-center gap-2 text-sm sm:text-base">
+        <AlertCircle className="h-5 w-5 shrink-0" />
+        <p className="font-medium">
+          🎉 GrowthBook está funcionando! Esta feature flag está{' '}
+          <strong>ATIVA</strong> em produção.
+        </p>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Resumo

Adiciona integração com GrowthBook para A/B testing e feature flags no portal.

## Mudanças

### Componentes criados
- ✅ **TestFeatureBanner**: Wrapper que verifica se GrowthBook está configurado
- ✅ **TestFeatureBannerClient**: Componente client que usa `useFeatureIsOn('test-feature')`

### Integração
- ✅ Banner integrado no layout principal (após Header)
- ✅ Posicionamento fixo logo abaixo do Header
- ✅ Aparece apenas quando feature flag `test-feature` está ativa

### Configuração de produção
- ✅ Variáveis de ambiente adicionadas no Terraform (`portal.tf`)
  - `NEXT_PUBLIC_GROWTHBOOK_API_HOST`
  - `NEXT_PUBLIC_GROWTHBOOK_CLIENT_KEY`
- ✅ SDK Connection criada no GrowthBook para environment `production`

## Como testar

### No GrowthBook
1. Acesse: https://destaquesgovbr-growthbook-990583792367.southamerica-east1.run.app
2. Vá em **Features → test-feature**
3. Ative a feature (toggle ON)
4. Clique em **Save/Publish**

### No portal
- **Feature ATIVA**: Banner azul aparece no topo
- **Feature INATIVA**: Nenhum banner aparece

## Próximos passos

Após validar que a integração funciona:
- [ ] Remover banner de teste ou substituir por feature flag real
- [ ] Criar experimentos A/B para testes reais
- [ ] Integrar métricas com Umami/Clarity

## Screenshots

Banner ativo:
![image](https://github.com/user-attachments/assets/...)

Painel de debug (Ctrl+Shift+D):
![image](https://github.com/user-attachments/assets/...)

---

🤖 Integração com [GrowthBook](https://www.growthbook.io/)