### PR TITLE
docs: revisa e atualiza documentações do portal

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 ## Visão Geral do Projeto
 
-Portal de notícias do Governo Federal brasileiro, desenvolvido com Next.js 15, que agrega e exibe conteúdo de diversos ministérios e órgãos governamentais. O projeto utiliza Typesense para busca e indexação de artigos.
+Plataforma do Governo Federal brasileiro ("Web Difusora") desenvolvida com Next.js 15, que agrega conteúdo de diversos ministérios e órgãos governamentais e oferece clippings automatizados por IA, marketplace de clippings, widgets embarcáveis, notificações push e feeds RSS/Atom/JSON. O projeto utiliza Typesense para busca e indexação de artigos.
 
 **Nome do projeto**: portal
 **Tecnologia principal**: Next.js 15.5.3 com App Router
@@ -22,11 +22,16 @@ Portal de notícias do Governo Federal brasileiro, desenvolvido com Next.js 15, 
 - **Formulários**: React Hook Form + Zod
 - **Markdown**: react-markdown + remark-gfm + rehype-raw
 - **Temas**: next-themes
+- **A/B Testing**: GrowthBook SDK
+- **Analytics**: Umami (privacy-first) + Microsoft Clarity (heatmaps)
 - **Linting/Formatting**: Biome 2.2.0
 
 ### Backend/Dados
 
 - **Busca**: Typesense 2.1.0
+- **Persistência**: Firebase/Firestore (clippings, usuários, convites)
+- **Email**: SendGrid (notificações de clipping e waitlist)
+- **Pub/Sub**: Google Cloud Pub/Sub (execução de clippings)
 - **Revalidação**: ISR (Incremental Static Regeneration) a cada 10 minutos
 
 ### Ferramentas de Build
@@ -34,88 +39,178 @@ Portal de notícias do Governo Federal brasileiro, desenvolvido com Next.js 15, 
 - **Package Manager**: pnpm
 - **Build Tool**: Next.js Turbopack
 - **Container**: Docker (Dockerfile presente)
+- **Testes**: Vitest (unitários) + Playwright (E2E)
 
 ## Estrutura de Diretórios
 
 ```
 /portal
 ├── src/
-│   ├── auth.ts                 # Configuração central do NextAuth
-│   ├── middleware.ts           # Middleware (pathname header)
-│   ├── app/                    # App Router (Next.js 15)
-│   │   ├── page.tsx           # Homepage principal
-│   │   ├── layout.tsx         # Layout raiz
-│   │   ├── globals.css        # Estilos globais
-│   │   ├── actions.ts         # Server actions da homepage
-│   │   ├── api/
-│   │   │   └── auth/
-│   │   │       └── [...nextauth]/
-│   │   │           └── route.ts  # NextAuth route handler
-│   │   ├── artigos/           # Rota de artigos
-│   │   │   ├── page.tsx
-│   │   │   ├── actions.ts
-│   │   │   └── [articleId]/
-│   │   │       ├── page.tsx
-│   │   │       ├── actions.ts
-│   │   │       ├── loading.tsx
-│   │   │       └── not-found.tsx
-│   │   ├── busca/             # Página de busca
-│   │   │   ├── page.tsx
-│   │   │   └── actions.ts
-│   │   ├── temas/             # Páginas de temas
-│   │   │   ├── page.tsx
-│   │   │   └── [themeLabel]/
-│   │   │       ├── page.tsx
-│   │   │       └── actions.ts
-│   │   └── dados-editoriais/  # Dashboard de dados
-│   │       ├── page.tsx
-│   │       └── actions.ts
-│   │   ├── (logged-in)/       # Route group autenticado (redireciona se sem sessão)
-│   │   │   ├── layout.tsx     # Guarda de autenticação
-│   │   │   └── minha-conta/
-│   │   │       └── clipping/
-│   │   │           ├── page.tsx          # Lista de clippings
-│   │   │           ├── novo/page.tsx     # Wizard de criação
-│   │   │           └── [id]/editar/page.tsx  # Edição de clipping
+│   ├── auth.ts                    # Configuração central do NextAuth
+│   ├── middleware.ts              # Middleware (pathname header)
+│   ├── ab-testing/                # Integração GrowthBook (A/B testing + feature flags)
+│   │   ├── index.ts               # Exports públicos do módulo
+│   │   ├── GrowthBookProvider.tsx  # Provider do GrowthBook
+│   │   ├── growthbook.ts          # Configuração do SDK
+│   │   ├── hooks.ts               # useAB, useFeatureFlag, useIsVariant
+│   │   ├── tracking.ts            # Tracking de experimentos
+│   │   └── components/
+│   │       └── ABDebugPanel.tsx    # Painel de debug para A/B tests
+│   ├── config/                    # Configurações de negócio
+│   │   ├── prioritization.ts      # Lógica de priorização de conteúdo
+│   │   ├── prioritization-config.ts
+│   │   ├── prioritization.yaml
+│   │   ├── widget-presets.ts      # Presets de widgets
+│   │   ├── themes.yaml            # Definição de temas (YAML)
+│   │   ├── agencies.yaml          # Definição de agências (YAML)
+│   │   └── hierarchy.yaml         # Hierarquia tema/agência
+│   ├── data/                      # Dados e utilitários de dados
+│   │   ├── agencies-utils.ts
+│   │   ├── agency-groups.ts
+│   │   ├── themes.ts
+│   │   └── themes-utils.ts
+│   ├── hooks/                     # Custom React hooks
+│   │   └── useRecorteEstimation.ts
+│   ├── services/                  # Camada de serviços
+│   │   ├── typesense/client.ts    # Cliente Typesense
+│   │   └── embeddings/client.ts   # Cliente da API de embeddings
+│   ├── types/                     # Definições de tipos
+│   │   ├── article.ts             # ArticleRow
+│   │   ├── clipping.ts            # Clipping, Recorte, Release, MarketplaceListing
+│   │   ├── search.ts              # Tipos de busca
+│   │   ├── analytics.ts           # Tipos de analytics
+│   │   ├── invite.ts              # Tipos de convite
+│   │   ├── widget.ts              # Tipos de widget
+│   │   ├── action-state.ts        # Estado de server actions
+│   │   └── next-auth.d.ts         # Extensões de tipos NextAuth
+│   ├── app/                       # App Router (Next.js 15)
+│   │   ├── layout.tsx             # Layout raiz
+│   │   ├── globals.css            # Estilos globais
+│   │   ├── not-found.tsx          # Página 404
+│   │   ├── feed.xml/route.ts      # Feed RSS
+│   │   ├── feed.json/route.ts     # Feed JSON
+│   │   ├── feed.atom/route.ts     # Feed Atom
+│   │   ├── (public)/              # Route group público
+│   │   │   ├── page.tsx           # Landing institucional (homepage)
+│   │   │   ├── noticias/          # Feed de notícias
+│   │   │   ├── artigos/[articleId]/ # Detalhe de artigo
+│   │   │   ├── busca/             # Página de busca
+│   │   │   ├── temas/             # Listagem e detalhe de temas
+│   │   │   ├── orgaos/            # Listagem e detalhe de órgãos
+│   │   │   ├── clippings/         # Galeria de Clippings (marketplace)
+│   │   │   ├── integracao/        # Página de integração (API/MCP/Chat)
+│   │   │   ├── feeds/             # Listagem de feeds disponíveis
+│   │   │   ├── widgets/configurador/ # Configurador de widgets
+│   │   │   ├── transparencia-algoritmica/ # Transparência algorítmica
+│   │   │   ├── web-difusora/      # Demo Web Difusora
+│   │   │   ├── convite/           # Fluxo de convites
+│   │   │   ├── convites/          # Listagem de convites
+│   │   │   └── lista-espera/      # Cadastro na lista de espera
+│   │   ├── (logged-in)/           # Route group autenticado
+│   │   │   ├── layout.tsx         # Guarda de autenticação
+│   │   │   └── minha-conta/clipping/
+│   │   │       ├── page.tsx       # Lista de clippings do usuário
+│   │   │       ├── novo/page.tsx  # Wizard de criação
+│   │   │       ├── [id]/page.tsx  # Detalhe do clipping
+│   │   │       └── [id]/editar/page.tsx # Edição de clipping
+│   │   ├── (admin)/               # Route group de administração
+│   │   │   ├── layout.tsx
+│   │   │   └── admin/
+│   │   │       ├── convites/      # Gerenciamento de convites
+│   │   │       └── preview/       # Preview admin
+│   │   ├── (analytics)/           # Route group de analytics
+│   │   │   └── dados-editoriais/  # Dashboard editorial
+│   │   ├── (widget-embed)/        # Route group para embedding
+│   │   │   ├── layout.tsx
+│   │   │   └── embed/             # Widget embed (iframe)
+│   │   ├── clipping/release/[releaseId]/ # Visualização de releases
+│   │   ├── auth/                  # Páginas pós-login e Telegram
 │   │   └── api/
 │   │       ├── auth/
 │   │       │   ├── [...nextauth]/route.ts
-│   │       │   └── telegram/
-│   │       │       ├── route.ts          # Inicia vinculação Telegram
-│   │       │       └── callback/route.ts # Finaliza vinculação, salva chatId
-│   │       └── clipping/
-│   │           ├── route.ts              # GET + POST /api/clipping
-│   │           └── [id]/route.ts         # PUT + DELETE /api/clipping/[id]
-│   ├── components/            # Componentes React
-│   │   ├── ui/               # Componentes shadcn/ui
-│   │   ├── auth/
-│   │   │   └── AuthButton.tsx # Botão de login/logout
-│   │   ├── layout/
-│   │   │   ├── Header.tsx
-│   │   │   └── Footer.tsx
-│   │   ├── common/
-│   │   │   └── Providers.tsx  # SessionProvider + QueryClient
-│   │   ├── NewsCard.tsx
-│   │   ├── SearchBar.tsx
-│   │   ├── MarkdownRenderer.tsx
-│   │   ├── ClientArticle.tsx
-│   │   ├── DashboardClient.tsx
-│   │   ├── ChartTooltip.tsx
-│   │   └── KpiCard.tsx
-│   └── lib/                   # Utilitários e helpers
-│       ├── typesense-client.ts
-│       ├── themes.ts
+│   │       │   └── telegram/      # Vinculação Telegram
+│   │       ├── clipping/          # CRUD de clippings
+│   │       │   ├── route.ts       # GET + POST
+│   │       │   ├── estimate/      # Estimativa de recorte
+│   │       │   ├── generate-recortes/ # Geração IA de recortes
+│   │       │   └── [id]/
+│   │       │       ├── route.ts   # PUT + DELETE
+│   │       │       ├── releases/  # Releases do clipping
+│   │       │       └── send/      # Envio manual
+│   │       ├── clippings/         # APIs do marketplace
+│   │       │   ├── publish/       # Publicação
+│   │       │   └── public/        # Listagem/detalhe público
+│   │       │       └── [listingId]/
+│   │       │           ├── follow/ # Seguir
+│   │       │           ├── like/   # Curtir
+│   │       │           ├── clone/  # Clonar
+│   │       │           ├── releases/
+│   │       │           ├── feed.json/
+│   │       │           └── feed.xml/
+│   │       ├── push/              # Push notifications
+│   │       └── widgets/           # APIs de widgets
+│   ├── components/                # Componentes React
+│   │   ├── ui/                    # Componentes shadcn/ui
+│   │   ├── layout/                # Header, Footer, Portal, ZenMode
+│   │   ├── landing/               # Componentes da landing page
+│   │   │   ├── LandingHero.tsx
+│   │   │   ├── LandingSection.tsx
+│   │   │   ├── FeatureCard.tsx
+│   │   │   ├── PainPointGrid.tsx
+│   │   │   ├── StatsBar.tsx
+│   │   │   ├── ShowcaseMockup.tsx
+│   │   │   ├── CalloutAnnotation.tsx
+│   │   │   └── FlowBadge.tsx
+│   │   ├── articles/              # NewsCard, ClientArticle, filtros, carousel, video
+│   │   ├── search/                # SearchBar
+│   │   ├── clipping/              # Wizard, editors, badges, release list
+│   │   ├── marketplace/           # MarketplaceCard, Follow, Publish, ListingActions
+│   │   ├── filters/               # Multi-selects de agência/tema
+│   │   ├── dashboard/             # DashboardClient, KpiCard, ChartTooltip
+│   │   ├── analytics/             # UmamiScript, ClarityScript, useUmamiTrack
+│   │   ├── push/                  # PushSubscriber, ServiceWorkerRegistrar
+│   │   ├── widgets/               # Widget container, carousel, configurador
+│   │   ├── auth/                  # AuthButton
+│   │   ├── invite/                # InviteLanding, InviteList, InviteCodeInput
+│   │   ├── waitlist/              # WaitlistForm
+│   │   ├── admin/                 # InviteStatsCards, WaitlistManager
+│   │   ├── consent/               # ConsentProvider, CookieConsent
+│   │   └── common/                # Providers, MarkdownRenderer, FeedLink
+│   └── lib/                       # Utilitários e helpers
 │       ├── utils.ts
-│       ├── article-row.ts
 │       ├── result.ts
-│       ├── action-state.ts
-│       └── getAgencyName.ts
-├── public/                    # Assets estáticos
+│       ├── clipping-validation.ts
+│       ├── clipping-worker.ts
+│       ├── recorte-utils.ts
+│       ├── recorte-preview-url.ts
+│       ├── estimate-recorte-count.ts
+│       ├── feed.ts
+│       ├── feed-handler.ts
+│       ├── marketplace-feed.ts
+│       ├── release-utils.ts
+│       ├── email.ts
+│       ├── email-templates.ts
+│       ├── markdown-carousel.ts
+│       ├── markdown-to-html.ts
+│       ├── firebase-admin.ts
+│       ├── pubsub.ts
+│       ├── admin.ts
+│       ├── invite.ts
+│       ├── normalize-email.ts
+│       ├── resolve-stable-user-id.ts
+│       ├── cron-utils.ts
+│       ├── push-utils.ts
+│       ├── widget-utils.ts
+│       └── landing-stats.ts
+├── e2e/                           # Testes E2E com Playwright
+├── public/                        # Assets estáticos
 ├── package.json
 ├── tsconfig.json
 ├── next.config.ts
-├── components.json            # Config do shadcn/ui
-├── biome.json                 # Config do Biome
+├── components.json                # Config do shadcn/ui
+├── biome.json                     # Config do Biome
+├── vitest.config.ts               # Config do Vitest
+├── playwright.config.ts           # Config do Playwright
 ├── Dockerfile
 └── README.md
 ```
@@ -128,7 +223,7 @@ O projeto utiliza extensivamente Server Actions do Next.js 15 para buscar dados:
 
 - **actions.ts**: Cada rota tem seu próprio arquivo de server actions
 - **Padrão de Result**: Utiliza um tipo `Result<T>` para tratamento de erros consistente
-- **Integração com Typesense**: Cliente configurado em `lib/typesense-client.ts`
+- **Integração com Typesense**: Cliente configurado em `services/typesense/client.ts`
 
 Exemplo de uso:
 
@@ -146,7 +241,7 @@ const articles = result.data;
 
 ### 2. Tipos de Artigo
 
-Estrutura principal definida em `lib/article-row.ts`:
+Estrutura principal definida em `types/article.ts`:
 
 - `unique_id`: Identificador único
 - `title`: Título da notícia
@@ -154,15 +249,11 @@ Estrutura principal definida em `lib/article-row.ts`:
 - `image`: URL da imagem
 - `published_at`: Timestamp Unix
 - `theme_1_level_1_label`: Tema principal
-- `agency_slug`: Órgão/ministério responsável
+- `agency`: Órgão/ministério responsável
 
-### 3. Sistema de Temas
+### 3. Sistema de Temas e Agências
 
-Definidos em `lib/themes.ts`:
-
-- Mapeia temas para ícones e imagens
-- Usado na página inicial e páginas de temas
-- Estrutura: `{ [themeName: string]: { icon: React.Component, image: string } }`
+Definidos em YAML em `config/themes.yaml` e `config/agencies.yaml`, com utilitários em `data/themes.ts` e `data/agencies-utils.ts`. A hierarquia temática é definida em `config/hierarchy.yaml`.
 
 ### 4. Componentes de UI
 
@@ -172,15 +263,22 @@ Baseados em shadcn/ui (Radix UI):
 - Componentes em `components/ui/`
 - Estilos personalizados com cores do governo brasileiro
 
-### 5. Homepage Layout
+### 5. Homepage (Landing Institucional)
 
-A página inicial (`app/page.tsx`) tem 5 seções principais:
+A homepage (`app/(public)/page.tsx`) é uma landing page institucional ("Web Difusora") com as seguintes seções:
 
-1. **Hero**: 1 manchete grande + 2 cards laterais + 2 secundários sem imagem
-2. **Últimas Notícias**: Grid de 6 cards com preview
-3. **Temas em Foco**: 3 temas com 2 notícias cada
-4. **Transparência**: Links para portais externos (Portal da Transparência, Dados Abertos, Ouvidoria)
-5. **Estatísticas**: KPIs editoriais (notícias do mês, total, ministérios, etc.)
+1. **Hero**: Apresentação da plataforma com mockup visual (Clipping + Panorama + notificação)
+2. **Pain Points**: Grid de problemas que a plataforma resolve
+3. **Três Fluxos**: Difusão, Inteligência e Integração
+4. **Feature Grid**: 9 funcionalidades (Clipping, Widgets, WebPush, Feeds, Busca, Panorama, Chat, MCP, GraphQL)
+5. **Web Difusora Showcase**: Teaser da funcionalidade de difusão
+6. **Roadmap**: Linha do tempo das próximas entregas
+7. **Transparência**: Prova de transparência com estatísticas do índice
+8. **CTA Final**: Call-to-action para cadastro/uso
+
+A rota `/noticias` contém o feed de notícias que anteriormente era a homepage.
+
+Componentes da landing ficam em `components/landing/` (LandingHero, LandingSection, FeatureCard, PainPointGrid, StatsBar, ShowcaseMockup, CalloutAnnotation, FlowBadge).
 
 ### 6. Revalidação
 
@@ -277,6 +375,26 @@ NEXT_PUBLIC_TYPESENSE_SEARCH_ONLY_API_KEY=sua-api-key
 docker logs govbrnews-typesense | grep "API Key:"
 ```
 
+### GrowthBook — A/B Testing e Feature Flags (opcional)
+
+```env
+NEXT_PUBLIC_GROWTHBOOK_API_HOST=https://cdn.growthbook.io
+NEXT_PUBLIC_GROWTHBOOK_CLIENT_KEY=sdk-xxxxx
+```
+
+Se não configurado, features usam valores padrão. O módulo `src/ab-testing/` exporta hooks (`useAB`, `useFeatureFlag`, `useIsVariant`) e componentes (`ABDebugPanel`, `GrowthBookProvider`).
+
+### Analytics (opcional)
+
+```env
+# Umami — privacy-first
+NEXT_PUBLIC_UMAMI_WEBSITE_ID=
+NEXT_PUBLIC_UMAMI_SCRIPT_URL=https://your-umami-instance.com/script.js
+
+# Microsoft Clarity — heatmaps e gravação de sessão
+NEXT_PUBLIC_CLARITY_PROJECT_ID=
+```
+
 ### Autenticação (opcional)
 
 ```env
@@ -297,6 +415,24 @@ AUTH_GOOGLE_SECRET=
 - Se nenhum provedor for configurado, o `AuthButton` fica oculto automaticamente.
 - `AUTH_SECRET` é obrigatório sempre que qualquer provedor for ativado.
 - Em Cloud Run, adicione também `AUTH_URL=https://seu-dominio.com` para que os redirects funcionem corretamente.
+
+### Admin e Email (opcional)
+
+```env
+# Controle de acesso admin (lista de emails separados por vírgula)
+ADMIN_EMAILS=
+
+# SendGrid — notificações de clipping e waitlist
+SENDGRID_API_KEY=
+EMAIL_FROM_ADDRESS=noreply@destaquesgovbr.gov.br
+```
+
+### Busca Semântica (opcional)
+
+```env
+EMBEDDINGS_API_URL=
+EMBEDDINGS_API_KEY=
+```
 
 ## Padrões de Código
 
@@ -382,27 +518,30 @@ SVGs decorativos de fundo para cards de temas e transparência.
 
 ## Integração com Typesense
 
-Cliente configurado em `lib/typesense-client.ts`:
+Cliente configurado em `services/typesense/client.ts`:
 
 ```typescript
-import Typesense from "typesense";
+import Typesense from 'typesense'
 
-const host = process.env.NEXT_PUBLIC_TYPESENSE_HOST ?? 'localhost';
-const port = 8108;
-const protocol = 'http';
+const host = process.env.NEXT_PUBLIC_TYPESENSE_HOST ?? 'localhost'
+const port = Number(process.env.NEXT_PUBLIC_TYPESENSE_PORT ?? '8108')
+const protocol = process.env.NEXT_PUBLIC_TYPESENSE_PROTOCOL ?? 'http'
 
-const client = new Typesense.Client({
+export const typesense = new Typesense.Client({
   nodes: [{ host, port, protocol }],
-  apiKey: process.env.NEXT_PUBLIC_TYPESENSE_SEARCH_ONLY_API_KEY ??
+  apiKey:
+    process.env.NEXT_PUBLIC_TYPESENSE_SEARCH_ONLY_API_KEY ??
     'govbrnews_api_key_change_in_production',
   connectionTimeoutSeconds: 10,
-});
+})
 ```
+
+O portal também suporta **busca semântica/híbrida** via `services/embeddings/client.ts`, que usa a API de embeddings para gerar vetores de busca. A busca híbrida combina keyword + semântica com `alpha` configurável.
 
 ### Busca de Artigos
 
 ```typescript
-const searchResults = await client.collections("articles").documents().search({
+const searchResults = await typesense.collections("articles").documents().search({
   q: query,
   query_by: "title,content",
   sort_by: "published_at:desc",
@@ -411,7 +550,7 @@ const searchResults = await client.collections("articles").documents().search({
 
 ## Componentes Importantes
 
-### NewsCard
+### NewsCard (`components/articles/NewsCard.tsx`)
 
 Card de notícia reutilizável com suporte a diferentes layouts:
 
@@ -419,38 +558,33 @@ Card de notícia reutilizável com suporte a diferentes layouts:
 - Modo padrão (card médio)
 - Modo compacto (sem imagem)
 
-Props principais:
+### MarkdownRenderer (`components/common/MarkdownRenderer.tsx`)
 
-- `title`, `summary`, `date`, `theme_1_level_1`
-- `imageUrl`, `internalUrl`
-- `isMain` (boolean para manchete principal)
+Renderiza conteúdo markdown dos artigos com suporte a HTML bruto (rehype-raw), GFM (remark-gfm), e carrosséis de imagem via `lib/markdown-carousel.ts`.
 
-### MarkdownRenderer
+### SearchBar (`components/search/SearchBar.tsx`)
 
-Renderiza conteúdo markdown dos artigos:
+Barra de busca com debounce e navegação para `/busca?q=termo`.
 
-- Suporta HTML bruto (rehype-raw)
-- GitHub Flavored Markdown (remark-gfm)
-- Estilos customizados para elementos markdown
+### AuthButton (`components/auth/AuthButton.tsx`)
 
-### SearchBar
+Botão de autenticação — consulta `/api/auth/providers` e se oculta se nenhum provedor está configurado.
 
-Barra de busca com:
+### ClippingWizard (`components/clipping/ClippingWizard.tsx`)
 
-- Debounce
-- Navegação para `/busca?q=termo`
-- Ícone de busca (Lucide React)
+Wizard de criação de clipping em 4 passos: Recortes → Prompt → Horário → Canais.
 
-### AuthButton
+### ClippingDetailView (`components/clipping/ClippingDetailView.tsx`)
 
-Botão de autenticação em `components/auth/AuthButton.tsx`:
+Componente unificado para exibição de detalhes de clipping, usado tanto na área logada quanto na visualização pública do marketplace. Renderiza o digest (conteúdo markdown da release) e metadados do clipping.
 
-- Consulta `/api/auth/providers` ao montar para verificar se há provedores configurados
-- Se nenhum provedor estiver ativo, **não renderiza nada** (graceful degradation)
-- Estado de loading: skeleton animado enquanto verifica sessão
-- Não autenticado: botão "Entrar" com ícone `LogIn`
-- Autenticado: avatar com iniciais do nome + dropdown com opção "Sair"
-- Presente no Header tanto em desktop quanto em mobile
+### Galeria de Clippings (`app/(public)/clippings/page.tsx`)
+
+Marketplace público de clippings — permite descobrir, seguir, curtir e clonar clippings criados pela comunidade. Componentes do marketplace ficam em `components/marketplace/`.
+
+### Widgets (`components/widgets/`)
+
+Sistema de widgets embarcáveis que permite que sites externos exibam notícias do portal via iframe. Inclui configurador visual (`widgets/configurador/`) e endpoint `/embed`.
 
 ## Dicas para Desenvolvimento
 
@@ -472,10 +606,9 @@ Componentes são adicionados automaticamente em `components/ui/`
 
 ### Trabalhar com Temas
 
-1. Adicione tema em `lib/themes.ts`
-2. Importe ícone do lucide-react
-3. Adicione imagem em `public/`
-4. Use em componentes via `THEME_ICONS[themeName]`
+1. Adicione tema em `config/themes.yaml`
+2. Use utilitários de `data/themes.ts` e `data/themes-utils.ts`
+3. Para agências: `config/agencies.yaml` + `data/agencies-utils.ts`
 
 ### Debugging do Typesense
 
@@ -517,6 +650,9 @@ Certifique-se de configurar:
 - `AUTH_SECRET` (obrigatório se qualquer provedor de auth estiver ativo)
 - `AUTH_URL` (URL pública do app, ex: `https://portal.exemplo.gov.br`) — necessário para Cloud Run pois o `trustHost: true` não infere a URL base automaticamente em todos os cenários
 - `AUTH_GOVBR_ID`, `AUTH_GOVBR_SECRET`, `AUTH_GOVBR_ISSUER` (para Gov.Br em produção)
+- `NEXT_PUBLIC_GROWTHBOOK_API_HOST`, `NEXT_PUBLIC_GROWTHBOOK_CLIENT_KEY` (para A/B testing)
+- `SENDGRID_API_KEY`, `EMAIL_FROM_ADDRESS` (para envio de clippings e notificações)
+- `ADMIN_EMAILS` (controle de acesso admin)
 
 ## Security Headers
 
@@ -580,7 +716,7 @@ No Keycloak, `*` só funciona como **sufixo** (prefix match). Exemplo: `https://
 ### TypeScript Errors
 
 - Rode `npx tsc --noEmit` para ver todos os erros
-- Verifique tipos em `lib/article-row.ts`
+- Verifique tipos em `types/article.ts` e `types/clipping.ts`
 - Use `Result<T>` consistentemente
 
 ### Erros de Autenticação
@@ -607,7 +743,8 @@ Route group protegido por autenticação. O layout em `src/app/(logged-in)/layou
 ### Páginas disponíveis
 
 - `/minha-conta/clipping` — Lista de clippings do usuário
-- `/minha-conta/clipping/novo` — Wizard de criação de clipping (4 passos)
+- `/minha-conta/clipping/novo` — Wizard de criação de clipping
+- `/minha-conta/clipping/[id]` — Detalhe do clipping (com releases e digest markdown)
 - `/minha-conta/clipping/[id]/editar` — Edição de clipping existente
 
 ### Componentes (`src/components/clipping/`)
@@ -615,17 +752,28 @@ Route group protegido por autenticação. O layout em `src/app/(logged-in)/layou
 | Componente | Propósito |
 |------------|-----------|
 | `ClippingWizard` | Wizard 4 passos: Recortes → Prompt → Horário → Canais |
+| `ClippingDetailView` | Visualização unificada de detalhe de clipping |
 | `RecorteEditor` | Editor de um Recorte com tema, agência e keywords |
-| `ScheduleSelect` | Select com 48 horários (00:00–23:30 de 30 em 30 min) |
+| `CronScheduleBuilder` | Construtor visual de agendamento cron |
+| `ScheduleSelect` | Select com horários pré-definidos |
 | `PromptEditor` | Textarea com prompt LLM, contador de chars, botão restaurar |
-| `ChannelSelector` | Checkboxes email/telegram/push |
+| `ChannelSelector` | Checkboxes email/telegram/push/webhook |
+| `ExtraEmailsInput` | Input para emails adicionais de entrega |
 | `ClippingCard` | Card na listagem com ações de editar/excluir/toggle |
+| `ReleaseList` | Lista de releases (edições) do clipping |
+| `RecorteEstimationBadge` | Badge com estimativa de artigos por recorte |
+| `ArticleCountBadge` | Badge com contagem de artigos |
+| `AgentRecorteGenerator` | Gerador de recortes via IA |
 
 ### Tipos (`src/types/clipping.ts`)
 
-- `Recorte` — filtro composto: `{ id, themes, agencies, keywords }`
-- `Clipping` — configuração completa com `recortes[]`, `scheduleTime`, `deliveryChannels`, `prompt`
+- `Recorte` — filtro composto: `{ id, title, themes, agencies, keywords }`
+- `Clipping` — configuração completa com `recortes[]`, `schedule`, `deliveryChannels`, `prompt`, campos de marketplace
 - `ClippingPayload` — payload para criação/atualização
+- `Release` — edição gerada do clipping: `{ id, digest, digestHtml, articlesCount, createdAt }`
+- `MarketplaceListing` — listagem pública no marketplace
+- `MarketplaceFollower` — seguidor de uma listagem
+- `Subscription` — assinatura de um clipping
 
 ## Clipping APIs
 
@@ -634,12 +782,30 @@ Route group protegido por autenticação. O layout em `src/app/(logged-in)/layou
 | Method | Path | Auth | Descrição |
 |--------|------|------|-----------|
 | GET | `/api/clipping` | Required | Lista clippings do usuário |
-| POST | `/api/clipping` | Required | Cria novo clipping (max 10) |
+| POST | `/api/clipping` | Required | Cria novo clipping |
 | PUT | `/api/clipping/[id]` | Required | Atualiza clipping |
 | DELETE | `/api/clipping/[id]` | Required | Remove clipping |
+| GET | `/api/clipping/[id]/releases` | Required | Lista releases do clipping |
+| POST | `/api/clipping/[id]/send` | Required | Envia clipping manualmente |
+| POST | `/api/clipping/estimate` | Required | Estimativa de artigos por recorte |
+| POST | `/api/clipping/generate-recortes` | Required | Geração de recortes via IA |
 
 Validação: `ClippingPayloadSchema` em `src/lib/clipping-validation.ts`
 Persistência: Firestore `users/{userId}/clippings/{clippingId}`
+
+### Marketplace APIs
+
+| Method | Path | Auth | Descrição |
+|--------|------|------|-----------|
+| POST | `/api/clippings/publish` | Required | Publica clipping no marketplace |
+| GET | `/api/clippings/public` | — | Lista clippings públicos |
+| GET | `/api/clippings/public/[listingId]` | — | Detalhe de listagem pública |
+| POST | `/api/clippings/public/[listingId]/follow` | Required | Seguir clipping |
+| POST | `/api/clippings/public/[listingId]/like` | Required | Curtir clipping |
+| POST | `/api/clippings/public/[listingId]/clone` | Required | Clonar clipping |
+| GET | `/api/clippings/public/[listingId]/releases` | — | Releases da listagem |
+| GET | `/api/clippings/public/[listingId]/feed.json` | — | Feed JSON da listagem |
+| GET | `/api/clippings/public/[listingId]/feed.xml` | — | Feed RSS da listagem |
 
 ### Vinculação Telegram
 
@@ -649,6 +815,51 @@ Persistência: Firestore `users/{userId}/clippings/{clippingId}`
 | GET | `/api/auth/telegram/callback?state=TOKEN` | Finaliza vinculação, salva chatId |
 
 Fluxo: Bot `/login` → token Firestore → portal auth → callback → `users/{userId}/telegramLink/account`
+
+### Push Notifications
+
+| Method | Path | Auth | Descrição |
+|--------|------|------|-----------|
+| GET | `/api/push/filters-data` | — | Dados de filtros para push |
+| GET/PUT | `/api/push/preferences` | Required | Preferências de push do usuário |
+| POST | `/api/push/sync` | — | Sincronização de subscription |
+
+### Widgets
+
+| Method | Path | Auth | Descrição |
+|--------|------|------|-----------|
+| GET | `/api/widgets/articles` | — | Artigos para widget |
+| GET | `/api/widgets/config` | — | Configuração do widget |
+
+## Área Admin (`(admin)`)
+
+Route group protegido para administradores. Acesso controlado por `ADMIN_EMAILS`.
+
+- `/admin/convites` — Gerenciamento de convites e lista de espera
+- `/admin/preview` — Preview de funcionalidades
+
+## Feeds e Conteúdo Público
+
+O portal disponibiliza feeds nos formatos RSS, Atom e JSON:
+
+- `/feed.xml` — Feed RSS global
+- `/feed.atom` — Feed Atom global
+- `/feed.json` — Feed JSON global
+- `/api/clippings/public/[listingId]/feed.xml` — Feed RSS de clipping público
+- `/api/clippings/public/[listingId]/feed.json` — Feed JSON de clipping público
+
+A página `/feeds` lista todos os feeds disponíveis.
+
+## Sistema de Convites e Lista de Espera
+
+O portal possui um sistema de acesso por convite:
+
+- `/convite` — Landing de convite
+- `/convite/[code]` — Detalhe de convite específico
+- `/convite/[code]/redeem` — Resgate de convite
+- `/lista-espera` — Cadastro na lista de espera
+- Componentes: `InviteLanding`, `InviteList`, `InviteCodeInput`, `GenerateInviteButton`
+- Utilitários: `lib/invite.ts`
 
 ## Links Úteis
 
@@ -735,5 +946,5 @@ pnpm format  # Formata código
 
 ---
 
-**Última atualização**: Março 2026
+**Última atualização**: Abril 2026
 **Mantido por**: Equipe MGI/Governo Federal

--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
-# Portal DestaquesGovBr
+# Portal DestaquesGovBr — Web Difusora
 
 [![Licença: AGPL v3](https://img.shields.io/badge/License-AGPL_v3-blue.svg)](https://www.gnu.org/licenses/agpl-3.0)
 
-Este é um projeto [Next.js](https://nextjs.org) criado com [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app).
+Plataforma do Governo Federal brasileiro que agrega conteúdo de ministérios e órgãos governamentais. Oferece clippings automatizados por IA, marketplace de clippings, widgets embarcáveis, notificações push, feeds RSS/Atom/JSON e busca semântica.
+
+Desenvolvido com [Next.js 15](https://nextjs.org) (App Router), TypeScript, Tailwind CSS, shadcn/ui e Typesense.
 
 ## Primeiros Passos
 
@@ -40,6 +42,17 @@ AUTH_GOOGLE_SECRET=seu-client-secret
 ```
 
 Se nenhuma variável de auth for configurada, o botão de login simplesmente não aparece — o portal continua funcionando normalmente.
+
+#### GrowthBook — A/B Testing (opcional)
+
+```env
+NEXT_PUBLIC_GROWTHBOOK_API_HOST=https://cdn.growthbook.io
+NEXT_PUBLIC_GROWTHBOOK_CLIENT_KEY=sdk-xxxxx
+```
+
+Se não configurado, feature flags usam valores padrão.
+
+Veja `.env.example` para a lista completa de variáveis de ambiente disponíveis (analytics, email, embeddings, admin, etc.).
 
 ### 3. Executar o servidor de desenvolvimento
 
@@ -184,12 +197,14 @@ curl -H "X-TYPESENSE-API-KEY: sua-api-key" http://localhost:8108/collections
 
 ## Saiba Mais
 
-Para aprender mais sobre Next.js, confira os seguintes recursos:
+- [Documentação do Next.js](https://nextjs.org/docs)
+- [Typesense Docs](https://typesense.org/docs/)
+- [shadcn/ui](https://ui.shadcn.com/)
+- [GrowthBook Docs](https://docs.growthbook.io/)
+- [NextAuth.js v5 Docs](https://authjs.dev/)
+- [Gov.Br SSO — Documentação](https://manual-roteiro-integracao-login-unico.servicos.gov.br/)
 
-- [Documentação do Next.js](https://nextjs.org/docs) - aprenda sobre recursos e API do Next.js.
-- [Aprenda Next.js](https://nextjs.org/learn) - um tutorial interativo de Next.js.
-
-Você pode conferir o [repositório do Next.js no GitHub](https://github.com/vercel/next.js) - seu feedback e contribuições são bem-vindos!
+Para detalhes completos da arquitetura, convenções e padrões do projeto, consulte o [`CLAUDE.md`](./CLAUDE.md).
 
 ## Deploy em Produção
 


### PR DESCRIPTION
## Summary

Closes #201

- Reescreve `CLAUDE.md` e atualiza `README.md` para refletir o estado atual do codebase após implementações recentes
- Atualiza estrutura de diretórios completa (novos módulos: `ab-testing/`, `config/`, `data/`, `hooks/`, `services/`, `types/`)
- Documenta landing institucional ("Web Difusora") como homepage, substituindo o antigo feed de notícias
- Adiciona documentação de GrowthBook (A/B testing), Analytics (Umami + Clarity), Marketplace APIs, Push Notifications, Widgets, sistema de convites e feeds
- Corrige caminhos desatualizados (`lib/typesense-client.ts` → `services/typesense/client.ts`, `lib/article-row.ts` → `types/article.ts`, etc.)
- Documenta novos componentes: `ClippingDetailView`, `CronScheduleBuilder`, `AgentRecorteGenerator`, landing kit, marketplace components

## Test plan

- [ ] Verificar que `CLAUDE.md` reflete a estrutura real dos diretórios e rotas do projeto
- [ ] Verificar que variáveis de ambiente documentadas correspondem ao `.env.example`
- [ ] Confirmar que caminhos de arquivos referenciados existem no codebase
- [ ] Verificar que o `README.md` tem instruções de setup consistentes

🤖 Generated with [Claude Code](https://claude.com/claude-code)