### PR TITLE
fix: corrige leitura de campo expiresAtMs na auth Telegram

### DIFF
--- a/src/app/api/auth/telegram/__tests__/route.test.ts
+++ b/src/app/api/auth/telegram/__tests__/route.test.ts
@@ -98,8 +98,8 @@ describe('GET /api/auth/telegram', () => {
   it('returns 400 if token is expired', async () => {
     mockAuth.mockResolvedValue({ user: { id: 'user-1' } } as never)
 
-    const expiredTime = { toDate: () => new Date(Date.now() - 3600 * 1000) }
-    makeTokenDocChain(true, { expiresAt: expiredTime, chatId: '12345' })
+    const expiredTimeMs = Date.now() - 3600 * 1000
+    makeTokenDocChain(true, { expiresAtMs: expiredTimeMs, chatId: '12345' })
 
     const request = new NextRequest(
       'http://localhost/api/auth/telegram?state=expiredtoken',
@@ -114,8 +114,8 @@ describe('GET /api/auth/telegram', () => {
   it('redirects to callback when token is valid', async () => {
     mockAuth.mockResolvedValue({ user: { id: 'user-1' } } as never)
 
-    const futureTime = { toDate: () => new Date(Date.now() + 3600 * 1000) }
-    makeTokenDocChain(true, { expiresAt: futureTime, chatId: '12345' })
+    const futureTimeMs = Date.now() + 3600 * 1000
+    makeTokenDocChain(true, { expiresAtMs: futureTimeMs, chatId: '12345' })
 
     const request = new NextRequest(
       'http://localhost/api/auth/telegram?state=validtoken',

--- a/src/app/api/auth/telegram/callback/__tests__/route.test.ts
+++ b/src/app/api/auth/telegram/callback/__tests__/route.test.ts
@@ -56,7 +56,7 @@ function makeDocRef(exists: boolean, data: object = {}) {
 
 function validTokenData(chatId = '31949381') {
   return {
-    expiresAt: { toDate: () => new Date(Date.now() + 600_000) },
+    expiresAtMs: Date.now() + 600_000,
     chatId,
     userId: null,
   }
@@ -64,7 +64,7 @@ function validTokenData(chatId = '31949381') {
 
 function expiredTokenData(chatId = '31949381') {
   return {
-    expiresAt: { toDate: () => new Date(Date.now() - 600_000) },
+    expiresAtMs: Date.now() - 600_000,
     chatId,
     userId: null,
   }

--- a/src/app/api/auth/telegram/callback/route.ts
+++ b/src/app/api/auth/telegram/callback/route.ts
@@ -1,4 +1,4 @@
-import { FieldValue, Timestamp } from 'firebase-admin/firestore'
+import { FieldValue } from 'firebase-admin/firestore'
 import { redirect } from 'next/navigation'
 import { NextResponse } from 'next/server'
 import { auth } from '@/auth'
@@ -32,10 +32,7 @@ export async function GET(request: Request) {
     }
 
     const tokenData = tokenDoc.data()!
-    const expiresAt: Date =
-      tokenData.expiresAt instanceof Timestamp
-        ? tokenData.expiresAt.toDate()
-        : tokenData.expiresAt.toDate()
+    const expiresAt = new Date(tokenData.expiresAtMs)
 
     if (expiresAt < new Date()) {
       return NextResponse.json({ error: 'Token expirado' }, { status: 400 })

--- a/src/app/api/auth/telegram/route.ts
+++ b/src/app/api/auth/telegram/route.ts
@@ -1,4 +1,3 @@
-import { Timestamp } from 'firebase-admin/firestore'
 import { redirect } from 'next/navigation'
 import { NextResponse } from 'next/server'
 import { auth } from '@/auth'
@@ -37,10 +36,7 @@ export async function GET(request: Request) {
     }
 
     const tokenData = tokenDoc.data()!
-    const expiresAt: Date =
-      tokenData.expiresAt instanceof Timestamp
-        ? tokenData.expiresAt.toDate()
-        : tokenData.expiresAt.toDate()
+    const expiresAt = new Date(tokenData.expiresAtMs)
 
     if (expiresAt < new Date()) {
       return NextResponse.json({ error: 'Token expirado' }, { status: 400 })


### PR DESCRIPTION
## Resumo
Corrige fluxo de vinculação Telegram que estava completamente quebrado devido a incompatibilidade de campos entre gravação e leitura.

## Problema
- `initiate/route.ts` grava `expiresAtMs` (número em milissegundos)
- `route.ts` e `callback/route.ts` tentavam ler `expiresAt` (inexistente)
- Chamavam `.toDate()` em `undefined` → `TypeError`
- Fluxo inteiro retornava 500 e falhava

## Solução
- Alterada leitura para usar `expiresAtMs` em ambos os arquivos
- Simplificado para `new Date(tokenData.expiresAtMs)`
- Removidos imports não utilizados de `Timestamp`

## Arquivos alterados
- [src/app/api/auth/telegram/route.ts](https://github.com/destaquesgovbr/portal/blob/fix/telegram-auth-expiry-field/src/app/api/auth/telegram/route.ts)
- [src/app/api/auth/telegram/callback/route.ts](https://github.com/destaquesgovbr/portal/blob/fix/telegram-auth-expiry-field/src/app/api/auth/telegram/callback/route.ts)

## Critérios de Aceite
- [x] Token gravado e lido com o mesmo campo
- [x] Fluxo completo de vinculação Telegram funciona
- [x] Token expirado retorna 400, não 500

Closes #205