### PR TITLE
fix: adiciona validação de segurança para webhook URLs

### DIFF
--- a/src/lib/clipping-validation.test.ts
+++ b/src/lib/clipping-validation.test.ts
@@ -1,0 +1,198 @@
+import { describe, expect, it } from 'vitest'
+import {
+  ClippingPayloadSchema,
+  FollowListingSchema,
+} from './clipping-validation'
+
+describe('ClippingPayloadSchema - webhook URL validation', () => {
+  const basePayload = {
+    name: 'Test Clipping',
+    description: 'Test description',
+    recortes: [
+      {
+        id: '1',
+        title: 'Recorte 1',
+        themes: ['economia'],
+        agencies: [],
+        keywords: [],
+      },
+    ],
+    prompt: 'Test prompt',
+    schedule: '0 9 * * *',
+    deliveryChannels: {
+      email: false,
+      telegram: false,
+      push: false,
+      webhook: true,
+    },
+    active: true,
+    extraEmails: [],
+  }
+
+  describe('URLs permitidas', () => {
+    it('aceita URL HTTPS válida', () => {
+      const result = ClippingPayloadSchema.safeParse({
+        ...basePayload,
+        webhookUrl: 'https://example.com/webhook',
+      })
+      expect(result.success).toBe(true)
+    })
+
+    it('aceita URL HTTPS com subdomínio', () => {
+      const result = ClippingPayloadSchema.safeParse({
+        ...basePayload,
+        webhookUrl: 'https://api.example.com/webhook',
+      })
+      expect(result.success).toBe(true)
+    })
+
+    it('aceita webhook URL vazia quando webhook está desativado', () => {
+      const result = ClippingPayloadSchema.safeParse({
+        ...basePayload,
+        deliveryChannels: {
+          email: true,
+          telegram: false,
+          push: false,
+          webhook: false,
+        },
+        webhookUrl: '',
+      })
+      expect(result.success).toBe(true)
+    })
+  })
+
+  describe('URLs bloqueadas', () => {
+    it('rejeita HTTP (não-HTTPS)', () => {
+      const result = ClippingPayloadSchema.safeParse({
+        ...basePayload,
+        webhookUrl: 'http://example.com/webhook',
+      })
+      expect(result.success).toBe(false)
+    })
+
+    it('rejeita localhost', () => {
+      const result = ClippingPayloadSchema.safeParse({
+        ...basePayload,
+        webhookUrl: 'https://localhost:8080/webhook',
+      })
+      expect(result.success).toBe(false)
+    })
+
+    it('rejeita 127.0.0.1', () => {
+      const result = ClippingPayloadSchema.safeParse({
+        ...basePayload,
+        webhookUrl: 'https://127.0.0.1/webhook',
+      })
+      expect(result.success).toBe(false)
+    })
+
+    it('rejeita metadata.google.internal', () => {
+      const result = ClippingPayloadSchema.safeParse({
+        ...basePayload,
+        webhookUrl:
+          'https://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/identity',
+      })
+      expect(result.success).toBe(false)
+    })
+
+    it('rejeita 169.254.169.254 (AWS/GCP metadata)', () => {
+      const result = ClippingPayloadSchema.safeParse({
+        ...basePayload,
+        webhookUrl: 'https://169.254.169.254/latest/meta-data/',
+      })
+      expect(result.success).toBe(false)
+    })
+
+    it('rejeita IP privado 10.x.x.x', () => {
+      const result = ClippingPayloadSchema.safeParse({
+        ...basePayload,
+        webhookUrl: 'https://10.0.0.1/webhook',
+      })
+      expect(result.success).toBe(false)
+    })
+
+    it('rejeita IP privado 192.168.x.x', () => {
+      const result = ClippingPayloadSchema.safeParse({
+        ...basePayload,
+        webhookUrl: 'https://192.168.1.1/webhook',
+      })
+      expect(result.success).toBe(false)
+    })
+
+    it('rejeita IP privado 172.16.x.x', () => {
+      const result = ClippingPayloadSchema.safeParse({
+        ...basePayload,
+        webhookUrl: 'https://172.16.0.1/webhook',
+      })
+      expect(result.success).toBe(false)
+    })
+
+    it('rejeita IP privado 172.31.x.x', () => {
+      const result = ClippingPayloadSchema.safeParse({
+        ...basePayload,
+        webhookUrl: 'https://172.31.255.255/webhook',
+      })
+      expect(result.success).toBe(false)
+    })
+
+    it('rejeita IPv6 loopback [::1]', () => {
+      const result = ClippingPayloadSchema.safeParse({
+        ...basePayload,
+        webhookUrl: 'https://[::1]/webhook',
+      })
+      expect(result.success).toBe(false)
+    })
+
+    it('rejeita 0.0.0.0', () => {
+      const result = ClippingPayloadSchema.safeParse({
+        ...basePayload,
+        webhookUrl: 'https://0.0.0.0/webhook',
+      })
+      expect(result.success).toBe(false)
+    })
+  })
+})
+
+describe('FollowListingSchema - webhook URL validation', () => {
+  const baseFollowPayload = {
+    deliveryChannels: {
+      email: false,
+      telegram: false,
+      push: false,
+      webhook: true,
+    },
+    extraEmails: [],
+  }
+
+  it('aceita URL HTTPS válida', () => {
+    const result = FollowListingSchema.safeParse({
+      ...baseFollowPayload,
+      webhookUrl: 'https://example.com/webhook',
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('rejeita HTTP', () => {
+    const result = FollowListingSchema.safeParse({
+      ...baseFollowPayload,
+      webhookUrl: 'http://example.com/webhook',
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('rejeita localhost', () => {
+    const result = FollowListingSchema.safeParse({
+      ...baseFollowPayload,
+      webhookUrl: 'https://localhost/webhook',
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('rejeita metadata.google.internal', () => {
+    const result = FollowListingSchema.safeParse({
+      ...baseFollowPayload,
+      webhookUrl: 'https://metadata.google.internal/path',
+    })
+    expect(result.success).toBe(false)
+  })
+})

--- a/src/lib/clipping-validation.ts
+++ b/src/lib/clipping-validation.ts
@@ -1,6 +1,41 @@
 import { z } from 'zod'
 import { isValidCron } from '@/lib/cron-utils'
 
+function isSecureWebhookUrl(url: string): boolean {
+  if (!url) return true // empty is valid (optional)
+
+  try {
+    const parsed = new URL(url)
+
+    // Apenas HTTPS em produção
+    if (parsed.protocol !== 'https:') return false
+
+    // Bloquear hosts internos
+    const blocked = [
+      'localhost',
+      '127.0.0.1',
+      '169.254.169.254',
+      'metadata.google.internal',
+      'metadata',
+      '[::1]',
+      '0.0.0.0',
+    ]
+    const hostname = parsed.hostname.toLowerCase()
+    if (blocked.some((h) => hostname === h || hostname.endsWith(`.${h}`))) {
+      return false
+    }
+
+    // Bloquear IPs privados (10.x, 172.16-31.x, 192.168.x)
+    if (/^(10\.|172\.(1[6-9]|2\d|3[01])\.|192\.168\.)/.test(parsed.hostname)) {
+      return false
+    }
+
+    return true
+  } catch {
+    return false
+  }
+}
+
 export const RecorteSchema = z
   .object({
     id: z.string().min(1),
@@ -34,7 +69,16 @@ export const ClippingPayloadSchema = z
     }),
     active: z.boolean(),
     extraEmails: z.array(z.string().email()).max(3).default([]),
-    webhookUrl: z.string().url().optional().or(z.literal('')).default(''),
+    webhookUrl: z
+      .string()
+      .url()
+      .refine(isSecureWebhookUrl, {
+        message:
+          'URL de webhook deve ser HTTPS e apontar para host externo (IPs privados e hosts internos não são permitidos)',
+      })
+      .optional()
+      .or(z.literal(''))
+      .default(''),
     includeHistory: z.boolean().optional().default(false),
   })
   .refine(
@@ -65,7 +109,16 @@ export const FollowListingSchema = z
       webhook: z.boolean().optional().default(false),
     }),
     extraEmails: z.array(z.string().email()).optional().default([]),
-    webhookUrl: z.string().url().optional().or(z.literal('')).default(''),
+    webhookUrl: z
+      .string()
+      .url()
+      .refine(isSecureWebhookUrl, {
+        message:
+          'URL de webhook deve ser HTTPS e apontar para host externo (IPs privados e hosts internos não são permitidos)',
+      })
+      .optional()
+      .or(z.literal(''))
+      .default(''),
   })
   .refine(
     (data) =>


### PR DESCRIPTION
## Resumo
Corrige vulnerabilidade SSRF (Server-Side Request Forgery) na validação de webhook URLs que permitia ataques a endpoints internos e exfiltração de tokens.

## Problema
- Schema Zod usava apenas `z.string().url()` sem validação de segurança
- Aceitava qualquer URL válida, incluindo:
  - `http://metadata.google.internal/...` (tokens GCP)
  - `http://localhost`, `http://127.0.0.1`
  - `http://169.254.169.254` (metadata AWS/GCP)
  - IPs privados (10.x, 172.16-31.x, 192.168.x)
- Usuário autenticado poderia exfiltrar tokens da service account do Cloud Run

## Solução
- Implementada função `isSecureWebhookUrl()` que valida:
  - ✅ Apenas HTTPS permitido
  - ✅ Bloqueia hosts internos (localhost, metadata.google.internal, 169.254.169.254)
  - ✅ Bloqueia IPs privados (10.x, 172.16-31.x, 192.168.x)
  - ✅ Bloqueia IPv6 loopback ([::1])
- Aplicado em `ClippingPayloadSchema` e `FollowListingSchema`
- Adicionados testes unitários abrangentes

## Arquivos alterados
- [src/lib/clipping-validation.ts](https://github.com/destaquesgovbr/portal/blob/fix/webhook-ssrf-validation/src/lib/clipping-validation.ts): Implementação da validação
- [src/lib/clipping-validation.test.ts](https://github.com/destaquesgovbr/portal/blob/fix/webhook-ssrf-validation/src/lib/clipping-validation.test.ts): Suite de testes (novo)

## Testes
Suite de testes cobrindo:
- ✅ URLs HTTPS válidas (permitidas)
- ✅ HTTP (bloqueado)
- ✅ localhost, 127.0.0.1 (bloqueados)
- ✅ metadata.google.internal (bloqueado)
- ✅ 169.254.169.254 (bloqueado)
- ✅ IPs privados (bloqueados)
- ✅ IPv6 loopback (bloqueado)

## Critérios de Aceite
- [x] Webhook URL só aceita HTTPS
- [x] IPs privados e hosts internos são rejeitados
- [x] Validação aplicada em ambos os schemas
- [x] Testes unitários cobrindo URLs bloqueadas e permitidas

Closes #206