### PR TITLE
fix: corrige bugs nos filtros de data (#220 #221)

### DIFF
--- a/src/app/(public)/busca/actions.ts
+++ b/src/app/(public)/busca/actions.ts
@@ -272,11 +272,11 @@ export async function queryArticles(
   const filter_by: string[] = []
 
   if (startDate) {
-    filter_by.push(`published_at:>${Math.floor(startDate / 1000)}`)
+    filter_by.push(`published_at:>=${Math.floor(startDate / 1000)}`)
   }
 
   if (endDate) {
-    filter_by.push(`published_at:<${Math.floor(endDate / 1000 + 60 * 60 * 3)}`)
+    filter_by.push(`published_at:<${Math.floor(endDate / 1000) + 86400}`)
   }
 
   if (agencies && agencies.length > 0) {

--- a/src/app/(public)/orgaos/[agencyKey]/actions.ts
+++ b/src/app/(public)/orgaos/[agencyKey]/actions.ts
@@ -26,11 +26,11 @@ export async function getArticles(
   const filter_by: string[] = [`agency:=${agency}`]
 
   if (startDate) {
-    filter_by.push(`published_at:>${Math.floor(startDate / 1000)}`)
+    filter_by.push(`published_at:>=${Math.floor(startDate / 1000)}`)
   }
 
   if (endDate) {
-    filter_by.push(`published_at:<${Math.floor(endDate / 1000 + 60 * 60 * 3)}`)
+    filter_by.push(`published_at:<${Math.floor(endDate / 1000) + 86400}`)
   }
 
   if (themes && themes.length > 0) {

--- a/src/app/(public)/temas/[themeLabel]/actions.ts
+++ b/src/app/(public)/temas/[themeLabel]/actions.ts
@@ -26,11 +26,11 @@ export async function getArticles(
   const filter_by: string[] = [`theme_1_level_1_label:=${theme_1_level_1}`]
 
   if (startDate) {
-    filter_by.push(`published_at:>${Math.floor(startDate / 1000)}`)
+    filter_by.push(`published_at:>=${Math.floor(startDate / 1000)}`)
   }
 
   if (endDate) {
-    filter_by.push(`published_at:<${Math.floor(endDate / 1000 + 60 * 60 * 3)}`)
+    filter_by.push(`published_at:<${Math.floor(endDate / 1000) + 86400}`)
   }
 
   if (agencies && agencies.length > 0) {

--- a/src/components/articles/ArticleFilters.tsx
+++ b/src/components/articles/ArticleFilters.tsx
@@ -29,9 +29,15 @@ function DateFilter({ label, value, onChange }: DateFilterProps) {
         <Input
           id={inputId}
           type="date"
-          onChange={(e) => onChange(new Date(e.target.value))}
+          onChange={(e) =>
+            onChange(e.target.value ? new Date(e.target.value) : undefined)
+          }
           className={value ? 'pr-9' : undefined}
-          value={value ? value.toISOString().split('T')[0] : ''}
+          value={
+            value && !isNaN(value.getTime())
+              ? value.toISOString().split('T')[0]
+              : ''
+          }
         />
         {value && (
           <Button


### PR DESCRIPTION
## Resumo

Este PR corrige dois bugs relacionados aos filtros de data no portal:

- **Issue #220**: Ao filtrar notícias com a mesma data de início e fim, nenhum resultado era retornado
- **Issue #221**: Ao limpar campos de data ou acessar URLs com query strings inválidas, o portal apresentava erro

## Mudanças Implementadas

### Issue #220: Filtro de data não retorna resultados

**Problema**: Janela de apenas 3 horas + operador exclusivo `>` resultava em nenhum resultado quando mesma data era selecionada.

**Solução**:
- Mudou operador de `>` para `>=` no `startDate` (inclusivo)
- Mudou janela de 3h (`+ 60*60*3`) para 24h (`+ 86400`)

**Arquivos modificados** (3):
- `src/app/(public)/temas/[themeLabel]/actions.ts`
- `src/app/(public)/orgaos/[agencyKey]/actions.ts`
- `src/app/(public)/busca/actions.ts`

### Issue #221: Erro ao limpar campos de data

**Problema**: `new Date("")` criava `Invalid Date`, que é truthy mas causa erro ao chamar `.toISOString()`.

**Solução** (defesa em profundidade):
- Linha 32: Valida `e.target.value` antes de criar `Date`
- Linha 34: Valida `Date` com `isNaN(value.getTime())` antes de chamar `toISOString()`

**Arquivo modificado** (1):
- `src/components/articles/ArticleFilters.tsx`

## Testes Realizados

### Testes Automatizados

Todos os 5 testes automatizados passaram:

| Teste | Resultado |
|-------|-----------|
| Página /temas carrega | ✅ HTTP 200 |
| Query string vazia (`?dataInicio=`) | ✅ HTTP 200 (antes: erro 500) |
| Valor inválido (`?dataInicio=invalid`) | ✅ HTTP 200 (antes: erro 500) |
| Página /orgaos (regressão) | ✅ HTTP 200 |
| Página /busca com datas vazias | ✅ HTTP 200 (antes: erro 500) |

**Ambiente de teste**:
- Container Docker com imagem buildada
- Typesense local em 172.17.0.1:8108

### Cenários Validados

**Issue #220**:
- ✅ Mesma data em ambos os campos retorna resultados
- ✅ Datas diferentes continuam funcionando (sem regressão)

**Issue #221**:
- ✅ URL com `?dataInicio=` não gera erro
- ✅ URL com `?dataInicio=invalid` não gera erro
- ✅ Apagar campo manualmente não gera erro
- ✅ Botão X (limpar) continua funcionando

## Documentação

- `TESTE_ISSUES_220_221.md` — Roteiro completo de testes manuais
- `RESULTADO_TESTES.md` — Resultado dos testes automatizados
- `PLANO_FIX_ISSUE_220.md` — Análise técnica detalhada

## Checklist

- [x] Código segue padrões do projeto
- [x] Testes automatizados executados e passaram
- [x] Sem regressões detectadas
- [x] Documentação atualizada
- [x] Commit message segue convenção

## Issues Relacionadas

Closes #220
Closes #221