### PR TITLE
fix: torna extra emails opcionais no wizard de clipping

### DIFF
--- a/e2e/clipping-manual.authed.spec.ts
+++ b/e2e/clipping-manual.authed.spec.ts
@@ -85,4 +85,79 @@ test.describe('Clipping — Manual Creation & Edit', () => {
         .or(page.locator('.border.rounded-lg').first()),
     ).toBeVisible({ timeout: 10000 })
   })
+
+  test('botão Confirmar fica habilitado com apenas Email marcado, sem emails extras', async ({
+    page,
+  }) => {
+    await page.goto('/minha-conta/clipping/novo')
+    await page.waitForLoadState('networkidle')
+
+    // Modo manual
+    await page.click('text=Configuração manual')
+
+    // Preenche nome e adiciona keyword
+    await page.fill('#clipping-name', 'E2E Email Only')
+
+    const recorteTitle = page.locator('input[placeholder*="Educação Superior"]')
+    if (await recorteTitle.isVisible()) {
+      await recorteTitle.fill('Recorte Email Only')
+    }
+
+    const keywordInput = page.locator('input[placeholder*="palavra-chave"]')
+    if (await keywordInput.isVisible()) {
+      await keywordInput.fill('e2e email only')
+      await keywordInput.press('Enter')
+    }
+
+    // Avança: Recortes → Agendamento → Canais
+    await page.click('button:has-text("ximo")')
+    await page.waitForTimeout(500)
+    await page.click('button:has-text("ximo")')
+    await page.waitForTimeout(500)
+
+    // Marca apenas o canal Email (sem adicionar nenhum email extra)
+    await page.locator('label:has-text("Email")').click()
+
+    // Confirmar deve estar habilitado mesmo sem emails extras
+    const confirmBtn = page.locator('button:has-text("Confirmar")')
+    await expect(confirmBtn).toBeEnabled({ timeout: 5000 })
+
+    // Cria o clipping
+    await confirmBtn.click()
+
+    // Redireciona para a listagem
+    await expect(page).toHaveURL(/minha-conta\/clipping/, { timeout: 10000 })
+  })
+
+  test('botão Confirmar fica desabilitado quando nenhum canal está selecionado', async ({
+    page,
+  }) => {
+    await page.goto('/minha-conta/clipping/novo')
+    await page.waitForLoadState('networkidle')
+
+    // Modo manual
+    await page.click('text=Configuração manual')
+
+    await page.fill('#clipping-name', 'E2E No Channel')
+
+    const recorteTitle = page.locator('input[placeholder*="Educação Superior"]')
+    if (await recorteTitle.isVisible()) {
+      await recorteTitle.fill('Recorte No Channel')
+    }
+
+    const keywordInput = page.locator('input[placeholder*="palavra-chave"]')
+    if (await keywordInput.isVisible()) {
+      await keywordInput.fill('e2e no channel')
+      await keywordInput.press('Enter')
+    }
+
+    // Avança até Canais sem marcar nenhum canal
+    await page.click('button:has-text("ximo")')
+    await page.waitForTimeout(500)
+    await page.click('button:has-text("ximo")')
+    await page.waitForTimeout(500)
+
+    const confirmBtn = page.locator('button:has-text("Confirmar")')
+    await expect(confirmBtn).toBeDisabled({ timeout: 5000 })
+  })
 })

--- a/src/components/clipping/ClippingWizard.tsx
+++ b/src/components/clipping/ClippingWizard.tsx
@@ -176,18 +176,9 @@ export function ClippingWizard({
         deliveryChannels.push ||
         deliveryChannels.webhook
       if (!anyEnabled) return 'Selecione ao menos um canal de entrega.'
-      if (deliveryChannels.email && extraEmails.length === 0)
-        return 'Adicione ao menos um email para receber o clipping.'
     }
     return null
-  }, [
-    currentStepLabel,
-    name,
-    recortes,
-    deliveryChannels,
-    estimatedTotal,
-    extraEmails,
-  ])
+  }, [currentStepLabel, name, recortes, deliveryChannels, estimatedTotal])
 
   const handleNext = useCallback(() => {
     const err = validateStep()
@@ -219,19 +210,10 @@ export function ClippingWizard({
       deliveryChannels.push ||
       deliveryChannels.webhook
     if (!anyChannel) return 'Selecione ao menos um canal de entrega.'
-    if (deliveryChannels.email && extraEmails.length === 0)
-      return 'Adicione ao menos um email para receber o clipping.'
     if (deliveryChannels.webhook && !webhookUrl)
       return 'URL do webhook é obrigatória quando webhook está ativo.'
     return null
-  }, [
-    name,
-    recortes,
-    deliveryChannels,
-    estimatedTotal,
-    extraEmails,
-    webhookUrl,
-  ])
+  }, [name, recortes, deliveryChannels, estimatedTotal, webhookUrl])
 
   const ensurePushSubscription = useCallback(async () => {
     if (!('Notification' in window) || !('serviceWorker' in navigator)) {

--- a/src/components/clipping/ExtraEmailsInput.tsx
+++ b/src/components/clipping/ExtraEmailsInput.tsx
@@ -66,8 +66,8 @@ export function ExtraEmailsInput({ emails, onChange }: Props) {
   return (
     <div className="space-y-2 pl-7">
       <p className="text-xs text-muted-foreground">
-        Adicione até {MAX_EXTRA_EMAILS} emails extras para receber cópia do
-        clipping.
+        Opcional: adicione até {MAX_EXTRA_EMAILS} emails extras para receber
+        cópia do clipping (além do seu email cadastrado).
       </p>
       <div className="flex gap-2">
         <Input

--- a/src/components/clipping/__tests__/ClippingWizard.test.tsx
+++ b/src/components/clipping/__tests__/ClippingWizard.test.tsx
@@ -225,10 +225,8 @@ describe('ClippingWizard (3-step flow, prompt step hidden)', () => {
     await user.click(screen.getByRole('button', { name: /próximo/i }))
     await user.click(screen.getByRole('button', { name: /próximo/i }))
 
-    // Enable email channel
+    // Enable email channel (sem emails extras — basta o email do usuário logado)
     await user.click(screen.getByTestId('channel-email'))
-    // Add an email (required by new validation)
-    await user.click(screen.getByTestId('add-extra-email'))
 
     await user.click(screen.getByRole('button', { name: /confirmar/i }))
 
@@ -261,8 +259,6 @@ describe('ClippingWizard (3-step flow, prompt step hidden)', () => {
     await user.click(screen.getByRole('button', { name: /próximo/i }))
 
     await user.click(screen.getByTestId('channel-email'))
-    // Add an email (required by new validation)
-    await user.click(screen.getByTestId('add-extra-email'))
     await user.click(screen.getByRole('button', { name: /confirmar/i }))
 
     await waitFor(() => {
@@ -270,6 +266,54 @@ describe('ClippingWizard (3-step flow, prompt step hidden)', () => {
     })
 
     resolveSubmit()
+  })
+
+  it('permite confirmar com apenas o canal Email e sem emails extras', async () => {
+    const handleSubmit = vi.fn().mockResolvedValue(undefined)
+    const { user } = render(
+      <ClippingWizard onSubmit={handleSubmit} themes={[]} agencies={[]} />,
+    )
+
+    await fillRecorteAndName(user)
+
+    // Avança até Canais
+    await user.click(screen.getByRole('button', { name: /próximo/i }))
+    await user.click(screen.getByRole('button', { name: /próximo/i }))
+
+    // Marca apenas Email — sem adicionar emails extras
+    await user.click(screen.getByTestId('channel-email'))
+
+    const confirmBtn = screen.getByRole('button', { name: /confirmar/i })
+    expect(confirmBtn).toBeEnabled()
+
+    await user.click(confirmBtn)
+
+    await waitFor(() => {
+      expect(handleSubmit).toHaveBeenCalledWith(
+        expect.objectContaining({
+          deliveryChannels: expect.objectContaining({ email: true }),
+          extraEmails: [],
+        }),
+      )
+    })
+  })
+
+  it('mantém Confirmar desabilitado quando nenhum canal está selecionado', async () => {
+    const { user } = render(
+      <ClippingWizard onSubmit={defaultOnSubmit} themes={[]} agencies={[]} />,
+    )
+
+    await fillRecorteAndName(user)
+
+    // Avança até Canais sem marcar nenhum canal
+    await user.click(screen.getByRole('button', { name: /próximo/i }))
+    await user.click(screen.getByRole('button', { name: /próximo/i }))
+
+    expect(screen.getByText(/3\/3/i)).toBeInTheDocument()
+    expect(screen.getByTestId('channel-selector')).toBeInTheDocument()
+
+    const confirmBtn = screen.getByRole('button', { name: /confirmar/i })
+    expect(confirmBtn).toBeDisabled()
   })
 
   it('includes webhookUrl in submit payload', async () => {


### PR DESCRIPTION
## Resumo

Corrige UX bug no `ClippingWizard` onde o botão Confirmar ficava desabilitado no último passo (Canais) quando o usuário marcava o canal Email mas não adicionava nenhum email extra. O usuário logado já é o destinatário primário (via `session.user.email`); o campo `extraEmails` é literalmente "Adicione até 3 emails extras para receber cópia do clipping" — opcional por design.

## Mudanças

- Remove a regra `deliveryChannels.email && extraEmails.length === 0` de `validateStep` e `validateAll` em `ClippingWizard.tsx`. Mantém apenas a regra "pelo menos um canal de entrega".
- Ajusta o copy do `ExtraEmailsInput` para deixar explícito que o campo é opcional ("Opcional: adicione até 3 emails extras... além do seu email cadastrado.").
- Atualiza testes unitários existentes em `ClippingWizard.test.tsx` (removendo o `add-extra-email` que tinha sido marcado como "required by new validation") e adiciona dois casos novos:
  - Email-only sem extras → Confirmar habilitado e submit é chamado com `extraEmails: []`.
  - Nenhum canal selecionado → Confirmar desabilitado.
- Adiciona os mesmos casos E2E em `e2e/clipping-manual.authed.spec.ts`.

A validação de **formato** de email extra continua funcionando — ela já era responsabilidade do componente `ExtraEmailsInput` (regex em `isValidEmail`), só não é mais obrigatório adicionar pelo menos um.

## Test plan

- [x] `pnpm exec biome check` em todos os arquivos modificados → limpo
- [x] `pnpm exec vitest run src/components/clipping/__tests__/ClippingWizard.test.tsx` → 8/8 verdes
- [x] `pnpm exec vitest run src/components/clipping/` → 56/56 verdes
- [ ] Playwright E2E rodando no CI (staging) — não foi executado localmente
- [ ] Validar manualmente em staging: criar clipping novo com apenas o canal Email marcado, sem adicionar emails extras