### PR TITLE
fix: separa GROWTHBOOK_CLIENT_KEY de staging vs produção

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -50,7 +50,7 @@ jobs:
             --build-arg NEXT_PUBLIC_UMAMI_WEBSITE_ID="${{ secrets.UMAMI_WEBSITE_ID }}" \
             --build-arg NEXT_PUBLIC_UMAMI_SCRIPT_URL="${{ secrets.UMAMI_SCRIPT_URL }}" \
             --build-arg NEXT_PUBLIC_GROWTHBOOK_API_HOST="${{ secrets.NEXT_PUBLIC_GROWTHBOOK_API_HOST }}" \
-            --build-arg NEXT_PUBLIC_GROWTHBOOK_CLIENT_KEY="${{ secrets.NEXT_PUBLIC_GROWTHBOOK_CLIENT_KEY }}" \
+            --build-arg NEXT_PUBLIC_GROWTHBOOK_CLIENT_KEY="${{ secrets.NEXT_PUBLIC_GROWTHBOOK_CLIENT_KEY_STAGING }}" \
             --build-arg NEXT_PUBLIC_GRAPHQL_URL="https://destaquesgovbr-graphql-api-klvx64dufq-rj.a.run.app/graphql" \
             -t ${{ env.REGISTRY }}/${{ env.PROJECT_ID }}/${{ env.REPOSITORY }}/portal:staging-${{ github.sha }} \
             -t ${{ env.REGISTRY }}/${{ env.PROJECT_ID }}/${{ env.REPOSITORY }}/portal:staging-latest \


### PR DESCRIPTION
## Problema

Durante validação da migração GraphQL R1 (PR #226 acabou de mergear), notamos que mesmo com o build-arg `NEXT_PUBLIC_GRAPHQL_URL` agora correto, o portal staging **continua** caindo no path REST. Investigando, achei que o `deploy-staging.yml:53` usa o mesmo secret de prod:

\`\`\`yaml
--build-arg NEXT_PUBLIC_GROWTHBOOK_CLIENT_KEY="${{ secrets.NEXT_PUBLIC_GROWTHBOOK_CLIENT_KEY }}"
\`\`\`

Esse secret contém a key `sdk-VpkL3YnUNw97PvQ5`, vinculada ao environment `production` no GrowthBook. Resultado: o portal staging foi sempre buildado com a key de prod, o SDK no browser conectava no env `production`, e flags ativadas apenas em `staging` nunca eram lidas como true.

## Fix

- Criei novo secret `NEXT_PUBLIC_GROWTHBOOK_CLIENT_KEY_STAGING` com `sdk-e0WQYWQ33eTnIQmN` (bound ao env=staging via SDK Connection no GrowthBook self-hosted)
- `deploy-staging.yml` passa a usar esse novo secret
- `deploy-production.yml` continua usando `NEXT_PUBLIC_GROWTHBOOK_CLIENT_KEY` (prod, inalterado)

## Test plan

- [ ] CI build do deploy-staging.yml passa
- [ ] Nova revisão do `destaquesgovbr-portal-staging` deploya
- [ ] Browser do portal staging, com hard reload, faz POST em `/graphql` no `destaquesgovbr-graphql-api` ao criar/editar clipping (confirmando que a flag `graphql.clippings` resolve true)