### PR TITLE
fix: useFeatureFlag não dispara erro quando GrowthBook ainda inicializando

### DIFF
--- a/e2e/clipping-manual.authed.spec.ts
+++ b/e2e/clipping-manual.authed.spec.ts
@@ -3,6 +3,38 @@ import { expect, test } from '@playwright/test'
 const createdClippingId: string | null = null
 
 test.describe('Clipping — Manual Creation & Edit', () => {
+  test('wizard novo não dispara pageerror (regressão GrowthBook race)', async ({
+    page,
+  }) => {
+    // Regressão: páginas autenticadas que usam `useClippingService()` →
+    // `useFeatureFlag()` explodiam com "Missing or invalid GrowthBookProvider"
+    // durante a janela entre o initial render e o `setGrowthbook(gb)` do
+    // `useEffect` async no `GrowthBookProvider` customizado.
+    //
+    // Esse teste capta qualquer `pageerror` (erro não tratado no
+    // navegador) que ocorra na navegação do wizard.
+    const pageErrors: Error[] = []
+    page.on('pageerror', (err) => {
+      pageErrors.push(err)
+    })
+
+    await page.goto('/minha-conta/clipping/novo')
+    await page.waitForLoadState('networkidle')
+
+    // Aguarda o conteúdo principal do wizard renderizar (qualquer um dos
+    // dois modos: assistente IA ou configuração manual).
+    await expect(
+      page.locator('text=Assistente IA').or(page.locator('#clipping-name')),
+    ).toBeVisible({ timeout: 10000 })
+
+    // Garante que nenhum erro do tipo "Missing or invalid GrowthBookProvider"
+    // (nem nenhum outro) escapou para o error boundary do Next.js.
+    expect(
+      pageErrors.map((e) => e.message),
+      `pageerror events captured: ${pageErrors.map((e) => e.message).join(', ')}`,
+    ).toEqual([])
+  })
+
   test.afterAll(async ({ request }) => {
     // Cleanup: delete the test clipping if created
     if (createdClippingId) {

--- a/src/lib/__tests__/feature-flags.test.ts
+++ b/src/lib/__tests__/feature-flags.test.ts
@@ -7,17 +7,15 @@
  *   - Constante `GRAPHQL_FLAGS`: chaves planejadas para B2-B5.
  */
 
+import {
+  type GrowthBook,
+  GrowthBookContext,
+} from '@growthbook/growthbook-react'
 import { renderHook } from '@testing-library/react'
+import { createElement, type ReactNode } from 'react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-// Mocks devem ser declarados ANTES dos imports do módulo testado.
-const mockUseFeatureValue = vi.fn()
 const mockIsGrowthBookConfigured = vi.fn(() => true)
-
-vi.mock('@growthbook/growthbook-react', () => ({
-  useFeatureValue: (key: string, defaultValue: unknown) =>
-    mockUseFeatureValue(key, defaultValue),
-}))
 
 vi.mock('@/ab-testing/growthbook', () => ({
   isGrowthBookConfigured: () => mockIsGrowthBookConfigured(),
@@ -25,57 +23,144 @@ vi.mock('@/ab-testing/growthbook', () => ({
 
 import { GRAPHQL_FLAGS, getFeatureFlag, useFeatureFlag } from '../feature-flags'
 
+/**
+ * Wrapper que injeta um `growthbook` no `GrowthBookContext` sem precisar
+ * carregar features de rede. Simula o estado "provider pronto".
+ */
+function withGrowthBook(gb: Partial<GrowthBook>) {
+  return function GrowthBookContextProvider({
+    children,
+  }: {
+    children: ReactNode
+  }) {
+    return createElement(
+      GrowthBookContext.Provider,
+      { value: { growthbook: gb as GrowthBook } },
+      children,
+    )
+  }
+}
+
 describe('useFeatureFlag', () => {
   beforeEach(() => {
-    mockUseFeatureValue.mockReset()
     mockIsGrowthBookConfigured.mockReset()
     mockIsGrowthBookConfigured.mockReturnValue(true)
   })
 
   it('test_useFeatureFlag_returns_true_when_growthbook_returns_true', () => {
-    mockUseFeatureValue.mockReturnValue(true)
-    const { result } = renderHook(() =>
-      useFeatureFlag('graphql.clippings', false),
+    const wrapper = withGrowthBook({
+      getFeatureValue: vi.fn().mockReturnValue(true),
+    })
+    const { result } = renderHook(
+      () => useFeatureFlag('graphql.clippings', false),
+      { wrapper },
     )
     expect(result.current).toBe(true)
   })
 
   it('test_useFeatureFlag_returns_false_when_growthbook_returns_false', () => {
-    mockUseFeatureValue.mockReturnValue(false)
-    const { result } = renderHook(() =>
-      useFeatureFlag('graphql.clippings', true),
+    const wrapper = withGrowthBook({
+      getFeatureValue: vi.fn().mockReturnValue(false),
+    })
+    const { result } = renderHook(
+      () => useFeatureFlag('graphql.clippings', true),
+      { wrapper },
     )
     expect(result.current).toBe(false)
   })
 
   it('test_useFeatureFlag_falls_back_to_default_when_growthbook_unavailable', () => {
     mockIsGrowthBookConfigured.mockReturnValue(false)
-    mockUseFeatureValue.mockReturnValue(true) // simula valor "verdadeiro" do mock
-    const { result } = renderHook(() =>
-      useFeatureFlag('graphql.clippings', false),
+    const wrapper = withGrowthBook({
+      getFeatureValue: vi.fn().mockReturnValue(true),
+    })
+    const { result } = renderHook(
+      () => useFeatureFlag('graphql.clippings', false),
+      { wrapper },
     )
     // GrowthBook não está configurado: deve retornar o default explícito (false)
     expect(result.current).toBe(false)
   })
 
   it('test_useFeatureFlag_falls_back_to_default_when_value_is_not_boolean', () => {
-    mockUseFeatureValue.mockReturnValue(undefined as unknown as boolean)
-    const { result } = renderHook(() =>
-      useFeatureFlag('graphql.unknown', false),
+    const wrapper = withGrowthBook({
+      getFeatureValue: vi.fn().mockReturnValue(undefined),
+    })
+    const { result } = renderHook(
+      () => useFeatureFlag('graphql.unknown', false),
+      { wrapper },
     )
     expect(result.current).toBe(false)
   })
 
   it('test_useFeatureFlag_falls_back_to_false_for_graphql_flags_by_default', () => {
     // Simula chave não definida no GrowthBook (retorna o defaultValue passado).
-    mockUseFeatureValue.mockImplementation(
-      (_key: string, defaultValue: unknown) => defaultValue,
-    )
+    const wrapper = withGrowthBook({
+      getFeatureValue: vi
+        .fn()
+        .mockImplementation(
+          (_key: string, defaultValue: unknown) => defaultValue,
+        ),
+    })
 
     for (const flag of Object.values(GRAPHQL_FLAGS)) {
-      const { result } = renderHook(() => useFeatureFlag(flag, false))
+      const { result } = renderHook(() => useFeatureFlag(flag, false), {
+        wrapper,
+      })
       expect(result.current).toBe(false)
     }
+  })
+
+  // --- Regressão: race condition do provider durante init ---
+  //
+  // Antes do fix, `useFeatureFlag` chamava `useFeatureValue` do
+  // `@growthbook/growthbook-react`, que THROWA "Missing or invalid
+  // GrowthBookProvider" quando não há provider ancestor — exatamente o que
+  // acontecia durante o intervalo entre o initial render do
+  // `GrowthBookProvider` customizado e o `setGrowthbook(gb)` no `useEffect`.
+  // Esses testes garantem que o hook NUNCA propaga essa exceção.
+
+  it('test_useFeatureFlag_no_provider_does_not_throw_and_returns_default', () => {
+    // Renderiza SEM nenhum GrowthBookContext.Provider ancestor — replica o
+    // estado em que o portal estava renderizando children sem `<GBProvider>`
+    // antes da instância carregar.
+    expect(() => {
+      renderHook(() => useFeatureFlag('graphql.clippings', false))
+    }).not.toThrow()
+
+    const { result } = renderHook(() =>
+      useFeatureFlag('graphql.clippings', false),
+    )
+    expect(result.current).toBe(false)
+  })
+
+  it('test_useFeatureFlag_no_provider_returns_default_true', () => {
+    // Mesma coisa que acima, mas com defaultValue=true — garante que o
+    // fallback respeita o default passado, não retorna sempre `false`.
+    const { result } = renderHook(() =>
+      useFeatureFlag('graphql.clippings', true),
+    )
+    expect(result.current).toBe(true)
+  })
+
+  it('test_useFeatureFlag_provider_present_but_growthbook_initializing_returns_default', () => {
+    // Simula o estado intermédio: existe um Provider, mas a instância
+    // ainda é `undefined` (GrowthBook ainda não inicializou). O type do
+    // `GrowthBookContextValue` no SDK marca `growthbook` como obrigatório,
+    // mas em runtime esse é exactamente o cenário do bug — por isso o cast.
+    function NotReadyProvider({ children }: { children: ReactNode }) {
+      return createElement(
+        GrowthBookContext.Provider,
+        // biome-ignore lint/suspicious/noExplicitAny: reproduz cenário runtime onde growthbook é undefined
+        { value: {} as any },
+        children,
+      )
+    }
+    const { result } = renderHook(
+      () => useFeatureFlag('graphql.clippings', false),
+      { wrapper: NotReadyProvider },
+    )
+    expect(result.current).toBe(false)
   })
 })
 

--- a/src/lib/feature-flags.ts
+++ b/src/lib/feature-flags.ts
@@ -12,8 +12,11 @@
 
 'use client'
 
-import type { GrowthBook } from '@growthbook/growthbook-react'
-import { useFeatureValue } from '@growthbook/growthbook-react'
+import {
+  type GrowthBook,
+  GrowthBookContext,
+} from '@growthbook/growthbook-react'
+import { useContext } from 'react'
 import { isGrowthBookConfigured } from '@/ab-testing/growthbook'
 
 /**
@@ -40,24 +43,45 @@ export type GraphQLFlagKey = (typeof GRAPHQL_FLAGS)[keyof typeof GRAPHQL_FLAGS]
  *   - Se GrowthBook não estiver configurado **ou** falhar, retorna `defaultValue`.
  *   - Wrapper estável para uso na migração GraphQL (B2-B5).
  *
+ * Implementação: lê o `growthbook` directamente do `GrowthBookContext`
+ * via `useContext` (em vez de `useFeatureValue`, que THROWA "Missing or
+ * invalid GrowthBookProvider" quando consumido fora do `<GBProvider>`).
+ *
+ * O `GrowthBookProvider` custom do portal renderiza children sem o
+ * `<GBProvider>` ancestor durante a janela entre o initial render e o
+ * `setGrowthbook(gb)` do `useEffect` async. Usar `useContext` evita
+ * propagar essa exceção e fazer páginas autenticadas (clipping wizard,
+ * marketplace, …) explodirem com "Application error".
+ *
+ * Trade-off conhecido: a leitura via `gb.getFeatureValue()` directa não
+ * subscreve a re-renders quando o GrowthBook recebe novas features via
+ * streaming. Para `GRAPHQL_FLAGS` (toggles operados manualmente, com
+ * reload aceitável) isso é aceitável; para experimentos A/B "ao vivo",
+ * usar os hooks específicos do `src/ab-testing/`.
+ *
  * @example
  *   const useGraphQL = useFeatureFlag('graphql.clippings', false)
  *   if (useGraphQL) { ... } else { ... fallback REST ... }
  */
 export function useFeatureFlag(key: string, defaultValue: boolean): boolean {
-  // Chama o hook do GrowthBook incondicionalmente (regras de hooks)
-  const value = useFeatureValue<boolean>(key, defaultValue)
+  // Lê o GrowthBook do contexto sem throwar quando o provider está ausente
+  // ou ainda inicializando (estado intermediário do `GrowthBookProvider`).
+  const { growthbook } = useContext(GrowthBookContext)
 
-  if (!isGrowthBookConfigured()) {
+  if (!growthbook || !isGrowthBookConfigured()) {
     return defaultValue
   }
 
-  // GrowthBook pode retornar undefined/null se a flag não existir
-  if (typeof value !== 'boolean') {
+  try {
+    const value = growthbook.getFeatureValue<boolean>(key, defaultValue)
+    if (typeof value !== 'boolean') {
+      return defaultValue
+    }
+    return value
+  } catch {
+    // Falha graciosa: nunca quebra o portal por causa de uma flag.
     return defaultValue
   }
-
-  return value
 }
 
 /**


### PR DESCRIPTION
## Bug

Páginas autenticadas (`/minha-conta/clipping/novo`, marketplace, agente, etc.) que usam `useClippingService()` / `useMarketplaceService()` / `useFeatureFlag()` explodiam com **"Application error: a client-side exception has occurred"** durante o initial render.

Reproduzido via E2E:

```
PLAYWRIGHT_BASE_URL=https://destaquesgovbr-portal-staging-klvx64dufq-rj.a.run.app
→ /minha-conta/clipping/novo
→ console: pageerror "Missing or invalid GrowthBookProvider"
```

## Causa raiz

`useFeatureFlag` chamava `useFeatureValue` do `@growthbook/growthbook-react`, que internamente faz `useGrowthBook()`. Esse hook **THROWA** `"Missing or invalid GrowthBookProvider"` quando não há `<GBProvider>` ancestor:

```js
// node_modules/@growthbook/growthbook-react/dist/esm/index.js:68
function useGrowthBook() {
  const { growthbook } = React.useContext(GrowthBookContext);
  if (!growthbook) {
    throw new Error("Missing or invalid GrowthBookProvider");
  }
  return growthbook;
}
```

O `GrowthBookProvider` customizado em `src/ab-testing/GrowthBookProvider.tsx` renderiza `children` SEM o `<GBProvider>` ancestor durante a janela entre:

1. Initial render (antes do `useEffect` rodar)
2. `gb.init()` async terminar e fazer `setGrowthbook(gb)`

Durante essa janela, qualquer `useFeatureFlag` no subtree fazia o React error boundary do Next.js exibir a "Application error".

## Fix

Substituí `useFeatureValue` por leitura direta do `GrowthBookContext` via `useContext`, que **nunca throwa** — apenas retorna o valor default do contexto (`{}`) quando não há provider. Quando `growthbook` é `undefined` (sem provider OU init em andamento), o hook devolve o `defaultValue` passado pelo caller.

### Por que essa abordagem (Opção A do plano)

- Menos código, contido em `feature-flags.ts`
- Não muda a estrutura de Providers (sem risco em outros consumidores)
- O `useClippingService` / `useMarketplaceService` / `AgentRecorteGenerator` continuam usando a mesma assinatura, fix transparente

### Trade-off conhecido

`gb.getFeatureValue()` não força re-render quando a flag muda via streaming. Para os `GRAPHQL_FLAGS` (toggles operados manualmente com reload aceitável) isso é OK. Para experimentos A/B "ao vivo" há os hooks específicos em `src/ab-testing/` (que continuam usando o `<GBProvider>` normal).

## Test plan

- [x] **TDD strict**: testes escritos primeiro, validados a falhar antes da implementação (3 testes de regressão em `src/lib/__tests__/feature-flags.test.ts`)
- [x] `pnpm exec vitest run src/lib/__tests__/feature-flags.test.ts` → 15/15 verdes
- [x] `pnpm exec vitest run` → 529/529 verdes (sem regressões)
- [x] `pnpm lint` → mesma contagem que baseline (1 erro + 16 warnings pré-existentes)
- [x] `pnpm exec tsc --noEmit` → sem novos erros nos arquivos tocados
- [ ] Smoke remoto via Playwright (`e2e/clipping-manual.authed.spec.ts` → "wizard novo não dispara pageerror") — só passa após este PR ser deployado em staging

## Arquivos tocados

- `src/lib/feature-flags.ts` — substitui `useFeatureValue` por `useContext(GrowthBookContext)`
- `src/lib/__tests__/feature-flags.test.ts` — reescreve mocks para usar `GrowthBookContext.Provider` real + 3 testes de regressão (sem provider, sem provider com default true, provider sem growthbook)
- `e2e/clipping-manual.authed.spec.ts` — novo teste de regressão que falha se `pageerror` for emitido em `/minha-conta/clipping/novo`