### PR TITLE
fix: corrige config E2E (storageState hardcoded + projects sem testIgnore)

### DIFF
--- a/e2e/clipping-edit.authed.spec.ts
+++ b/e2e/clipping-edit.authed.spec.ts
@@ -1,13 +1,15 @@
 import { expect, test } from '@playwright/test'
 
-test.use({ storageState: 'e2e/.auth/user.json' })
+const AUTH_STATE_FILE = process.env.PLAYWRIGHT_BASE_URL
+  ? 'e2e/.auth/staging.json'
+  : 'e2e/.auth/user.json'
 
 test.describe('Clipping — Edit Flow', () => {
   let editUrl: string | null = null
 
   test.beforeAll(async ({ browser }) => {
     const context = await browser.newContext({
-      storageState: 'e2e/.auth/user.json',
+      storageState: AUTH_STATE_FILE,
     })
     const page = await context.newPage()
     await page.goto('/minha-conta/clipping')

--- a/e2e/clipping-manual.authed.spec.ts
+++ b/e2e/clipping-manual.authed.spec.ts
@@ -1,10 +1,11 @@
 import { expect, test } from '@playwright/test'
 
-const createdClippingId: string | null = null
+let createdClippingId: string | null = null
 
 test.describe('Clipping — Manual Creation & Edit', () => {
   test.afterAll(async ({ request }) => {
     // Cleanup: delete the test clipping if created
+    // TODO: portar para GraphQL no §9 R1 (RUNBOOK-R1.md) — endpoint REST será removido
     if (createdClippingId) {
       await request.delete(`/api/clipping/${createdClippingId}`)
     }
@@ -72,6 +73,12 @@ test.describe('Clipping — Manual Creation & Edit', () => {
 
     // Should redirect to listing
     await expect(page).toHaveURL(/minha-conta\/clipping/, { timeout: 10000 })
+
+    // Captura o ID do clipping criado para cleanup no afterAll
+    const match = page.url().match(/\/minha-conta\/clipping\/([^/?#]+)/)
+    if (match?.[1] && match[1] !== 'novo') {
+      createdClippingId = match[1]
+    }
   })
 
   test('meus clippings page shows created clippings', async ({ page }) => {

--- a/e2e/listing-detail.authed.spec.ts
+++ b/e2e/listing-detail.authed.spec.ts
@@ -1,6 +1,8 @@
 import { expect, test } from '@playwright/test'
 
-test.use({ storageState: 'e2e/.auth/user.json' })
+const AUTH_STATE_FILE = process.env.PLAYWRIGHT_BASE_URL
+  ? 'e2e/.auth/staging.json'
+  : 'e2e/.auth/user.json'
 
 test.describe('Listing Detail Page', () => {
   let listingUrl: string | null = null
@@ -8,7 +10,7 @@ test.describe('Listing Detail Page', () => {
   test.beforeAll(async ({ browser }) => {
     // Find a listing URL from the marketplace page
     const context = await browser.newContext({
-      storageState: 'e2e/.auth/user.json',
+      storageState: AUTH_STATE_FILE,
     })
     const page = await context.newPage()
     await page.goto('/clippings')

--- a/e2e/meus-clippings.authed.spec.ts
+++ b/e2e/meus-clippings.authed.spec.ts
@@ -1,7 +1,5 @@
 import { expect, test } from '@playwright/test'
 
-test.use({ storageState: 'e2e/.auth/user.json' })
-
 test.describe('Meus Clippings — Listagem', () => {
   test.beforeEach(async ({ page }) => {
     await page.goto('/minha-conta/clipping')

--- a/e2e/release-page.authed.spec.ts
+++ b/e2e/release-page.authed.spec.ts
@@ -1,6 +1,8 @@
 import { expect, test } from '@playwright/test'
 
-test.use({ storageState: 'e2e/.auth/user.json' })
+const AUTH_STATE_FILE = process.env.PLAYWRIGHT_BASE_URL
+  ? 'e2e/.auth/staging.json'
+  : 'e2e/.auth/user.json'
 
 test.describe('Release Page', () => {
   let releaseUrl: string | null = null
@@ -8,7 +10,7 @@ test.describe('Release Page', () => {
   test.beforeAll(async ({ browser }) => {
     // Find a release URL from a listing's releases
     const context = await browser.newContext({
-      storageState: 'e2e/.auth/user.json',
+      storageState: AUTH_STATE_FILE,
     })
     const page = await context.newPage()
 

--- a/e2e/zen-mode.authed.spec.ts
+++ b/e2e/zen-mode.authed.spec.ts
@@ -1,8 +1,5 @@
 import { expect, test } from '@playwright/test'
 
-// Only run in authenticated desktop (zen mode requires login + desktop header)
-test.use({ storageState: 'e2e/.auth/user.json' })
-
 test.describe('Zen Mode', () => {
   test.beforeEach(async ({ page }) => {
     await page.goto('/')

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -46,6 +46,7 @@ export default defineConfig({
       name: 'chromium',
       use: { ...devices['Desktop Chrome'] },
       dependencies: ['setup'],
+      testIgnore: /\.authed\.spec\.ts$/,
     },
     {
       name: 'chromium-authed',
@@ -60,6 +61,7 @@ export default defineConfig({
       name: 'mobile',
       use: { ...devices['Pixel 5'] },
       dependencies: ['setup'],
+      testIgnore: /\.authed\.spec\.ts$/,
     },
     {
       name: 'mobile-authed',


### PR DESCRIPTION
## Resumo

Fase 1 do cleanup do suite Playwright E2E do portal. Três bugs de **configuração** (não de produto) faziam a maioria dos testes falhar contra staging.

## Bugs identificados

### 1. 5 specs hardcodavam `e2e/.auth/user.json`

`test.use({ storageState: 'e2e/.auth/user.json' })` sobrescrevia o storageState dual-mode (`user.json` local vs `staging.json` remoto) configurado nos projects. Como rodamos contra staging, esses specs procuravam um arquivo que não existe.

**Fix:** removida a linha. Em specs que usavam `browser.newContext({ storageState })` em `beforeAll`, o literal foi substituído por uma constante que respeita `PLAYWRIGHT_BASE_URL`.

Specs afetados:
- `e2e/clipping-edit.authed.spec.ts`
- `e2e/listing-detail.authed.spec.ts`
- `e2e/meus-clippings.authed.spec.ts`
- `e2e/release-page.authed.spec.ts`
- `e2e/zen-mode.authed.spec.ts`

### 2. Projects `chromium` e `mobile` rodavam testes autenticados sem auth

Os projects `chromium`/`mobile` não filtravam nada — rodavam testes `.authed.spec.ts` (que precisam de sessão) sem storageState, falhando em massa.

**Fix:** adicionado `testIgnore: /\.authed\.spec\.ts$/` em `playwright.config.ts`.

### 3. `clipping-manual.authed.spec.ts` tinha `const createdClippingId`

`const` impedia atribuição → cleanup `afterAll` nunca executava.

**Fix:** trocado para `let` e capturado o ID via regex na URL pós-redirect. Endpoint REST `/api/clipping/[id]` mantido com `TODO` apontando para migração GraphQL no §9 R1.

## Resultado contra staging

`PLAYWRIGHT_BASE_URL=https://destaquesgovbr-portal-staging-klvx64dufq-rj.a.run.app`

| Métrica | Antes | Depois |
|---------|-------|--------|
| `expected` (passed) | 171 | 143 |
| `unexpected` (failed) | **84** | **32** |
| `skipped` | 104 | 60 |
| `duration` | 595s | 283s |

Redução de ~62% nas falhas. Os 32 remanescentes são bugs reais de produto/teste (não config), para Fase 3.

## Specs que ainda falham (Fase 3)

### Públicos (sem auth)
- `clipping.spec.ts > banner de Clipping possui link para /api/auth/signin` [chromium, mobile]
- `clipping.spec.ts > usuário não autenticado vê banner de Clipping no push subscriber` [chromium, mobile]
- `clippings-scroll.spec.ts > loads initial clippings and more on scroll` [chromium, mobile]
- `clippings-scroll.spec.ts > shows all published clippings eventually` [chromium, mobile]
- `home.spec.ts > should have search functionality` [mobile]
- `search-autocomplete.spec.ts` — 9 testes [maioria mobile]

### Authed
- `clipping-agent.authed.spec.ts > generates recortes with AI agent and shows SSE timeline` [mobile-authed]
- `clipping-manual.authed.spec.ts > meus clippings page shows created clippings` [chromium-authed, mobile-authed]
- `marketplace-subscription.authed.spec.ts > listing detail page shows follow button` [chromium-authed, mobile-authed]
- `marketplace.authed.spec.ts > acessa marketplace via menu principal` [chromium-authed, mobile-authed]
- `meus-clippings.authed.spec.ts > clipping cards show delivery channel badges` [chromium-authed, mobile-authed]
- `meus-clippings.authed.spec.ts > page loads without errors` [mobile-authed]
- `zen-mode.authed.spec.ts` — 4 testes [mobile-authed]

## Test plan

- [x] Smoke test isolado contra staging (30s) — passou
- [x] Suite completa contra staging — 84→32 failed
- [x] Biome check nos arquivos modificados — OK (só warnings pré-existentes)
- [x] Lint-staged via pre-commit hook — OK