### PR TITLE
fix: aumenta timeouts E2E para acomodar cold start do staging

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -25,7 +25,9 @@ export default defineConfig({
   retries: process.env.CI ? 2 : 0,
   workers: process.env.CI ? 1 : undefined,
   reporter: [['html'], ['json', { outputFile: 'test-results/results.json' }]],
-  timeout: isRemote ? 60_000 : 15_000,
+  // Em remote (Cloud Run staging) cold starts podem levar 20-40s. Usamos
+  // tempos generosos para evitar flakes oriundos de infraestrutura.
+  timeout: isRemote ? 90_000 : 15_000,
   expect: {
     timeout: isRemote ? 10_000 : 3_000,
   },
@@ -33,7 +35,7 @@ export default defineConfig({
     baseURL,
     trace: 'on-first-retry',
     screenshot: 'only-on-failure',
-    navigationTimeout: isRemote ? 30_000 : 10_000,
+    navigationTimeout: isRemote ? 60_000 : 10_000,
     actionTimeout: isRemote ? 15_000 : 5_000,
   },
   projects: [


### PR DESCRIPTION
## Resumo

Em staging (Cloud Run) cold starts atingem 20-40s e quando o teste anterior também sofreu cold start o próximo extrapola o `timeout` global de 60s. Esta mudança eleva as janelas para o pior caso observado mantendo margem confortável, sem mascarar regressões reais de produto.

- `timeout` global remoto: 60s → 90s
- `navigationTimeout` remoto: 30s → 60s
- Locais permanecem em 15s/10s (sem impacto)

## Fase 3 — bucket

- (D) Timeouts inadequados para a infra do alvo. Pré-requisito para destrancar fails encadeadas em `clipping-agent`, `meus-clippings`, etc.

## Test plan

- [ ] CI verde
- [ ] Suite E2E contra staging mostra redução em fails por `Test timeout` / `Navigation timeout`