### PR TITLE
test: testes E2E resilientes a estado de dados ausente

### DIFF
--- a/e2e/clipping-manual.authed.spec.ts
+++ b/e2e/clipping-manual.authed.spec.ts
@@ -115,14 +115,25 @@ test.describe('Clipping — Manual Creation & Edit', () => {
 
   test('meus clippings page shows created clippings', async ({ page }) => {
     await page.goto('/minha-conta/clipping')
-    await page.waitForLoadState('networkidle')
+    await page.waitForLoadState('networkidle').catch(() => {})
 
-    // Should have at least one clipping card
-    await expect(
-      page
-        .locator('[data-testid="clipping-card"]')
-        .or(page.locator('.border.rounded-lg').first()),
-    ).toBeVisible({ timeout: 10000 })
+    // Este teste pressupõe que `creates clipping with manual recorte`
+    // tenha rodado antes e criado um clipping. Em runs onde o teste
+    // anterior é skipped/falha (p.ex. dependências externas), evita
+    // falso negativo aqui pulando se não houver nenhum cartão.
+    const cards = page
+      .locator('[data-testid="clipping-card"]')
+      .or(page.locator('.border.rounded-lg').first())
+    const count = await cards.count().catch(() => 0)
+    if (count === 0) {
+      test.skip(
+        true,
+        'Nenhum clipping presente — depende de criação prévia no spec',
+      )
+      return
+    }
+
+    await expect(cards.first()).toBeVisible({ timeout: 10000 })
   })
 
   test('botão Confirmar fica habilitado com apenas Email marcado, sem emails extras', async ({

--- a/e2e/clippings-filters.spec.ts
+++ b/e2e/clippings-filters.spec.ts
@@ -26,8 +26,11 @@ test.describe('Galeria de Clippings — Filtros e Ordenação', () => {
 
   test('search updates URL params', async ({ page }) => {
     await page.getByPlaceholder(/buscar por nome/i).fill('cultura')
-    await page.waitForTimeout(1000)
-    expect(page.url()).toContain('busca=cultura')
+    // Em vez de timeout fixo (que falha em cold start de Cloud Run),
+    // espera explicitamente a URL refletir o parâmetro.
+    await expect
+      .poll(() => page.url(), { timeout: 5_000 })
+      .toContain('busca=cultura')
   })
 
   test('frequency chip filters daily clippings', async ({ page }) => {
@@ -70,9 +73,11 @@ test.describe('Galeria de Clippings — Filtros e Ordenação', () => {
   test('sort by popular changes order', async ({ page }) => {
     const sortSelect = page.locator('select')
     await sortSelect.selectOption('popular')
-    await page.waitForTimeout(300)
 
-    expect(page.url()).toContain('sort=popular')
+    // Espera explícita pela atualização da URL (mais robusto que sleep fixo).
+    await expect
+      .poll(() => page.url(), { timeout: 5_000 })
+      .toContain('sort=popular')
   })
 
   test('transparency link is visible and navigates', async ({ page }) => {

--- a/e2e/clippings-scroll.spec.ts
+++ b/e2e/clippings-scroll.spec.ts
@@ -3,7 +3,7 @@ import { expect, test } from '@playwright/test'
 test.describe('Galeria de Clippings — Infinite Scroll', () => {
   test('loads initial clippings and more on scroll', async ({ page }) => {
     await page.goto('/clippings')
-    await page.waitForLoadState('networkidle')
+    await page.waitForLoadState('networkidle').catch(() => {})
 
     const cards = page.locator('a[href^="/clippings/"]')
     const initialCount = await cards.count()
@@ -12,22 +12,27 @@ test.describe('Galeria de Clippings — Infinite Scroll', () => {
     // Should have at least some cards
     expect(initialCount).toBeGreaterThan(0)
 
-    // If there are 12 (full page), scroll to load more
-    if (initialCount >= 12) {
-      // Scroll to the last card to trigger infinite scroll
+    // Só tenta validar o infinite scroll se a página inicial está cheia
+    // (PAGE_SIZE = 12). Quando o total de listings publicados é menor ou
+    // igual a 12, não existe próxima página e o teste de "carrega mais"
+    // não se aplica.
+    const PAGE_SIZE = 12
+    if (initialCount >= PAGE_SIZE) {
       await cards.last().scrollIntoViewIfNeeded()
       await page.waitForTimeout(2000)
 
-      // Check if more loaded
       const afterCount = await cards.count()
       console.log(`After scroll cards: ${afterCount}`)
-      expect(afterCount).toBeGreaterThan(initialCount)
+      // Se já havia >PAGE_SIZE inicialmente, a próxima leva mais. Se
+      // havia exatamente PAGE_SIZE e o total publicado é =PAGE_SIZE,
+      // não há mais para carregar — toleramos ambos os casos.
+      expect(afterCount).toBeGreaterThanOrEqual(initialCount)
     }
   })
 
   test('shows all published clippings eventually', async ({ page }) => {
     await page.goto('/clippings')
-    await page.waitForLoadState('networkidle')
+    await page.waitForLoadState('networkidle').catch(() => {})
 
     const cards = page.locator('a[href^="/clippings/"]')
 
@@ -45,7 +50,9 @@ test.describe('Galeria de Clippings — Infinite Scroll', () => {
     }
 
     console.log(`Total cards after scrolling: ${currentCount}`)
-    // We know there are 18 published clippings
-    expect(currentCount).toBeGreaterThanOrEqual(17)
+    // Apenas garante que pelo menos UM card é renderizado — o total exato
+    // depende do estado de produção/staging do Firestore e não deve
+    // ser hard-coded no teste.
+    expect(currentCount).toBeGreaterThan(0)
   })
 })

--- a/e2e/marketplace-subscription.authed.spec.ts
+++ b/e2e/marketplace-subscription.authed.spec.ts
@@ -10,23 +10,27 @@ test.describe('Marketplace — Follow via Subscriptions', () => {
 
   test('listing detail page shows follow button', async ({ page }) => {
     await page.goto('/clippings')
-    await page.waitForLoadState('networkidle')
+    await page.waitForLoadState('networkidle').catch(() => {})
 
-    // Click first listing card
-    const firstCard = page.locator('a[href*="/clippings/"]').first()
-    if (await firstCard.isVisible()) {
-      await firstCard.click()
-      await page.waitForLoadState('networkidle')
-
-      // Should show follow or following state
-      const followBtn = page.locator('button:has-text("Seguir")')
-      const followingBadge = page.locator('text=Seguindo')
-
-      const hasFollow = await followBtn.isVisible().catch(() => false)
-      const hasFollowing = await followingBadge.isVisible().catch(() => false)
-
-      expect(hasFollow || hasFollowing).toBe(true)
+    // O nav do header tem `/clippings?sort=trending`; cards de listing
+    // apontam para `/clippings/<id>`. Filtramos só os links de detalhe
+    // (path com slug, sem query string).
+    const detailLinks = page.locator('a[href^="/clippings/"]:not([href*="?"])')
+    const linkCount = await detailLinks.count()
+    if (linkCount === 0) {
+      test.skip(true, 'Nenhum listing no marketplace — nada para seguir')
+      return
     }
+
+    await detailLinks.first().click()
+    await page.waitForURL(/\/clippings\/[^?#]+/, { timeout: 10_000 })
+    await page.waitForLoadState('networkidle').catch(() => {})
+
+    // Deve haver botão "Seguir" OU já estar "Seguindo".
+    const followOrFollowing = page
+      .getByRole('button', { name: /seguir|seguindo/i })
+      .first()
+    await expect(followOrFollowing).toBeVisible({ timeout: 10_000 })
   })
 
   test('meus clippings page shows followed section when following', async ({

--- a/e2e/marketplace.authed.spec.ts
+++ b/e2e/marketplace.authed.spec.ts
@@ -9,7 +9,9 @@ test.describe('Marketplace — Navegação', () => {
     await expect(clippingsLink).toBeVisible()
     await clippingsLink.click()
 
-    await expect(page).toHaveURL('/clippings')
+    // O link do header é `/clippings?sort=trending` (sort default).
+    // Aceita ambos com/sem query string para robustez.
+    await expect(page).toHaveURL(/\/clippings(\?.*)?$/)
     await expect(page.getByText('Galeria de Clippings')).toBeVisible()
   })
 

--- a/e2e/meus-clippings.authed.spec.ts
+++ b/e2e/meus-clippings.authed.spec.ts
@@ -2,13 +2,24 @@ import { expect, test } from '@playwright/test'
 
 test.describe('Meus Clippings — Listagem', () => {
   test.beforeEach(async ({ page }) => {
-    await page.goto('/minha-conta/clipping')
-    await page.waitForLoadState('networkidle')
+    // Cloud Run cold start em staging pode ultrapassar 10s; tolerância
+    // explícita evita flaky em `page.goto`.
+    await page.goto('/minha-conta/clipping', { timeout: 45_000 })
+    await page
+      .waitForLoadState('networkidle', { timeout: 30_000 })
+      .catch(() => {
+        /* networkidle pode não chegar em páginas com background polling */
+      })
   })
 
   test('page loads without errors', async ({ page }) => {
-    // No error messages or blank page
-    await expect(page.locator('text=Meus Clippings').first()).toBeVisible()
+    // No error messages or blank page.
+    // O Header também contém o texto "Meus Clippings" dentro de um
+    // `<span class="hidden lg:inline">` (oculto em mobile/tablet), então
+    // usamos o heading da página para evitar pegar o span invisível.
+    await expect(
+      page.getByRole('heading', { name: 'Meus Clippings' }).first(),
+    ).toBeVisible()
     const errorText = await page.locator('text=Erro').count()
     expect(errorText).toBe(0)
   })
@@ -27,6 +38,19 @@ test.describe('Meus Clippings — Listagem', () => {
   })
 
   test('clipping cards show delivery channel badges', async ({ page }) => {
+    // Pré-requisito: o usuário tem pelo menos um clipping. Em ambientes
+    // descartáveis (bot e2e) pode não haver dados — pulamos o teste em vez
+    // de falhar.
+    const cards = page.locator('[data-testid="clipping-card"]')
+    const count = await cards.count()
+    if (count === 0) {
+      test.skip(
+        true,
+        'Usuário sem clippings — sem badges de canal para verificar',
+      )
+      return
+    }
+
     // Check for any channel badge (Email, Telegram, Push, Webhook)
     const emailBadge = page.locator('text=Email').first()
     const telegramBadge = page.locator('text=Telegram').first()


### PR DESCRIPTION
## Resumo

Em staging o bot e2e pode não ter clippings/listings nem haver dados no índice Typesense. Antes os testes que assumiam estado mínimo falhavam com "expected card, got 0". Esta mudança torna esses testes resilientes — pulam com mensagem explicativa quando o estado pré-requisito não existe.

Sem mudanças em código de produto.

## Fails endereçados

- `clippings-scroll.spec.ts` × 2 testes × 2 projects
- `clipping-manual.authed.spec.ts > meus clippings page shows created clippings` (chromium-authed + mobile-authed)
- `marketplace-subscription.authed.spec.ts > listing detail page shows follow button` (chromium-authed + mobile-authed)
- `marketplace.authed.spec.ts > acessa marketplace via menu principal` (chromium-authed + mobile-authed) — Header agora navega para `/clippings?sort=trending`
- `meus-clippings.authed.spec.ts > clipping cards show delivery channel badges` (chromium-authed + mobile-authed)
- `meus-clippings.authed.spec.ts > page loads without errors` (mobile-authed) — `text=Meus Clippings` pegava span oculto do Header
- `clippings-filters.spec.ts` — substitui `waitForTimeout` por `expect.poll` (flake em cold start)

## Fase 3 — bucket

- (C) Acoplados a estado de dados ausente. Decisão do usuário: não criar seed agora; testes devem se adaptar.

## Test plan

- [ ] CI verde
- [ ] Re-run staging: specs acima passam ou skipped por dados ausentes (não failed)