### PR TITLE
fix: cacheia token do bot no E2E + corrige reatividade da edição de clipping (R1)

### DIFF
--- a/e2e/auth.setup.ts
+++ b/e2e/auth.setup.ts
@@ -2,6 +2,7 @@ import crypto from 'node:crypto'
 import path from 'node:path'
 import { encode } from '@auth/core/jwt'
 import { expect, test as setup } from '@playwright/test'
+import { writeTokenCache } from './fixtures/keycloak'
 
 /**
  * Setup project para autenticação contra portal staging — bypassa o browser
@@ -133,6 +134,11 @@ setup(
       username: botUsername,
       password: botPassword,
     })
+
+    // 1b. Pré-popula o cache de token compartilhado para que as fixtures
+    //     reusem este grant (evita rajada de Direct Access Grants em paralelo,
+    //     que dispara o brute-force/quick-login lockout do Keycloak).
+    writeTokenCache(tokens)
 
     // 2. Decode access_token claims (sem validar — só para extrair metadados).
     const claims = decodeJwtPayload<AccessTokenClaims>(tokens.access_token)

--- a/e2e/fixtures/keycloak.ts
+++ b/e2e/fixtures/keycloak.ts
@@ -12,6 +12,9 @@
  * programático para autenticar o bot `e2e-bot@destaquesgovbr.gov.br`.
  */
 
+import fs from 'node:fs'
+import path from 'node:path'
+
 const DEFAULT_KC_URL = 'https://destaquesgovbr-keycloak-klvx64dufq-rj.a.run.app'
 const KC_REALM = 'destaquesgovbr'
 const KC_CLIENT_ID = 'portal-e2e'
@@ -31,27 +34,86 @@ export function keycloakUrl(): string {
 }
 
 /**
- * Obtém um `access_token` do bot E2E via Direct Access Grant.
+ * Cache de token compartilhado entre workers do Playwright.
  *
- * Requer `E2E_BOT_PASSWORD` no ambiente (carregado por
- * `scripts/e2e/load-creds.sh`). Lança erro verboso se faltar — nunca silencia.
+ * Motivação: cada fixture que cria um `E2EGraphQLClient` chamava
+ * `fetchBotAccessToken()`, que fazia um Direct Access Grant (password) do mesmo
+ * bot. Com vários workers em paralelo, dezenas de grants do mesmo usuário caíam
+ * dentro da janela de "quick login" do Keycloak (`quickLoginCheckMilliSeconds`,
+ * default 1s), disparando o brute-force detection e retornando `invalid_grant`
+ * mesmo com a senha certa.
+ *
+ * Solução: persistir o token (e o `refresh_token`) num arquivo dentro de
+ * `e2e/.auth/` — o nome `*.local.json` já casa o `.gitignore`, então a
+ * credencial nunca é commitada — reusá-lo enquanto válido e, ao expirar, renovar
+ * via `grant_type=refresh_token` (que NÃO conta como login → não dispara
+ * brute-force). O `auth.setup.ts` pré-popula o cache com 1 grant antes de
+ * qualquer fixture rodar, então no fluxo normal o run inteiro faz apenas 1
+ * password-grant.
  */
-export async function fetchBotAccessToken(): Promise<string> {
-  const password = process.env.E2E_BOT_PASSWORD
-  if (!password) {
-    throw new Error(
-      'E2E_BOT_PASSWORD ausente. Rode: source ./scripts/e2e/load-creds.sh',
-    )
+const TOKEN_CACHE_FILE = path.join(
+  __dirname,
+  '..',
+  '.auth',
+  'bot-token.local.json',
+)
+const EXPIRY_BUFFER_SECONDS = 30
+
+interface CachedToken {
+  access_token: string
+  refresh_token?: string
+  /** epoch (ms) em que o token foi obtido */
+  obtained_at: number
+  /** validade em segundos (campo `expires_in` do Keycloak) */
+  expires_in: number
+}
+
+let memoryToken: CachedToken | null = null
+let inflight: Promise<string> | null = null
+
+function tokenIsFresh(t: CachedToken | null): boolean {
+  if (!t?.access_token) return false
+  const ageMs = Date.now() - t.obtained_at
+  const ttlMs = (t.expires_in - EXPIRY_BUFFER_SECONDS) * 1000
+  return ttlMs > 0 && ageMs < ttlMs
+}
+
+function readTokenCacheFile(): CachedToken | null {
+  try {
+    return JSON.parse(fs.readFileSync(TOKEN_CACHE_FILE, 'utf8')) as CachedToken
+  } catch {
+    return null
   }
-  const username = process.env.E2E_BOT_USERNAME ?? DEFAULT_BOT_USERNAME
+}
+
+/**
+ * Persiste tokens no cache (memória + arquivo). Chamado pelo `auth.setup.ts`
+ * logo após o grant inicial e por `fetchBotAccessToken` ao renovar.
+ */
+export function writeTokenCache(tokens: {
+  access_token: string
+  refresh_token?: string
+  expires_in: number
+}): void {
+  const entry: CachedToken = {
+    access_token: tokens.access_token,
+    refresh_token: tokens.refresh_token,
+    obtained_at: Date.now(),
+    expires_in: tokens.expires_in,
+  }
+  memoryToken = entry
+  try {
+    fs.mkdirSync(path.dirname(TOKEN_CACHE_FILE), { recursive: true })
+    fs.writeFileSync(TOKEN_CACHE_FILE, JSON.stringify(entry), 'utf8')
+  } catch {
+    // cache em arquivo é best-effort; a memória do worker já guardou o token
+  }
+}
+
+async function requestToken(
+  body: URLSearchParams,
+): Promise<KeycloakTokenResponse> {
   const tokenEndpoint = `${keycloakUrl()}/realms/${KC_REALM}/protocol/openid-connect/token`
-  const body = new URLSearchParams({
-    grant_type: 'password',
-    client_id: KC_CLIENT_ID,
-    username,
-    password,
-    scope: 'openid email profile',
-  })
   const res = await fetch(tokenEndpoint, {
     method: 'POST',
     headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
@@ -67,7 +129,86 @@ export async function fetchBotAccessToken(): Promise<string> {
   if (!tokens.access_token) {
     throw new Error('Keycloak não retornou access_token')
   }
-  return tokens.access_token
+  return tokens
+}
+
+function passwordGrant(): Promise<KeycloakTokenResponse> {
+  const password = process.env.E2E_BOT_PASSWORD
+  if (!password) {
+    throw new Error(
+      'E2E_BOT_PASSWORD ausente. Rode: source ./scripts/e2e/load-creds.sh',
+    )
+  }
+  const username = process.env.E2E_BOT_USERNAME ?? DEFAULT_BOT_USERNAME
+  return requestToken(
+    new URLSearchParams({
+      grant_type: 'password',
+      client_id: KC_CLIENT_ID,
+      username,
+      password,
+      scope: 'openid email profile',
+    }),
+  )
+}
+
+async function refreshGrant(
+  refreshToken: string,
+): Promise<KeycloakTokenResponse | null> {
+  try {
+    return await requestToken(
+      new URLSearchParams({
+        grant_type: 'refresh_token',
+        client_id: KC_CLIENT_ID,
+        refresh_token: refreshToken,
+      }),
+    )
+  } catch {
+    // refresh expirado/inválido → cai no password grant
+    return null
+  }
+}
+
+/**
+ * Obtém um `access_token` do bot E2E, reusando o cache compartilhado.
+ *
+ * Ordem: memória do worker → arquivo de cache → `refresh_token` → password grant.
+ * Coalesce chamadas concorrentes no mesmo worker (uma única ida em voo).
+ *
+ * Requer `E2E_BOT_PASSWORD` no ambiente (via `scripts/e2e/load-creds.sh`)
+ * apenas quando precisar do password grant — com cache/refresh válidos, não.
+ */
+export async function fetchBotAccessToken(): Promise<string> {
+  if (memoryToken && tokenIsFresh(memoryToken)) return memoryToken.access_token
+  if (inflight) return inflight
+
+  inflight = (async () => {
+    if (memoryToken && tokenIsFresh(memoryToken))
+      return memoryToken.access_token
+
+    const cached = readTokenCacheFile()
+    if (cached && tokenIsFresh(cached)) {
+      memoryToken = cached
+      return cached.access_token
+    }
+
+    // Token expirado mas com refresh_token: renova (não dispara brute-force).
+    if (cached?.refresh_token) {
+      const refreshed = await refreshGrant(cached.refresh_token)
+      if (refreshed) {
+        writeTokenCache(refreshed)
+        return refreshed.access_token
+      }
+    }
+
+    // Fallback: novo password grant (raro — só sem cache/refresh válidos).
+    const tokens = await passwordGrant()
+    writeTokenCache(tokens)
+    return tokens.access_token
+  })().finally(() => {
+    inflight = null
+  })
+
+  return inflight
 }
 
 /** Decodifica o payload de um JWT (sem validar — só para extrair claims). */

--- a/src/app/(logged-in)/minha-conta/clipping/[id]/editar/EditarClippingClient.tsx
+++ b/src/app/(logged-in)/minha-conta/clipping/[id]/editar/EditarClippingClient.tsx
@@ -29,6 +29,15 @@ export function EditarClippingClient({
 
   useEffect(() => {
     let cancelled = false
+    // Reseta o estado a cada fetch. Crucial durante a migração GraphQL: no
+    // 1º render a flag `graphql.clippings` ainda não resolveu, então
+    // `useClippingService()` devolve o serviço REST (lê a coleção legada) e
+    // pode setar erro "Clipping não encontrado". Quando a flag resolve, o
+    // `clippingService` muda → este efeito re-roda via GraphQL. Sem limpar
+    // `error`/`loading` aqui, o erro da tentativa REST persistia e mascarava
+    // o sucesso do re-fetch (false-green do flag-race).
+    setLoading(true)
+    setError(null)
     clippingService
       .listClippings()
       .then((data) => {


### PR DESCRIPTION
## Objetivo

Dois fixes que tornam a validação browser (E2E) da migração GraphQL (R1) **confiável** em staging, parte da **opção C** (corrigir o flag-race agora; remover o fallback REST só no §9 pós-prod).

## 1. E2E — token-cache do bot (mata o lockout do Keycloak)

**Sintoma:** re-runs da suíte falhavam com `invalid_grant: Invalid user credentials` mesmo com a senha certa — brute-force/**quick-login** do Keycloak (`quickLoginCheckMilliSeconds`, 1s) disparado por dezenas de Direct Access Grants do mesmo bot, em paralelo (5 workers × fixtures).

**Causa:** `createE2EGraphQLClient()` chamava `fetchBotAccessToken()` por request, sem cache → rajada de grants.

**Fix:** `fetchBotAccessToken` reusa um token compartilhado:
- memória do worker → arquivo `e2e/.auth/bot-token.local.json` (gitignored via `*.local.json`) → `refresh_token` (não conta como login) → password grant (fallback).
- `auth.setup.ts` pré-popula o cache com o grant inicial, antes de qualquer fixture.
- Resultado: **1 password-grant por run** (em vez de dezenas) → sem lockout.

## 2. `EditarClippingClient` — reatividade do flag-race

**Sintoma:** abrir um clipping criado via GraphQL às vezes mostrava "Clipping não encontrado" e não se recuperava.

**Causa:** no 1º render a flag `graphql.clippings` ainda não resolveu → `useClippingService()` devolve REST → lê a coleção legada → `setError(...)`. Quando a flag resolve, o `clippingService` muda e o efeito re-busca via GraphQL, **mas** o `error` stale nunca era limpo → `if (error || !clipping)` continuava verdadeiro (false-green).

**Fix:** resetar `loading`/`error` no início de cada fetch → o re-fetch GraphQL passa a exibir o resultado.

## Validação local

- `pnpm lint` — sem erros (warnings de estilo pré-existentes).
- `tsc --noEmit` — sem erros nos arquivos tocados.
- `pnpm exec vitest run` — **529/529** (61 arquivos).

## Test plan (pós-merge → deploy-staging)

1. `deploy-staging` builda o portal com o fix do `EditarClippingClient`.
2. Re-rodar a suíte `e2e/graphql` full-staging:
   - confirmar **1 grant** no run inteiro (sem lockout) — token-cache;
   - confirmar **"edita o nome"** verde — reatividade.
3. Reds remanescentes esperados (não-bloqueantes): clone (eventual-consistency) e agent (latência LLM) — tolerância de harness, follow-up.

## Fora de escopo (proposto, precisa de OK — toca o A/B app-wide)

Tornar `useFeatureValue` reativo no `GrowthBookProvider` + resolver a flag no SSR, eliminando o flash REST inicial para usuários reais durante o canário em prod.
