### PR TITLE
fix: remove campo 'iteration' inexistente da subscription do agente (R1 drift)

### DIFF
--- a/src/components/clipping/AgentRecorteGenerator.tsx
+++ b/src/components/clipping/AgentRecorteGenerator.tsx
@@ -21,20 +21,17 @@ type AgentEvent =
   | { type: 'thinking'; message: string }
   | {
       type: 'tool_call'
-      iteration: number
       recorte: string
       filters: { themes: string[]; agencies: string[]; keywords: string[] }
     }
   | {
       type: 'tool_result'
-      iteration: number
       count: number
       top_themes: { code: string; label: string; count: number }[]
       top_agencies: { key: string; name: string; count: number }[]
     }
   | {
       type: 'sample_result'
-      iteration: number
       count: number
       articles: { title: string; summary: string; agency_name: string }[]
     }
@@ -86,7 +83,6 @@ function mapGraphQLEventToLocal(ev: AgentEventGraphQL): AgentEvent | null {
         }
         return {
           type: 'tool_call',
-          iteration: ev.iteration,
           recorte: args.recorte ?? '',
           filters: {
             themes: args.filters?.themes ?? [],
@@ -107,7 +103,6 @@ function mapGraphQLEventToLocal(ev: AgentEventGraphQL): AgentEvent | null {
         }
         return {
           type: 'tool_result',
-          iteration: ev.iteration,
           count: result.count ?? 0,
           top_themes: result.top_themes ?? [],
           top_agencies: result.top_agencies ?? [],
@@ -124,7 +119,6 @@ function mapGraphQLEventToLocal(ev: AgentEventGraphQL): AgentEvent | null {
         }
         return {
           type: 'sample_result',
-          iteration: ev.iteration,
           count: payload.count ?? 0,
           articles: payload.articles ?? [],
         }
@@ -455,7 +449,7 @@ function AgentRecorteGeneratorView({
       {events.length > 0 && (
         <div className="space-y-2 text-sm">
           {events.map((event, idx) => {
-            const eventKey = `${event.type}-${'iteration' in event ? event.iteration : idx}`
+            const eventKey = `${event.type}-${idx}`
             const isLast = idx === events.length - 1
             return (
               <div

--- a/src/components/clipping/__tests__/AgentRecorteGenerator.test.tsx
+++ b/src/components/clipping/__tests__/AgentRecorteGenerator.test.tsx
@@ -219,7 +219,6 @@ describe('AgentRecorteGenerator — renderização de eventos GraphQL', () => {
       data: {
         generateRecortes: {
           __typename: 'AgentEventToolCall',
-          iteration: 1,
           tool: 'searchArticles',
           argsJson: JSON.stringify({
             recorte: 'Educação básica',

--- a/src/lib/graphql/queries/agent.ts
+++ b/src/lib/graphql/queries/agent.ts
@@ -32,17 +32,14 @@ export const GENERATE_RECORTES_SUBSCRIPTION = gql`
         message
       }
       ... on AgentEventToolCall {
-        iteration
         tool
         argsJson
       }
       ... on AgentEventToolResult {
-        iteration
         tool
         resultJson
       }
       ... on AgentEventSampleResult {
-        iteration
         payloadJson
       }
       ... on AgentEventAdjusting {
@@ -78,21 +75,18 @@ export type AgentEventGraphQL =
     }
   | {
       __typename: 'AgentEventToolCall'
-      iteration: number
       tool: string
       /** JSON serializado com `{ recorte, filters: { themes, agencies, keywords } }`. */
       argsJson: string
     }
   | {
       __typename: 'AgentEventToolResult'
-      iteration: number
       tool: string
       /** JSON serializado com `{ count, top_themes, top_agencies }`. */
       resultJson: string
     }
   | {
       __typename: 'AgentEventSampleResult'
-      iteration: number
       /** JSON serializado com `{ count, articles: [{ title, summary, agency_name }] }`. */
       payloadJson: string
     }


### PR DESCRIPTION
## Objetivo

Corrigir o **último red** do E2E da migração GraphQL (R1): o agente de IA (subscription SSE). Era **schema drift**, não latência.

## Diagnóstico

O teste `agent.authed.spec.ts` falhava esperando "Analisando o pedido" (timeline). Investigando:

- **Backend OK:** logs mostram `POST /graphql/stream → 200` (graphql-api) e `POST /agent/generate-recortes → 200` (clipping-worker), com o agente streamando tool-calls (`count_articles` para vacinação, SUS, dengue…). O pipeline R1 (CSP → graphql-api → passthrough OIDC → worker → LLM) funciona.
- **Cliente quebrado:** o screenshot de falha mostra o erro real, em vermelho:
  `[GraphQL] Cannot query field 'iteration' on type 'AgentEventToolCall' / 'AgentEventToolResult' / 'AgentEventSampleResult'`.

A subscription `generateRecortes` pedia `iteration` (singular) nesses 3 tipos, mas o schema do graphql-api não os tem (só `AgentEventDone.iterations`, plural). A validação falhava → nenhum evento renderizava → timeline nunca aparecia.

## Fix

`iteration` era **over-query morto**: no portal só era usado como React `key` (com fallback para o índice). Removido da query, dos tipos GraphQL/locais, do mapeamento e da key (passa a usar o índice do array). Sem perda de UX — nunca era exibido. `iterations` (plural, em `AgentEventDone`) é válido e foi **mantido**.

## Validação local

- `pnpm exec biome check` — limpo.
- `tsc --noEmit` — sem novos erros nos arquivos tocados (o único erro remanescente no test, linha 135, é pré-existente em `development`).
- `pnpm exec vitest run AgentRecorteGenerator.test.tsx` — **9/9**.

## Test plan (pós-merge → deploy-staging)

Re-rodar `e2e/graphql` **serial** (`--workers=1`). Esperado: **16/16 verde** (o agente passa a renderizar a timeline e concluir/throttle).

## Contexto

Parte da validação browser R1 (estado combinado main+development). Os reds anteriores de clippings/marketplace eram interferência de execução paralela sobre os dados compartilhados do bot — serial passam (15/16). Este PR resolve o 16º.
