### PR TITLE
fix: gate anti-drift no codegen + schedule/toggle/SSR via GraphQL (R1)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,9 @@ jobs:
       - name: Run lint
         run: pnpm run lint
 
+      - name: Validate GraphQL operations against schema (anti-drift)
+        run: pnpm graphql:codegen
+
       - name: Build
         run: pnpm run build
         env:

--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,6 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+# GraphQL codegen (artefato de validação — não commitado)
+/src/lib/graphql/__generated__/

--- a/codegen.ts
+++ b/codegen.ts
@@ -1,34 +1,43 @@
 /**
  * Configuração do GraphQL Code Generator.
  *
- * Gera types TypeScript a partir do schema GraphQL exposto pelo `graphql-api`
- * (Strawberry/Python). Os types ficam em `src/lib/graphql/__generated__/`
- * e são importados pelas queries em `src/lib/graphql/queries/` (B2-B5).
+ * Função dupla:
+ *   1. **Gate anti-drift (principal):** valida TODAS as operações `gql\`...\``
+ *      do portal contra o schema do `graphql-api`. Se uma operação selecionar
+ *      um campo/argumento que o schema não expõe, o codegen FALHA — foi
+ *      exatamente o drift (`iteration`) que passou despercebido por este gate
+ *      estar quebrado: o glob antigo apontava para `*.graphql`, que não casa
+ *      nenhum arquivo (as ops vivem em `*.ts`), então o codegen rodava vazio.
+ *   2. Gera types em `src/lib/graphql/__generated__/` (gitignored; artefato de
+ *      validação, não commitado nem importado por ora).
  *
- * O schema pode vir de:
- *   - URL remota (default — `NEXT_PUBLIC_GRAPHQL_URL`); ou
- *   - Arquivo local (`src/lib/graphql/schema.graphql`) para CI/dev offline.
+ * Schema: snapshot commitado `src/lib/graphql/schema.graphql` (determinístico,
+ * offline em CI). Mantê-lo em sincronia com o `graphql-api`: rodar
+ * `make docs-schema` lá e copiar `docs/reference/schema.graphql` para cá.
+ * Override opcional via `GRAPHQL_SCHEMA_URL` (introspecção de um serviço vivo).
  *
- * Uso: `pnpm graphql:codegen` (ou `pnpm graphql:codegen --watch`).
+ * Uso: `pnpm graphql:codegen`.
  */
 
 import type { CodegenConfig } from '@graphql-codegen/cli'
 
-const schemaUrl = process.env.NEXT_PUBLIC_GRAPHQL_URL
-const localSchemaPath = './src/lib/graphql/schema.graphql'
+const schemaSource =
+  process.env.GRAPHQL_SCHEMA_URL ?? './src/lib/graphql/schema.graphql'
 
 const config: CodegenConfig = {
-  // Prefere schema remoto (introspection); cai para o arquivo local quando
-  // a URL não está definida (CI build sem graphql-api rodando).
-  schema: schemaUrl ?? localSchemaPath,
-  documents: ['src/lib/graphql/queries/**/*.graphql'],
+  schema: schemaSource,
+  // As operações são `gql\`...\`` em arquivos .ts (queries + services).
+  documents: ['src/**/*.{ts,tsx}'],
   ignoreNoDocuments: true,
   generates: {
+    // Apenas `typescript` + `typescript-operations`: bastam para validar as
+    // operações contra o schema (falham em campo/argumento inexistente). Não
+    // usamos `typed-document-node` — os tipos não são adotados (gate-only), e
+    // ele exigiria o peer-dep `@graphql-typed-document-node/core`.
     'src/lib/graphql/__generated__/types.ts': {
-      plugins: ['typescript', 'typescript-operations', 'typed-document-node'],
+      plugins: ['typescript', 'typescript-operations'],
       config: {
         useTypeImports: true,
-        // Mantém naming idiomático em TypeScript
         avoidOptionals: false,
         skipTypename: false,
       },

--- a/e2e/graphql/marketplace.authed.spec.ts
+++ b/e2e/graphql/marketplace.authed.spec.ts
@@ -17,6 +17,7 @@ import {
   type E2EGraphQLClient,
   makeClipping,
   publishListing,
+  removeClipping,
   unpublishListing,
 } from '../fixtures'
 
@@ -152,5 +153,36 @@ test.describe('Marketplace via GraphQL', () => {
 
     // O clone cria um novo clipping autorado → contagem sobe em 1.
     await expect.poll(countAuthored, { timeout: 10_000 }).toBe(before + 1)
+  })
+
+  test('unpublish desativa o listing no backend', async () => {
+    // Sanidade: o listing do beforeEach está ativo (a query o retorna).
+    const before = await client.execute<{
+      marketplaceListing: { id: string } | null
+    }>(LISTING_QUERY, { id: listing.id })
+    expect(before.marketplaceListing?.id).toBe(listing.id)
+
+    await unpublishListing(client, listing.id)
+
+    // `get_marketplace_listing` filtra `active=false` → retorna null.
+    const after = await client.execute<{
+      marketplaceListing: { id: string } | null
+    }>(LISTING_QUERY, { id: listing.id })
+    expect(after.marketplaceListing).toBeNull()
+  })
+
+  test('unpublish funciona mesmo com o clipping-fonte já excluído', async () => {
+    // Regressão (bug pego em staging): publicar → excluir o clipping → unpublish.
+    // Antes, o unpublish fazia `update` no clipping inexistente e o batch
+    // inteiro falhava ("No document to update"), deixando o listing ativo.
+    await removeClipping(client, clipping.id)
+
+    // Não deve lançar; o soft-delete do listing precisa commitar mesmo assim.
+    await unpublishListing(client, listing.id)
+
+    const after = await client.execute<{
+      marketplaceListing: { id: string } | null
+    }>(LISTING_QUERY, { id: listing.id })
+    expect(after.marketplaceListing).toBeNull()
   })
 })

--- a/src/app/(logged-in)/minha-conta/clipping/ClippingListClient.tsx
+++ b/src/app/(logged-in)/minha-conta/clipping/ClippingListClient.tsx
@@ -30,23 +30,13 @@ export function ClippingListClient({
   }
 
   const handleToggleActive = async (id: string, active: boolean) => {
-    // O facade GraphQL persiste 'active' via updateClipping; o REST atual
-    // usa um PATCH simples. Para manter compatibilidade durante a migração
-    // continuamos com fetch direto aqui (PATCH no REST). Quando o GraphQL
-    // expor uma mutation de toggle dedicada, atualizamos para usar o
-    // facade. Por enquanto, atualizamos o estado otimisticamente e o
-    // backend processa via PATCH (REST) ou via updateClipping (GraphQL).
+    // Roteado pelo facade: usa a mutation `setClippingActive` quando a flag
+    // `graphql.clippings` está ON, ou o PATCH REST legado caso contrário.
     try {
-      const res = await fetch(`/api/clipping/${id}`, {
-        method: 'PATCH',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ active }),
-      })
-      if (res.ok) {
-        setClippings((prev) =>
-          prev.map((c) => (c.id === id ? { ...c, active } : c)),
-        )
-      }
+      await clippingService.setClippingActive(id, active)
+      setClippings((prev) =>
+        prev.map((c) => (c.id === id ? { ...c, active } : c)),
+      )
     } catch (err) {
       console.error('Failed to toggle clipping:', err)
     }

--- a/src/app/(logged-in)/minha-conta/clipping/page.tsx
+++ b/src/app/(logged-in)/minha-conta/clipping/page.tsx
@@ -6,13 +6,38 @@ import {
 } from '@/components/marketplace/FollowCard'
 import { getAgenciesList } from '@/data/agencies-utils'
 import { getThemesWithHierarchy } from '@/data/themes-utils'
+import {
+  GRAPHQL_FLAGS,
+  resolveGraphQLFlagServer,
+} from '@/lib/feature-flags-server'
 import { getFirestoreDb } from '@/lib/firebase-admin'
+import { createSSRClient } from '@/lib/graphql/client'
+import { createGraphQLClippingService } from '@/services/clipping/graphql'
 import type { Clipping, MarketplaceListing } from '@/types/clipping'
 import { ClippingListClient } from './ClippingListClient'
 
 export async function getClippings(): Promise<Clipping[]> {
   const session = await auth()
   if (!session?.user?.id) return []
+
+  // Quando `graphql.clippings` está ON, hidrata via a fachada GraphQL (mesmo
+  // caminho do cliente) — assim o canário exercita os resolvers de leitura.
+  // Falha → fallback para o Firestore abaixo (comportamento legado).
+  const useGraphQL = await resolveGraphQLFlagServer(
+    GRAPHQL_FLAGS.CLIPPINGS,
+    session.user.id,
+  )
+  if (useGraphQL) {
+    try {
+      const client = createSSRClient(async () => session.accessToken ?? null)
+      return await createGraphQLClippingService(client).listClippings()
+    } catch (err) {
+      console.error(
+        'getClippings via GraphQL falhou; fallback Firestore:',
+        (err as Error).message,
+      )
+    }
+  }
 
   try {
     const db = getFirestoreDb()

--- a/src/lib/feature-flags-server.ts
+++ b/src/lib/feature-flags-server.ts
@@ -1,0 +1,39 @@
+/**
+ * Resolução de feature flags `graphql.*` no SERVIDOR (Server Components).
+ *
+ * O wrapper client (`@/lib/feature-flags`) é `'use client'` e não pode ser
+ * chamado em Server Components. Aqui criamos uma instância GrowthBook por
+ * request, carregamos as features e avaliamos a flag com o id do usuário —
+ * permitindo que o SSR hidrate dados via a fachada GraphQL quando a flag está
+ * ON (em vez de ler o Firestore direto, que ignora o estado da flag).
+ *
+ * Falha graciosa: qualquer erro → `false` (mantém o caminho legado/Firestore).
+ *
+ * Obs.: não usa `import 'server-only'` para permanecer importável pelos testes
+ * (vitest) que exercitam o `getClippings` da página; é usado apenas por Server
+ * Components e os boundaries RSC são validados pelo `next build`.
+ */
+
+import {
+  createGrowthBookInstance,
+  isGrowthBookConfigured,
+} from '@/ab-testing/growthbook'
+
+export { GRAPHQL_FLAGS } from '@/lib/graphql/flags'
+
+export async function resolveGraphQLFlagServer(
+  flagKey: string,
+  userId?: string | null,
+): Promise<boolean> {
+  if (!isGrowthBookConfigured()) return false
+  try {
+    const gb = createGrowthBookInstance()
+    if (userId) gb.setAttributes({ id: userId })
+    await gb.init({ timeout: 2000 })
+    const value = gb.getFeatureValue<boolean>(flagKey, false)
+    gb.destroy()
+    return typeof value === 'boolean' ? value : false
+  } catch {
+    return false
+  }
+}

--- a/src/lib/feature-flags.ts
+++ b/src/lib/feature-flags.ts
@@ -21,19 +21,13 @@ import { isGrowthBookConfigured } from '@/ab-testing/growthbook'
 
 /**
  * Flags planejadas para a migração GraphQL (PLANO-ATUALIZACAO-v2, §3 D4).
+ * Definição PURA em `@/lib/graphql/flags` (sem `'use client'`) para ser
+ * compartilhada com Server Components; re-exportada aqui por compatibilidade.
  *
  * Default = `false` em todas: portal continua usando REST até a flag ser
  * explicitamente ligada via GrowthBook.
  */
-export const GRAPHQL_FLAGS = {
-  CLIPPINGS: 'graphql.clippings',
-  MARKETPLACE: 'graphql.marketplace',
-  AGENT: 'graphql.agent',
-  PUSH: 'graphql.push',
-  WIDGETS: 'graphql.widgets',
-} as const
-
-export type GraphQLFlagKey = (typeof GRAPHQL_FLAGS)[keyof typeof GRAPHQL_FLAGS]
+export { GRAPHQL_FLAGS, type GraphQLFlagKey } from '@/lib/graphql/flags'
 
 /**
  * Hook client-side para ler uma feature flag com default explícito.

--- a/src/lib/graphql/__tests__/codegen-config.test.ts
+++ b/src/lib/graphql/__tests__/codegen-config.test.ts
@@ -26,7 +26,7 @@ describe('codegen.ts', () => {
     expect(targets.length).toBeGreaterThan(0)
   })
 
-  it('test_codegen_config_uses_expected_plugins: target principal inclui typescript + typescript-operations + typed-document-node', async () => {
+  it('test_codegen_config_uses_expected_plugins: target principal inclui typescript + typescript-operations', async () => {
     const configPath = path.resolve(__dirname, '../../../../codegen.ts')
     const mod = await import(/* @vite-ignore */ configPath)
     const config = mod.default
@@ -35,6 +35,22 @@ describe('codegen.ts', () => {
     }
     expect(target.plugins).toContain('typescript')
     expect(target.plugins).toContain('typescript-operations')
-    expect(target.plugins).toContain('typed-document-node')
+  })
+
+  it('test_codegen_documents_match_ts_files: o glob de documents aponta para .ts (as ops são gql`...` em .ts, não .graphql)', async () => {
+    // Regressão: o glob antigo apontava para `**/*.graphql` (zero arquivos),
+    // então o codegen rodava vazio e nenhum drift ops↔schema era detectado
+    // (foi assim que o campo `iteration` inexistente passou). Garante que o
+    // gate de fato varre os arquivos onde as operações vivem.
+    const configPath = path.resolve(__dirname, '../../../../codegen.ts')
+    const mod = await import(/* @vite-ignore */ configPath)
+    const config = mod.default
+    const documents = (
+      Array.isArray(config.documents) ? config.documents : [config.documents]
+    ).join(',')
+    // Casa arquivos .ts/.tsx (onde vivem os `gql\`...\``), não o glob morto
+    // `**/*.graphql` que não casava nada.
+    expect(documents).toMatch(/ts/)
+    expect(documents).not.toContain('.graphql')
   })
 })

--- a/src/lib/graphql/flags.ts
+++ b/src/lib/graphql/flags.ts
@@ -1,0 +1,17 @@
+/**
+ * Chaves das feature flags da migração GraphQL (módulo PURO — sem `'use client'`).
+ *
+ * Vive aqui (e não em `@/lib/feature-flags`, que é `'use client'`) para poder
+ * ser importado tanto por código client quanto por Server Components. O wrapper
+ * client re-exporta daqui para manter os imports existentes.
+ */
+
+export const GRAPHQL_FLAGS = {
+  CLIPPINGS: 'graphql.clippings',
+  MARKETPLACE: 'graphql.marketplace',
+  AGENT: 'graphql.agent',
+  PUSH: 'graphql.push',
+  WIDGETS: 'graphql.widgets',
+} as const
+
+export type GraphQLFlagKey = (typeof GRAPHQL_FLAGS)[keyof typeof GRAPHQL_FLAGS]

--- a/src/lib/graphql/queries/clippings.ts
+++ b/src/lib/graphql/queries/clippings.ts
@@ -101,7 +101,7 @@ export const CLIPPING_RELEASES_QUERY = gql`
         releaseUrl
         refTime
         sinceHours
-        publishedAt
+        createdAt
       }
     }
   }
@@ -148,6 +148,16 @@ export const UPDATE_CLIPPING_MUTATION = gql`
 export const DELETE_CLIPPING_MUTATION = gql`
   mutation DeleteClipping($id: String!) {
     deleteClipping(id: $id)
+  }
+`
+
+/** Liga/desliga um clipping (campo `active`; somente o autor). */
+export const SET_CLIPPING_ACTIVE_MUTATION = gql`
+  mutation SetClippingActive($id: String!, $active: Boolean!) {
+    setClippingActive(id: $id, active: $active) {
+      id
+      active
+    }
   }
 `
 
@@ -250,7 +260,7 @@ export interface ReleaseGraphQL {
   releaseUrl: string | null
   refTime: string | null
   sinceHours: number | null
-  publishedAt: string
+  createdAt: string
 }
 
 /** RecorteInput do schema NÃO tem `id` (diferente do `Recorte` de saída). */
@@ -287,6 +297,10 @@ export interface UpdateClippingMutationData {
 
 export interface DeleteClippingMutationData {
   deleteClipping: boolean
+}
+
+export interface SetClippingActiveMutationData {
+  setClippingActive: { id: string; active: boolean }
 }
 
 export interface UpdateMySubscriptionMutationData {

--- a/src/lib/graphql/queries/marketplace.ts
+++ b/src/lib/graphql/queries/marketplace.ts
@@ -40,6 +40,7 @@ const LISTING_FIELDS = gql`
       keywords
     }
     prompt
+    schedule
     likeCount
     followerCount
     cloneCount
@@ -165,6 +166,7 @@ export interface MarketplaceListingGraphQL {
   description: string | null
   recortes: MarketplaceRecorteGraphQL[]
   prompt: string | null
+  schedule: string | null
   likeCount: number
   followerCount: number
   cloneCount: number

--- a/src/lib/graphql/queries/push.ts
+++ b/src/lib/graphql/queries/push.ts
@@ -7,11 +7,9 @@
  *   POST /api/push/sync          → mutation syncPushSubscription
  *   GET  /api/push/filters-data  → query pushFiltersData
  *
- * Nota: `pushPreferences` e `pushFiltersData` não existem ainda como queries
- * no schema do `graphql-api` (apenas mutations). Caso a flag seja ativada
- * antes da Fase A correspondente, o facade cairá no fallback REST por
- * erro do client. Quando o schema for estendido, basta atualizar as
- * operations aqui — o facade já está pronto.
+ * As queries `pushPreferences` e `pushFiltersData` já existem no schema do
+ * `graphql-api` (validado pelo gate de codegen contra o SDL). O facade usa
+ * GraphQL quando a flag `graphql.push` está ON; senão, fallback REST.
  */
 
 import { gql } from '@urql/core'

--- a/src/lib/graphql/schema.graphql
+++ b/src/lib/graphql/schema.graphql
@@ -1,0 +1,756 @@
+type Agency {
+  code: String!
+  label: String!
+}
+
+"""
+Agency statistics with article count
+"""
+type AgencyStats {
+  name: String!
+  count: Int!
+}
+
+union AgentEvent =
+  | AgentEventThinking
+  | AgentEventToolCall
+  | AgentEventToolResult
+  | AgentEventSampleResult
+  | AgentEventAdjusting
+  | AgentEventDone
+  | AgentEventError
+
+type AgentEventAdjusting {
+  message: String!
+}
+
+type AgentEventDone {
+  recortes: [Recorte!]!
+  explanation: String!
+  description: String!
+  suggestedName: String!
+  iterations: Int!
+  converged: Boolean!
+}
+
+type AgentEventError {
+  message: String!
+}
+
+type AgentEventSampleResult {
+  payloadJson: String!
+}
+
+type AgentEventThinking {
+  message: String!
+}
+
+type AgentEventToolCall {
+  tool: String!
+  argsJson: String!
+}
+
+type AgentEventToolResult {
+  tool: String!
+  resultJson: String!
+}
+
+"""
+Key performance indicators for article analytics
+"""
+type AnalyticsKpis {
+  total: Int!
+  activeThemes: Int!
+  activeAgencies: Int!
+  dailyAverage: Float!
+}
+
+type Article {
+  uniqueId: String!
+  title: String!
+  url: String!
+  image: String
+  videoUrl: String
+  content: String
+  summary: String
+  subtitle: String
+  editorialLead: String
+  category: String
+  tags: [String!]!
+  agency: String
+  agencyName: String
+  publishedAt: DateTime
+  extractedAt: DateTime
+}
+
+input ArticleFilter {
+  agencies: [String!] = null
+  themes: [String!] = null
+  tags: [String!] = null
+  startDate: String = null
+  endDate: String = null
+}
+
+type ArticlesResult {
+  articles: [Article!]!
+  page: Int!
+  found: Int!
+}
+
+type BatchResult {
+  processed: Int!
+  failed: Int!
+}
+
+type BigQueryRecordType {
+  uniqueId: String!
+  title: String!
+  url: String!
+  imageUrl: String
+  videoUrl: String
+  content: String
+  summary: String
+  subtitle: String
+  editorialLead: String
+  category: String
+  tags: [String!]!
+  agencyKey: String
+  agencyName: String
+  publishedAt: DateTime
+  extractedAt: DateTime
+  themeL1Code: String
+  themeL1Label: String
+  themeL2Code: String
+  themeL2Label: String
+  themeL3Code: String
+  themeL3Label: String
+  mostSpecificThemeCode: String
+  mostSpecificThemeLabel: String
+  features: JSON
+  sentimentLabel: String
+  sentimentScore: Float
+  trendingScore: Float
+  wordCount: Int
+  hasImage: Boolean
+  hasVideo: Boolean
+  imageBroken: Boolean
+  readabilityFlesch: Float
+}
+
+type Clipping {
+  id: String!
+  name: String!
+  description: String
+  recortes: [Recorte!]!
+  prompt: String
+  schedule: String!
+  scheduleTime: String
+  nextRunAt: DateTime
+  startDate: DateTime
+  endDate: DateTime
+  extraEmails: [String!]!
+  includeHistory: Boolean!
+  deliveryChannels: DeliveryChannels
+  active: Boolean!
+  createdAt: DateTime
+  updatedAt: DateTime
+  authorUserId: String
+  publishedToMarketplace: Boolean!
+  marketplaceListingId: String
+
+  """
+  True se o usuário autenticado é o autor deste clipping.
+  """
+  isAuthor: Boolean!
+
+  """
+  Subscription do usuário autenticado para este clipping (None se não inscrito).
+  """
+  mySubscription: UserSubscription
+
+  """
+  Entregas historicas (releases) deste clipping. Ordenadas por createdAt desc. Apenas autor ou subscriber podem ver.
+  """
+  releases(limit: Int! = 20, before: DateTime = null): [Release!]!
+}
+
+input ClippingInput {
+  name: String!
+  schedule: String!
+  description: String = null
+  recortes: [RecorteInput!]! = []
+  prompt: String = null
+  scheduleTime: String = null
+  startDate: DateTime = null
+  endDate: DateTime = null
+  extraEmails: [String!] = null
+  includeHistory: Boolean = null
+  deliveryChannels: DeliveryChannelsInput = null
+}
+
+"""
+Daily article count
+"""
+type DailyCount {
+  date: String!
+  count: Int!
+}
+
+"""
+Date range filter specified as number of days from today
+"""
+input DateRange {
+  days: Int!
+}
+
+"""
+Date with time (isoformat)
+"""
+scalar DateTime
+
+type DeliveryChannels {
+  email: Boolean!
+  telegram: Boolean!
+  push: Boolean!
+  webhook: Boolean!
+}
+
+input DeliveryChannelsInput {
+  email: Boolean! = false
+  telegram: Boolean! = false
+  push: Boolean! = false
+  webhook: Boolean! = false
+}
+
+type EstimateResult {
+  totalEstimate: Int!
+}
+
+input FeatureUpsertInput {
+  uniqueId: String!
+  features: JSON!
+}
+
+type IntegrityCandidateType {
+  uniqueId: String!
+  url: String!
+  imageUrl: String
+  publishedAt: DateTime
+  integrity: JSON
+}
+
+"""
+The `JSON` scalar type represents JSON values as specified by [ECMA-404](https://ecma-international.org/wp-content/uploads/ECMA-404_2nd_edition_december_2017.pdf).
+"""
+scalar JSON
+  @specifiedBy(
+    url: "https://ecma-international.org/wp-content/uploads/ECMA-404_2nd_edition_december_2017.pdf"
+  )
+
+type MarketplaceListing {
+  id: String!
+  authorUserId: String!
+  authorDisplayName: String!
+  sourceClippingId: String!
+  name: String!
+  description: String
+  recortes: [MarketplaceRecorte!]!
+  prompt: String
+  schedule: String
+  likeCount: Int!
+  followerCount: Int!
+  cloneCount: Int!
+  publishedAt: DateTime
+  updatedAt: DateTime
+  active: Boolean!
+  hasLiked: Boolean
+  hasFollowed: Boolean
+}
+
+type MarketplaceListingsResult {
+  listings: [MarketplaceListing!]!
+  total: Int!
+}
+
+type MarketplaceRecorte {
+  id: String!
+  title: String!
+  themes: [String!]!
+  agencies: [String!]!
+  keywords: [String!]!
+}
+
+type Mutation {
+  """
+  Cria um novo clipping
+  """
+  createClipping(input: ClippingInput!): Clipping!
+
+  """
+  Atualiza um clipping existente
+  """
+  updateClipping(id: String!, input: ClippingInput!): Clipping!
+
+  """
+  Liga/desliga um clipping (campo `active`; somente o autor)
+  """
+  setClippingActive(id: String!, active: Boolean!): Clipping!
+
+  """
+  Deleta um clipping
+  """
+  deleteClipping(id: String!): Boolean!
+
+  """
+  Envia um clipping manualmente
+  """
+  sendClipping(id: String!): Boolean!
+
+  """
+  Inscreve o usuário autenticado em um clipping (role=subscriber)
+  """
+  subscribeToClipping(input: SubscribeInput!): UserSubscription!
+
+  """
+  Remove a inscrição do usuário em um clipping
+  """
+  unsubscribeFromClipping(clippingId: String!): Boolean!
+
+  """
+  Atualiza canais de entrega da inscrição do usuário
+  """
+  updateMySubscription(
+    clippingId: String!
+    channels: DeliveryChannelsInput!
+    extraEmails: [String!] = null
+    webhookUrl: String = null
+  ): UserSubscription
+
+  """
+  Publica um clipping no marketplace
+  """
+  publishToMarketplace(
+    clippingId: String!
+    input: PublishInput!
+  ): MarketplaceListing!
+
+  """
+  Remove um listing do marketplace (somente o dono)
+  """
+  unpublishFromMarketplace(listingId: String!): Boolean!
+
+  """
+  Curte/descurte um listing do marketplace
+  """
+  likeMarketplaceListing(listingId: String!): Boolean!
+
+  """
+  Segue/deixa de seguir um listing do marketplace
+  """
+  followMarketplaceListing(listingId: String!): Boolean!
+    @deprecated(
+      reason: "Use `subscribeToClipping(input)` passando `sourceClippingId` do listing. Esta mutation continua funcional para retro-compat e será removida em R1."
+    )
+
+  """
+  Clona um listing do marketplace para os clippings do usuario. Retorna o Clipping recem-criado (gap-fix pre-rollout: era Boolean! antes; portal B3 precisa do `id` para redirecionar para /minha-conta/clipping/[id]).
+  """
+  cloneMarketplaceListing(listingId: String!): Clipping!
+
+  """
+  Sync a push notification subscription
+  """
+  syncPushSubscription(subscription: PushSubscriptionInput!): Boolean!
+
+  """
+  Update push notification preferences
+  """
+  updatePushPreferences(preferences: PushPreferencesInput!): Boolean!
+
+  """
+  Upsert features for a news item (merges JSONB)
+  """
+  upsertFeatures(uniqueId: String!, features: JSON!): Boolean!
+
+  """
+  Batch upsert features for multiple news items
+  """
+  batchUpsertFeatures(items: [FeatureUpsertInput!]!): BatchResult!
+
+  """
+  Update a single field in a Typesense document
+  """
+  updateTypesenseField(
+    uniqueId: String!
+    field: String!
+    value: JSON!
+  ): Boolean!
+}
+
+type NewsRecordType {
+  uniqueId: String!
+  title: String!
+  url: String!
+  imageUrl: String
+  videoUrl: String
+  content: String
+  summary: String
+  subtitle: String
+  editorialLead: String
+  category: String
+  tags: [String!]!
+  agencyKey: String
+  agencyName: String
+  publishedAt: DateTime
+  extractedAt: DateTime
+  themeL1Code: String
+  themeL1Label: String
+  themeL2Code: String
+  themeL2Label: String
+  themeL3Code: String
+  themeL3Label: String
+  mostSpecificThemeCode: String
+  mostSpecificThemeLabel: String
+  features: JSON
+}
+
+input PublishInput {
+  name: String!
+  description: String = null
+}
+
+type PushFiltersData {
+  themes: [Theme!]!
+  agencies: [Agency!]!
+}
+
+type PushPreferences {
+  agencies: [String!]!
+}
+
+input PushPreferencesInput {
+  agencies: [String!]! = []
+  themes: [String!]! = []
+  enabled: Boolean! = true
+}
+
+input PushSubscriptionInput {
+  endpoint: String!
+  keysP256dh: String!
+  keysAuth: String!
+}
+
+type Query {
+  """
+  Verifica se a API está funcionando
+  """
+  ping: String!
+
+  """
+  Lista artigos com filtros e paginação
+  """
+  articles(
+    page: Int! = 1
+    limit: Int! = 10
+    filter: ArticleFilter = null
+  ): ArticlesResult!
+
+  """
+  Busca artigo por ID
+  """
+  article(uniqueId: String!): Article
+
+  """
+  Search articles with keyword or semantic search
+  """
+  search(
+    query: String!
+    filter: ArticleFilter = null
+    page: Int! = 1
+    semantic: Boolean! = false
+  ): ArticlesResult!
+
+  """
+  Get search suggestions for autocomplete
+  """
+  searchSuggestions(query: String!): [SearchSuggestion!]!
+
+  """
+  Lista de temas distintos extraidos das noticias
+  """
+  themes: [Theme!]!
+
+  """
+  Lista de orgaos distintos
+  """
+  agencies: [Agency!]!
+
+  """
+  Tags mais populares
+  """
+  popularTags(limit: Int = 20): [Tag!]!
+
+  """
+  Key performance indicators for the given date range
+  """
+  analyticsKpis(range: DateRange!): AnalyticsKpis!
+
+  """
+  Top themes by article count
+  """
+  topThemes(range: DateRange!, limit: Int! = 8): [ThemeStats!]!
+
+  """
+  Top agencies by article count
+  """
+  topAgencies(range: DateRange!, limit: Int! = 8): [AgencyStats!]!
+
+  """
+  Daily article counts for the given date range
+  """
+  articlesTimeline(range: DateRange!): [DailyCount!]!
+
+  """
+  Lista todos os clippings do usuario autenticado (autorados + inscritos)
+  """
+  clippings: [Clipping!]!
+
+  """
+  Busca um clipping por ID
+  """
+  clipping(id: String!): Clipping
+
+  """
+  Estima o numero de artigos para um clipping
+  """
+  clippingEstimate(
+    themes: [String!]! = []
+    agencies: [String!]! = []
+    keywords: [String!]! = []
+  ): EstimateResult!
+
+  """
+  Lista listings do marketplace com paginacao
+  """
+  marketplaceListings(page: Int! = 1): MarketplaceListingsResult!
+
+  """
+  Busca um listing do marketplace por ID
+  """
+  marketplaceListing(id: String!): MarketplaceListing
+
+  """
+  Preferencias de push notification do usuario autenticado
+  """
+  pushPreferences: PushPreferences!
+
+  """
+  Filtros disponiveis (temas e agencias) para o usuario escolher na UI de preferencias de push.
+  """
+  pushFiltersData: PushFiltersData!
+
+  """
+  Get available widget configuration options
+  """
+  widgetConfig: WidgetConfig!
+
+  """
+  Get articles for a widget
+  """
+  widgetArticles(
+    config: WidgetConfigInput!
+    page: Int! = 1
+  ): WidgetArticlesResult!
+
+  """
+  Fetch a single news record by unique_id
+  """
+  newsById(uniqueId: String!): NewsRecordType
+
+  """
+  Fetch a batch of news records by unique_ids
+  """
+  newsBatch(uniqueIds: [String!]!): [NewsRecordType!]!
+
+  """
+  Fetch a news record formatted for Typesense indexing
+  """
+  newsForTypesense(uniqueId: String!): TypesenseDocRecordType
+
+  """
+  Fetch a batch of news records for BigQuery export
+  """
+  newsBatchForBigquery(
+    startDate: String!
+    endDate: String!
+    batchSize: Int! = 100
+    cursor: String = null
+  ): [BigQueryRecordType!]!
+
+  """
+  Find articles similar to a given article using embeddings
+  """
+  similarArticles(
+    uniqueId: String!
+    threshold: Float! = 0.8
+    limit: Int! = 5
+  ): [SimilarArticleRecordType!]!
+
+  """
+  Fetch a batch of articles needing integrity checks
+  """
+  integrityBatch(batchSize: Int! = 50): [IntegrityCandidateType!]!
+}
+
+type Recorte {
+  id: String!
+  title: String!
+  themes: [String!]!
+  agencies: [String!]!
+  keywords: [String!]!
+}
+
+input RecorteInput {
+  title: String!
+  themes: [String!]! = []
+  agencies: [String!]! = []
+  keywords: [String!]! = []
+}
+
+type Release {
+  id: String!
+  clippingId: String!
+  clippingName: String!
+  digestHtml: String!
+  articlesCount: Int!
+  createdAt: DateTime
+  releaseUrl: String
+  refTime: DateTime
+  sinceHours: Int
+}
+
+type SearchSuggestion {
+  uniqueId: String!
+  title: String!
+}
+
+type SimilarArticleRecordType {
+  uniqueId: String!
+  similarity: Float!
+}
+
+input SubscribeInput {
+  clippingId: String!
+  deliveryChannels: DeliveryChannelsInput!
+  extraEmails: [String!] = null
+  webhookUrl: String = null
+}
+
+type Subscription {
+  """
+  Gera recortes em tempo real via agente LLM. Passthrough do SSE do worker clipping. Requer autenticacao.
+  """
+  generateRecortes(prompt: String!): AgentEvent!
+}
+
+enum SubscriptionRole {
+  AUTHOR
+  SUBSCRIBER
+}
+
+type Tag {
+  label: String!
+  count: Int!
+}
+
+type Theme {
+  code: String!
+  label: String!
+}
+
+"""
+Theme statistics with article count
+"""
+type ThemeStats {
+  label: String!
+  count: Int!
+}
+
+type TypesenseDocRecordType {
+  uniqueId: String!
+  title: String!
+  url: String!
+  imageUrl: String
+  videoUrl: String
+  content: String
+  summary: String
+  subtitle: String
+  editorialLead: String
+  category: String
+  tags: [String!]!
+  agencyKey: String
+  agencyName: String
+  publishedAt: DateTime
+  extractedAt: DateTime
+  themeL1Code: String
+  themeL1Label: String
+  themeL2Code: String
+  themeL2Label: String
+  themeL3Code: String
+  themeL3Label: String
+  mostSpecificThemeCode: String
+  mostSpecificThemeLabel: String
+  features: JSON
+  contentEmbedding: [Float!]
+  sentimentLabel: String
+  sentimentScore: Float
+  trendingScore: Float
+  wordCount: Int
+  hasImage: Boolean
+  hasVideo: Boolean
+  imageBroken: Boolean
+  readabilityFlesch: Float
+}
+
+type UserSubscription {
+  id: String!
+  clippingId: String!
+  userId: String!
+  role: SubscriptionRole!
+  deliveryChannels: DeliveryChannels!
+  extraEmails: [String!]!
+  webhookUrl: String
+  active: Boolean!
+  subscribedAt: DateTime
+}
+
+type WidgetArticlesResult {
+  articles: [Article!]!
+  pagination: WidgetPagination!
+}
+
+type WidgetConfig {
+  agencies: [String!]!
+  themes: [String!]!
+}
+
+input WidgetConfigInput {
+  agencies: [String!]! = []
+  themes: [String!]! = []
+  layout: WidgetLayout! = LIST
+  articlesPerPage: Int! = 10
+}
+
+enum WidgetLayout {
+  LIST
+  GRID_2
+  GRID_3
+  CAROUSEL
+}
+
+type WidgetPagination {
+  page: Int!
+  limit: Int!
+  total: Int!
+  hasMore: Boolean!
+}

--- a/src/services/clipping/graphql.ts
+++ b/src/services/clipping/graphql.ts
@@ -26,7 +26,9 @@ import {
   MY_CLIPPINGS_QUERY,
   type MyClippingsQueryData,
   SEND_CLIPPING_NOW_MUTATION,
+  SET_CLIPPING_ACTIVE_MUTATION,
   type SendClippingNowMutationData,
+  type SetClippingActiveMutationData,
   UPDATE_CLIPPING_MUTATION,
   UPDATE_MY_SUBSCRIPTION_MUTATION,
   type UpdateClippingMutationData,
@@ -267,6 +269,18 @@ export function createGraphQLClippingService(
       }
     },
 
+    async setClippingActive(id: string, active: boolean): Promise<void> {
+      const result = await client
+        .mutation<SetClippingActiveMutationData>(SET_CLIPPING_ACTIVE_MUTATION, {
+          id,
+          active,
+        })
+        .toPromise()
+      if (result.error) {
+        throw unwrapError(result.error, 'Falha ao alterar status do clipping')
+      }
+    },
+
     async estimate(recortes: Recorte[]): Promise<EstimateResult> {
       // O schema expõe `clippingEstimate(themes, agencies, keywords)` (estimativa
       // única). Montamos a estimativa por-recorte chamando uma vez por recorte
@@ -328,7 +342,7 @@ export function createGraphQLClippingService(
         digest: '',
         digestHtml: r.digestHtml,
         articlesCount: 0,
-        createdAt: r.publishedAt,
+        createdAt: r.createdAt,
         releaseUrl: r.releaseUrl ?? `/clipping/release/${r.id}`,
         refTime: r.refTime,
         sinceHours: r.sinceHours,

--- a/src/services/clipping/rest.ts
+++ b/src/services/clipping/rest.ts
@@ -90,6 +90,21 @@ export async function updateMySubscription(
   }
 }
 
+export async function setClippingActive(
+  id: string,
+  active: boolean,
+  fetchImpl: typeof fetch = fetch,
+): Promise<void> {
+  const res = await fetchImpl(`/api/clipping/${id}`, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ active }),
+  })
+  if (!res.ok) {
+    throw new Error(await readError(res, 'Falha ao alterar status do clipping'))
+  }
+}
+
 export async function deleteClipping(
   id: string,
   fetchImpl: typeof fetch = fetch,
@@ -153,6 +168,7 @@ export function createRestClippingService(
     listClippings: () => listClippings(fetchImpl),
     createClipping: (payload) => createClipping(payload, fetchImpl),
     updateClipping: (id, payload) => updateClipping(id, payload, fetchImpl),
+    setClippingActive: (id, active) => setClippingActive(id, active, fetchImpl),
     updateMySubscription: (clippingId, update) =>
       updateMySubscription(clippingId, update, fetchImpl),
     deleteClipping: (id) => deleteClipping(id, fetchImpl),

--- a/src/services/clipping/types.ts
+++ b/src/services/clipping/types.ts
@@ -44,6 +44,9 @@ export interface ClippingService {
   /** Atualiza um clipping existente (apenas conteúdo — autoria). */
   updateClipping(id: string, payload: ClippingPayload): Promise<Clipping>
 
+  /** Liga/desliga um clipping (campo `active`; somente o autor). */
+  setClippingActive(id: string, active: boolean): Promise<void>
+
   /** Atualiza somente os canais de entrega do usuário atual no clipping. */
   updateMySubscription(
     clippingId: string,

--- a/src/services/marketplace/graphql.ts
+++ b/src/services/marketplace/graphql.ts
@@ -63,6 +63,7 @@ function mapListing(node: MarketplaceListingGraphQL): MarketplaceListing {
       keywords: r.keywords ?? [],
     })),
     prompt: node.prompt ?? '',
+    schedule: node.schedule ?? undefined,
     likeCount: node.likeCount,
     followerCount: node.followerCount,
     cloneCount: node.cloneCount,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,5 +23,5 @@
     }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", "src/lib/graphql/__generated__"]
 }


### PR DESCRIPTION
## Objetivo

Fechar as **refatorações R1 esquecidas** encontradas na auditoria do portal (drift de schema / migração incompleta / cobertura) + instalar a validação automática que impede a classe de drift de voltar.

> ⚠️ **Depende do PR graphql-api [#8](https://github.com/destaquesgovbr/graphql-api/pull/8)** (`schedule` + `setClippingActive`) **deployado antes** — senão as ops novas viram drift em runtime. Mergear na ordem: graphql-api#8 → deploy → este PR.

## Mudanças

### R1-01 — Gate anti-drift no codegen (causa-raiz)
O glob `documents` apontava para `*.graphql` (zero arquivos) → o codegen rodava vazio e **nada validava operações × schema**. Foi assim que o campo `iteration` inexistente passou. Agora: `documents=src/**/*.{ts,tsx}`, `schema` = snapshot commitado do SDL (`src/lib/graphql/schema.graphql`), e `pnpm graphql:codegen` roda no CI (falha em divergência). **O gate já pegou um 2º drift:** `CLIPPING_RELEASES_QUERY` pedia `Release.publishedAt` (inexistente) → alinhado a `createdAt`.

### R1-05 — Consome `schedule` no marketplace
`schedule` adicionado ao fragment + `mapListing`; capa/horário voltam a aparecer com `graphql.marketplace` ON (antes sumiam silenciosamente). *(`coverImageUrl` fora de escopo — nunca é gravado.)*

### R1-03 — Toggle via GraphQL
`handleToggleActive` roteado pelo facade (`setClippingActive`) em vez de PATCH REST direto.

### R1-04 — Cobertura E2E de unpublish
Teste explícito de unpublish (antes só no teardown com `console.warn`), incluindo o **caso do clipping-fonte excluído** — trava a regressão do bug do graphql-api.

### R1-02 — SSR resolve flags GraphQL (lista de clippings)
Helper `resolveGraphQLFlagServer` + `flags.ts` server-safe; a página de lista hidrata via a fachada GraphQL quando a flag está ON (com fallback Firestore), fazendo o canário exercitar os resolvers de leitura. **Escopo:** só a lista de clippings — galeria (semântica de paginação) e páginas de detalhe (entrelaçadas) ficam para o §9/portal#237.

### minor
Comentário desatualizado em `push.ts` (queries já existem). *(o de `widgets.ts` estava correto — mantido.)*

## Validação local

- `pnpm graphql:codegen` — **verde** (gate ops×SDL).
- `next build` — **passa** (boundaries RSC do R1-02 ok).
- `pnpm exec vitest run` — **530 passed**.
- `pnpm lint` / `tsc --noEmit` — sem novos erros nos arquivos tocados.

## Test plan pós-merge → deploy-staging

E2E serial (`--workers=1`): confirmar o novo teste de unpublish verde e a lista de clippings carregando via GraphQL com a flag ON. (Comportamento do R1-02 só fecha contra staging.)
