### PR TITLE
fix: despublicar clipping via facade GraphQL (rota REST stale)

### DIFF
--- a/e2e/graphql/marketplace.authed.spec.ts
+++ b/e2e/graphql/marketplace.authed.spec.ts
@@ -171,6 +171,56 @@ test.describe('Marketplace via GraphQL', () => {
     expect(after.marketplaceListing).toBeNull()
   })
 
+  test('unpublish pela UI de "Meus Clippings" desativa o listing no backend', async ({
+    page,
+  }) => {
+    // Regressão (bug R1): o botão "Despublicar" do ClippingCard ainda chamava a
+    // rota REST stale `/api/clippings/public/[listingId]` (DELETE), que escrevia
+    // na subcoleção antiga `users/{uid}/clippings/{id}` → batch falhava com
+    // "No document to update" → 500 → o listing nunca era desativado. Após a
+    // migração para o facade GraphQL (`unpublishFromMarketplace`), o fluxo
+    // browser → portal → graphql-api deve funcionar ponta-a-ponta.
+    //
+    // Diferente do teste acima (que chama o fixture direto), este dirige a UI
+    // real — é o caminho que a regressão escapou (e2e só batia no fixture).
+
+    // Sanidade: o listing do beforeEach está ativo.
+    const before = await client.execute<{
+      marketplaceListing: { id: string } | null
+    }>(LISTING_QUERY, { id: listing.id })
+    expect(before.marketplaceListing?.id).toBe(listing.id)
+
+    await page.goto('/minha-conta/clipping')
+    await waitForAuthReady(page)
+
+    // Localiza o card do clipping-fonte (publicado no beforeEach).
+    const card = page
+      .locator('[data-testid="clipping-card"]')
+      .filter({ hasText: clipping.name })
+    await expect(card).toBeVisible({ timeout: 15_000 })
+
+    // Abre o dropdown de ações do card.
+    await card.locator('button[aria-haspopup="menu"]').first().click()
+
+    // Fluxo de 2 passos: "Despublicar" revela "Confirmar despublicação".
+    await page.getByRole('menuitem', { name: /^despublicar$/i }).click()
+    await page.getByRole('menuitem', { name: /confirmar despublica/i }).click()
+
+    // Valida no backend (não na UI): `get_marketplace_listing` filtra
+    // `active=false` → retorna null quando o listing foi desativado.
+    await expect
+      .poll(
+        async () => {
+          const r = await client.execute<{
+            marketplaceListing: { id: string } | null
+          }>(LISTING_QUERY, { id: listing.id })
+          return r.marketplaceListing
+        },
+        { timeout: 10_000 },
+      )
+      .toBeNull()
+  })
+
   test('unpublish funciona mesmo com o clipping-fonte já excluído', async () => {
     // Regressão (bug pego em staging): publicar → excluir o clipping → unpublish.
     // Antes, o unpublish fazia `update` no clipping inexistente e o batch

--- a/src/components/clipping/ClippingCard.tsx
+++ b/src/components/clipping/ClippingCard.tsx
@@ -39,6 +39,7 @@ import {
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu'
 import { cronToHumanReadable } from '@/lib/cron-utils'
+import { useMarketplaceService } from '@/services/marketplace'
 import type { Clipping } from '@/types/clipping'
 
 type SendStatus = 'idle' | 'loading' | 'success' | 'error'
@@ -71,6 +72,7 @@ export function ClippingCard({
   const [confirmUnpublish, setConfirmUnpublish] = useState(false)
   const [isUnpublishing, setIsUnpublishing] = useState(false)
   const [publishDialogOpen, setPublishDialogOpen] = useState(false)
+  const marketplaceService = useMarketplaceService()
 
   const isPublished =
     clipping.publishedToMarketplace && clipping.marketplaceListingId
@@ -104,15 +106,9 @@ export function ClippingCard({
     setIsUnpublishing(true)
 
     try {
-      const res = await fetch(
-        `/api/clippings/public/${clipping.marketplaceListingId}`,
-        { method: 'DELETE' },
-      )
-
-      if (!res.ok) {
-        const data = await res.json().catch(() => null)
-        throw new Error(data?.error ?? 'Erro ao despublicar')
-      }
+      // GraphQL é o único caminho: roteia para a mutation
+      // `unpublishFromMarketplace` (lança em caso de erro).
+      await marketplaceService.unpublish(clipping.marketplaceListingId)
 
       toast.success('Clipping removido do marketplace')
       setConfirmUnpublish(false)

--- a/src/components/clipping/__tests__/ClippingCard.test.tsx
+++ b/src/components/clipping/__tests__/ClippingCard.test.tsx
@@ -9,22 +9,23 @@
  */
 
 import { screen } from '@testing-library/react'
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { render } from '@/__tests__/test-utils'
 import type { Clipping } from '@/types/clipping'
 import { ClippingCard } from '../ClippingCard'
 
-vi.mock('@/lib/feature-flags', () => ({
-  GRAPHQL_FLAGS: {
-    CLIPPINGS: 'graphql.clippings',
-    MARKETPLACE: 'graphql.marketplace',
-    AGENT: 'graphql.agent',
-    PUSH: 'graphql.push',
-    WIDGETS: 'graphql.widgets',
-  },
-  useFeatureFlag: (_key: string, defaultValue: boolean) => defaultValue,
-  getFeatureFlag: (_key: string, defaultValue: boolean) => defaultValue,
+// Mock do facade de marketplace: o ClippingCard usa `useMarketplaceService()`
+// para despublicar via GraphQL (mutation `unpublishFromMarketplace`).
+const unpublishMock = vi.fn().mockResolvedValue(undefined)
+vi.mock('@/services/marketplace', () => ({
+  useMarketplaceService: () => ({
+    unpublish: unpublishMock,
+  }),
 }))
+
+beforeEach(() => {
+  unpublishMock.mockClear()
+})
 
 function makeClipping(overrides: Partial<Clipping> = {}): Clipping {
   return {
@@ -162,5 +163,41 @@ describe('ClippingCard — read-only para não-autor', () => {
     expect(screen.getByText('Editar')).toBeInTheDocument()
     expect(screen.getByText('Excluir')).toBeInTheDocument()
     expect(screen.getByText('Desativar')).toBeInTheDocument()
+  })
+})
+
+describe('ClippingCard — despublicar via GraphQL', () => {
+  function makePublishedClipping(): Clipping {
+    return makeClipping({
+      publishedToMarketplace: true,
+      marketplaceListingId: 'listing-123',
+    })
+  }
+
+  it('chama marketplaceService.unpublish(listingId) ao confirmar despublicação', async () => {
+    const clipping = makePublishedClipping()
+    const onUnpublished = vi.fn()
+
+    const { user } = render(
+      <ClippingCard
+        clipping={clipping}
+        onDelete={vi.fn()}
+        onToggleActive={vi.fn()}
+        onSend={vi.fn().mockResolvedValue(undefined)}
+        onUnpublished={onUnpublished}
+      />,
+    )
+
+    // Abre o menu de ações.
+    await user.click(screen.getByRole('button'))
+
+    // Primeiro clique em "Despublicar" pede confirmação.
+    await user.click(screen.getByText('Despublicar'))
+
+    // Confirma a despublicação.
+    await user.click(screen.getByText(/confirmar despublica/i))
+
+    expect(unpublishMock).toHaveBeenCalledWith('listing-123')
+    expect(onUnpublished).toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
## Bug
Na UI "Meus Clippings", **despublicar um clipping falha** (500 "Erro ao despublicar"). `ClippingCard.handleUnpublish` não foi migrado no refactor R1 e ainda chamava `DELETE /api/clippings/public/{listingId}`; esse handler escreve em `users/{uid}/clippings/{id}` (**subcoleção antiga**), mas os clippings são **top-level `clippings/{id}`** → `batch.update` em doc inexistente derruba o batch inteiro → 500.

## Fix (portal-only)
- `ClippingCard` passa a usar `useMarketplaceService().unpublish(listingId)` → mutation `unpublishFromMarketplace` (caminho top-level correto + guard de existência + checagem de autoria; já deployada no graphql-api). Sem mudança no graphql-api.
- Mantida a guarda/toast/estado; o facade lança em erro (tratado no catch).

## Validação local (graphql-api + portal locais)
- `e2e/graphql` serial (`--workers=1`): **18 passed** — inclui o novo teste que dirige o botão "Despublicar" na UI e confere o backend.
- `pnpm exec vitest run`: **502 passed** (ClippingCard test atualizado p/ mockar o facade).
- `pnpm lint` limpo · `tsc` sem novos erros · `pnpm graphql:codegen` sem drift.

Stale paths notados (não corrigidos aqui, p/ triagem): `ReleaseList`/`[id]/page.tsx` usando `/api/clipping(s)/.../releases`.