### PR TITLE
fix: releases (loadMore) do dono via facade GraphQL + corrige articlesCount

### DIFF
--- a/e2e/graphql/clippings.authed.spec.ts
+++ b/e2e/graphql/clippings.authed.spec.ts
@@ -167,4 +167,33 @@ test.describe('Clippings — CRUD via GraphQL', () => {
     }>(`{ clippings { id } }`)
     expect(data.clippings.find((c) => c.id === seeded.id)).toBeFalsy()
   })
+
+  test('página de detalhe do autor renderiza a seção de edições (releases via facade GraphQL)', async ({
+    page,
+  }) => {
+    // Migração R1: a página de detalhe do clipping (área logada) passou a
+    // carregar releases pelo facade GraphQL (`clipping(id) { releases }`) em vez
+    // da rota REST `/api/clipping/[id]/releases`. Aqui exercitamos o caminho
+    // real browser → portal → graphql-api: a página tem que renderizar sem erro
+    // e mostrar a seção "Edições". Clipping recém-criado não tem releases (não
+    // há fixture que as gere — vêm do clipping-worker), então validamos o
+    // empty-state, que prova que a query enriquecida (com `articlesCount`) é
+    // aceita pelo schema real e o componente monta corretamente.
+    const seeded = await makeClipping(client, { suffix: 'releases_detail' })
+
+    await page.goto(`/minha-conta/clipping/${seeded.id}`)
+
+    // Título do clipping (a página carregou e o usuário é o autor → 200, não 404).
+    await expect(page.getByRole('heading', { name: seeded.name })).toBeVisible({
+      timeout: 15_000,
+    })
+
+    // Seção de edições presente. Sem releases, o ReleaseList mostra o
+    // empty-state — sinal de que a query GraphQL retornou (sem erro de schema).
+    await expect(page.getByText('Nenhuma edição publicada ainda')).toBeVisible({
+      timeout: 10_000,
+    })
+
+    await removeClipping(client, seeded.id)
+  })
 })

--- a/src/app/(logged-in)/minha-conta/clipping/[id]/page.tsx
+++ b/src/app/(logged-in)/minha-conta/clipping/[id]/page.tsx
@@ -81,7 +81,7 @@ export default async function ClippingDetailPage({ params }: Props) {
       perRecorteEstimates={estimation.perRecorte}
       releases={releases}
       hasMoreReleases={hasMore}
-      releasesApiPath={`/api/clipping/${clippingId}/releases`}
+      releasesClippingId={clippingId}
       releasesPagePath={
         isPublished
           ? `/clippings/${clipping.marketplaceListingId}/releases`

--- a/src/components/clipping/ClippingDetailView.tsx
+++ b/src/components/clipping/ClippingDetailView.tsx
@@ -22,6 +22,11 @@ type Props = {
   hasMoreReleases: boolean
   releasesPagePath?: string
   releasesApiPath?: string
+  /**
+   * ID do clipping para carregar mais edições via facade GraphQL (contexto do
+   * autor). Tem prioridade sobre `releasesApiPath`.
+   */
+  releasesClippingId?: string
 
   actions?: React.ReactNode
   feedLinks?: { rss: string; json: string }
@@ -41,6 +46,7 @@ export function ClippingDetailView({
   hasMoreReleases,
   releasesPagePath,
   releasesApiPath,
+  releasesClippingId,
   actions,
   feedLinks,
 }: Props) {
@@ -87,6 +93,7 @@ export function ClippingDetailView({
           listingId=""
           initialReleases={releases}
           hasMore={hasMoreReleases}
+          clippingId={releasesClippingId}
           releasesPagePath={releasesPagePath}
           releasesApiPath={releasesApiPath}
         />

--- a/src/components/clipping/ReleaseList.tsx
+++ b/src/components/clipping/ReleaseList.tsx
@@ -13,6 +13,7 @@ import { useCallback, useState } from 'react'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { useClippingService } from '@/services/clipping'
 
 type ReleaseItem = {
   id: string
@@ -29,6 +30,13 @@ type ReleaseListProps = {
   listingId: string
   initialReleases: ReleaseItem[]
   hasMore: boolean
+  /**
+   * ID do clipping do qual carregar mais edições via facade GraphQL
+   * (`clipping(id) { releases }`). Usado no contexto do AUTOR (área logada),
+   * onde o usuário tem acesso às releases. Quando presente, tem prioridade
+   * sobre `releasesApiPath` (caminho REST legado).
+   */
+  clippingId?: string
   releasesApiPath?: string
   releasesPagePath?: string
   showAllCards?: boolean
@@ -80,10 +88,12 @@ export function ReleaseList({
   listingId,
   initialReleases,
   hasMore: initialHasMore,
+  clippingId,
   releasesApiPath,
   releasesPagePath,
   showAllCards = false,
 }: ReleaseListProps) {
+  const clippingService = useClippingService()
   const [releases, setReleases] = useState<ReleaseItem[]>(initialReleases)
   const [hasMore, setHasMore] = useState(initialHasMore)
   const [page, setPage] = useState(1)
@@ -92,6 +102,30 @@ export function ReleaseList({
   const loadMore = useCallback(async () => {
     setLoading(true)
     try {
+      // Contexto do AUTOR: paginação por cursor via facade GraphQL
+      // (`clipping(id) { releases(before:) }`). O cursor `before` é o
+      // `refTime`/`createdAt` da release mais antiga já carregada.
+      if (clippingId) {
+        const oldest = releases[releases.length - 1]
+        const before = oldest?.refTime ?? oldest?.createdAt ?? undefined
+        const data = await clippingService.listReleases(clippingId, { before })
+        const incoming: ReleaseItem[] = data.releases.map((r) => ({
+          id: r.id,
+          clippingName: r.clippingName,
+          articlesCount: r.articlesCount,
+          createdAt: r.createdAt,
+          releaseUrl: r.releaseUrl,
+          refTime: r.refTime,
+          sinceHours: r.sinceHours,
+        }))
+        setReleases((prev) => [...prev, ...incoming])
+        setHasMore(data.hasMore)
+        return
+      }
+
+      // Contexto PÚBLICO (listing): caminho REST legado por página.
+      // GraphQL não expõe releases de um listing público para visitantes não
+      // inscritos (ver gap de schema em graphql-api).
       const nextPage = page + 1
       const basePath =
         releasesApiPath ?? `/api/clippings/public/${listingId}/releases`
@@ -105,7 +139,7 @@ export function ReleaseList({
     } finally {
       setLoading(false)
     }
-  }, [listingId, page, releasesApiPath])
+  }, [clippingId, clippingService, listingId, page, releases, releasesApiPath])
 
   if (releases.length === 0) {
     return (

--- a/src/components/clipping/__tests__/ReleaseList.test.tsx
+++ b/src/components/clipping/__tests__/ReleaseList.test.tsx
@@ -3,9 +3,18 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { render } from '@/__tests__/test-utils'
 import { ReleaseList } from '../ReleaseList'
 
-// Mock fetch globally
+// Mock fetch globally (caminho REST público legado)
 const mockFetch = vi.fn()
 global.fetch = mockFetch
+
+// Mock do facade de clipping: o contexto do AUTOR usa
+// `useClippingService().listReleases(clippingId, { before })` em vez de REST.
+const listReleasesMock = vi.fn()
+vi.mock('@/services/clipping', () => ({
+  useClippingService: () => ({
+    listReleases: listReleasesMock,
+  }),
+}))
 
 function makeRelease(id: string, overrides: Record<string, unknown> = {}) {
   return {
@@ -194,6 +203,86 @@ describe('ReleaseList', () => {
       expect(mockFetch).toHaveBeenCalledWith(
         '/api/clippings/public/listing-1/releases?page=3',
       )
+    })
+  })
+
+  describe('contexto do autor (facade GraphQL)', () => {
+    it('carrega mais edições via facade quando clippingId é fornecido (sem REST)', async () => {
+      listReleasesMock.mockResolvedValueOnce({
+        releases: [
+          {
+            id: 'r2',
+            clippingName: 'Meio Ambiente',
+            articlesCount: 7,
+            createdAt: '2025-02-20T10:00:00.000Z',
+            releaseUrl: 'https://example.com/releases/r2',
+            refTime: null,
+            sinceHours: null,
+          },
+        ],
+        hasMore: false,
+      })
+
+      const { user } = render(
+        <ReleaseList
+          listingId=""
+          clippingId="clip-1"
+          initialReleases={[
+            makeRelease('r1', { createdAt: '2025-03-10T10:00:00.000Z' }),
+          ]}
+          hasMore={true}
+        />,
+      )
+
+      await user.click(screen.getByRole('button', { name: /Ver mais/i }))
+
+      // Usa o facade com cursor `before` (createdAt da release mais antiga).
+      await waitFor(() => {
+        expect(listReleasesMock).toHaveBeenCalledWith('clip-1', {
+          before: '2025-03-10T10:00:00.000Z',
+        })
+      })
+
+      // Nova edição renderiza e o REST não é tocado.
+      await waitFor(() => {
+        expect(screen.getByText(/20 de fevereiro de 2025/)).toBeInTheDocument()
+      })
+      expect(mockFetch).not.toHaveBeenCalled()
+
+      // Botão some após a última página.
+      expect(
+        screen.queryByRole('button', { name: /Ver mais/i }),
+      ).not.toBeInTheDocument()
+    })
+
+    it('usa refTime como cursor quando presente', async () => {
+      listReleasesMock.mockResolvedValueOnce({
+        releases: [],
+        hasMore: false,
+      })
+
+      const { user } = render(
+        <ReleaseList
+          listingId=""
+          clippingId="clip-1"
+          initialReleases={[
+            makeRelease('r1', {
+              createdAt: '2025-03-10T10:00:00.000Z',
+              refTime: '2025-03-09T06:00:00.000Z',
+            }),
+          ]}
+          hasMore={true}
+        />,
+      )
+
+      await user.click(screen.getByRole('button', { name: /Ver mais/i }))
+
+      await waitFor(() => {
+        expect(listReleasesMock).toHaveBeenCalledWith('clip-1', {
+          before: '2025-03-09T06:00:00.000Z',
+        })
+      })
+      expect(mockFetch).not.toHaveBeenCalled()
     })
   })
 })

--- a/src/lib/graphql/queries/clippings.ts
+++ b/src/lib/graphql/queries/clippings.ts
@@ -98,6 +98,7 @@ export const CLIPPING_RELEASES_QUERY = gql`
         clippingId
         clippingName
         digestHtml
+        articlesCount
         releaseUrl
         refTime
         sinceHours
@@ -257,6 +258,7 @@ export interface ReleaseGraphQL {
   clippingId: string
   clippingName: string
   digestHtml: string
+  articlesCount: number
   releaseUrl: string | null
   refTime: string | null
   sinceHours: number | null

--- a/src/services/clipping/__tests__/graphql.test.ts
+++ b/src/services/clipping/__tests__/graphql.test.ts
@@ -362,6 +362,7 @@ describe('graphqlClippingService — listReleases', () => {
       clippingId: 'c1',
       clippingName: 'Meu Clipping',
       digestHtml: `<p>${id}</p>`,
+      articlesCount: 9,
       releaseUrl: `/clipping/release/${id}`,
       refTime: '2026-05-26T08:00:00Z',
       sinceHours: 24,
@@ -380,8 +381,25 @@ describe('graphqlClippingService — listReleases', () => {
     const result = await service.listReleases('c1', { limit: 2 })
 
     expect(queries[0].query).toContain('ClippingReleases')
+    expect(queries[0].query).toContain('articlesCount')
     expect(result.releases).toHaveLength(2)
     expect(result.hasMore).toBe(true)
     expect(result.releases[0].digestHtml).toBe('<p>rel-1</p>')
+    // articlesCount agora vem do schema (antes era hardcoded 0).
+    expect(result.releases[0].articlesCount).toBe(9)
+  })
+
+  it('passa o cursor `before` para a query quando fornecido', async () => {
+    const { client, queries } = makeClientStub({
+      onQuery: () => ({ clipping: { id: 'c1', releases: [] } }),
+    })
+
+    const service = createGraphQLClippingService(client)
+    await service.listReleases('c1', { before: '2026-05-26T08:00:00Z' })
+
+    expect(queries[0].vars).toMatchObject({
+      id: 'c1',
+      before: '2026-05-26T08:00:00Z',
+    })
   })
 })

--- a/src/services/clipping/graphql.ts
+++ b/src/services/clipping/graphql.ts
@@ -319,13 +319,14 @@ export function createGraphQLClippingService(
 
     async listReleases(
       clippingId: string,
-      opts: { page?: number; limit?: number } = {},
+      opts: { limit?: number; before?: string } = {},
     ): Promise<ReleasesPage> {
       const limit = opts.limit ?? 10
       const result = await client
         .query<ClippingReleasesQueryData>(CLIPPING_RELEASES_QUERY, {
           id: clippingId,
           limit: limit + 1,
+          before: opts.before ?? null,
         })
         .toPromise()
       if (result.error) {
@@ -341,7 +342,7 @@ export function createGraphQLClippingService(
         clippingName: r.clippingName,
         digest: '',
         digestHtml: r.digestHtml,
-        articlesCount: 0,
+        articlesCount: r.articlesCount,
         createdAt: r.createdAt,
         releaseUrl: r.releaseUrl ?? `/clipping/release/${r.id}`,
         refTime: r.refTime,

--- a/src/services/clipping/types.ts
+++ b/src/services/clipping/types.ts
@@ -62,9 +62,16 @@ export interface ClippingService {
   /** Dispara o envio imediato do clipping (catchup). */
   sendNow(clippingId: string): Promise<void>
 
-  /** Lista releases (edições enviadas) de um clipping. */
+  /**
+   * Lista releases (edições enviadas) de um clipping.
+   *
+   * Paginação por cursor `before` (DateTime ISO): o schema GraphQL retorna as
+   * releases mais recentes primeiro e usa `before` para buscar as anteriores a
+   * um dado instante (em vez de `page`/offset). Para a próxima página, passe o
+   * `refTime` (ou `createdAt`) da última release recebida.
+   */
   listReleases(
     clippingId: string,
-    opts?: { page?: number; limit?: number },
+    opts?: { limit?: number; before?: string },
   ): Promise<ReleasesPage>
 }


### PR DESCRIPTION
## Contexto
Investigação dos caminhos REST de releases que sobraram do refactor R1. **Boa notícia:** as rotas REST de releases NÃO estavam stale — leem a coleção top-level `releases` correta (diferente do bug de unpublish). Não há quebra de dado.

A única chamada REST client-side é o `loadMore` ("Ver mais") do `ReleaseList`; o render inicial é SSR e correto.

## Migrado (contexto do dono)
- `ReleaseList` loadMore do clipping do **dono** → `useClippingService().listReleases(clippingId, { before })` (cursor `before: DateTime`), sem REST.
- **Fix real:** `articlesCount` vinha hardcoded `0` no facade; agora seleciona/mapeia o valor real do schema.
- `ClippingDetailView` encaminha `releasesClippingId`; a página do dono não referencia mais a rota REST.

## NÃO migrado (gap de schema — follow-up)
O `loadMore` da página **pública** de releases (visitante anônimo) fica no REST: `MarketplaceListing` não tem `releases`, e `clipping(id){releases}` exige auth + (autor/assinante). Migrar exige mudança no graphql-api (campo/queries públicos de releases respeitando `active`). Não improvisado.

## Validação local (graphql-api + portal locais)
- `e2e/graphql` serial (`--workers=1`): **19 passed** (+ teste do detalhe do dono renderizando "Edições" via facade).
- `pnpm exec vitest run`: **505 passed** (+3 testes). `lint` limpo · `tsc` sem novos erros · `graphql:codegen` sem drift.

Rotas REST não deletadas (out of scope; feeds/outros consumidores). Feeds RSS/JSON permanecem REST de propósito.