### PR TITLE
fix: releases públicas (loadMore) via facade GraphQL

### DIFF
--- a/e2e/graphql/marketplace.authed.spec.ts
+++ b/e2e/graphql/marketplace.authed.spec.ts
@@ -83,6 +83,30 @@ test.describe('Marketplace via GraphQL', () => {
     ).toBeVisible()
   })
 
+  test('página pública de edições do listing renderiza (releases via facade GraphQL)', async ({
+    page,
+  }) => {
+    // Migração R1: o loadMore das edições PÚBLICAS do `ReleaseList` passou da
+    // rota REST `/api/clippings/public/[listingId]/releases` para o campo
+    // GraphQL `marketplaceListing(id) { releases }` (conteúdo público de um
+    // listing ativo, exposto pelo graphql-api). Aqui dirigimos a página pública
+    // de edições no browser — caminho real browser → portal → graphql-api.
+    // O listing do beforeEach é recém-publicado (clipping sem releases geradas
+    // pelo worker), então validamos o empty-state, que prova que a query
+    // pública (com `articlesCount`) é aceita pelo schema real e a página monta.
+    await page.goto(`/clippings/${listing.id}/releases`)
+
+    // Título da página de edições (a página carregou — listing ativo).
+    await expect(page.getByRole('heading', { name: /edições —/i })).toBeVisible(
+      { timeout: 15_000 },
+    )
+
+    // Sem releases, o ReleaseList mostra o empty-state.
+    await expect(page.getByText('Nenhuma edição publicada ainda')).toBeVisible({
+      timeout: 10_000,
+    })
+  })
+
   test('like incrementa o contador no backend', async ({ page }) => {
     // Listing fresco: hasLiked começa false; clicar "Curtir" deve levá-lo a true.
     await page.goto(`/clippings/${listing.id}`)

--- a/src/app/(public)/clippings/[listingId]/page.tsx
+++ b/src/app/(public)/clippings/[listingId]/page.tsx
@@ -107,6 +107,7 @@ export default async function ListingDetailPage({ params }: Props) {
       perRecorteEstimates={estimation.perRecorte}
       releases={releases}
       hasMoreReleases={hasMore}
+      releasesListingId={listing.id}
       releasesPagePath={`/clippings/${listing.id}/releases`}
       actions={
         <ListingActions

--- a/src/components/clipping/ClippingDetailView.tsx
+++ b/src/components/clipping/ClippingDetailView.tsx
@@ -21,12 +21,14 @@ type Props = {
   releases: ReleaseItem[]
   hasMoreReleases: boolean
   releasesPagePath?: string
-  releasesApiPath?: string
   /**
    * ID do clipping para carregar mais edições via facade GraphQL (contexto do
-   * autor). Tem prioridade sobre `releasesApiPath`.
+   * autor). Quando ausente, o `ReleaseList` usa o caminho público por
+   * `releasesListingId` (`marketplaceListing.releases`).
    */
   releasesClippingId?: string
+  /** ID do listing para o caminho público de "Ver mais" (contexto marketplace). */
+  releasesListingId?: string
 
   actions?: React.ReactNode
   feedLinks?: { rss: string; json: string }
@@ -45,8 +47,8 @@ export function ClippingDetailView({
   releases,
   hasMoreReleases,
   releasesPagePath,
-  releasesApiPath,
   releasesClippingId,
+  releasesListingId,
   actions,
   feedLinks,
 }: Props) {
@@ -90,12 +92,11 @@ export function ClippingDetailView({
       {/* Releases */}
       <section className="mt-8">
         <ReleaseList
-          listingId=""
+          listingId={releasesListingId ?? ''}
           initialReleases={releases}
           hasMore={hasMoreReleases}
           clippingId={releasesClippingId}
           releasesPagePath={releasesPagePath}
-          releasesApiPath={releasesApiPath}
         />
       </section>
 

--- a/src/components/clipping/ReleaseList.tsx
+++ b/src/components/clipping/ReleaseList.tsx
@@ -14,6 +14,7 @@ import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { useClippingService } from '@/services/clipping'
+import { useMarketplaceService } from '@/services/marketplace'
 
 type ReleaseItem = {
   id: string
@@ -34,10 +35,9 @@ type ReleaseListProps = {
    * ID do clipping do qual carregar mais edições via facade GraphQL
    * (`clipping(id) { releases }`). Usado no contexto do AUTOR (área logada),
    * onde o usuário tem acesso às releases. Quando presente, tem prioridade
-   * sobre `releasesApiPath` (caminho REST legado).
+   * sobre o caminho público (por `listingId`).
    */
   clippingId?: string
-  releasesApiPath?: string
   releasesPagePath?: string
   showAllCards?: boolean
 }
@@ -89,57 +89,46 @@ export function ReleaseList({
   initialReleases,
   hasMore: initialHasMore,
   clippingId,
-  releasesApiPath,
   releasesPagePath,
   showAllCards = false,
 }: ReleaseListProps) {
   const clippingService = useClippingService()
+  const marketplaceService = useMarketplaceService()
   const [releases, setReleases] = useState<ReleaseItem[]>(initialReleases)
   const [hasMore, setHasMore] = useState(initialHasMore)
-  const [page, setPage] = useState(1)
   const [loading, setLoading] = useState(false)
 
   const loadMore = useCallback(async () => {
     setLoading(true)
     try {
-      // Contexto do AUTOR: paginação por cursor via facade GraphQL
-      // (`clipping(id) { releases(before:) }`). O cursor `before` é o
-      // `refTime`/`createdAt` da release mais antiga já carregada.
-      if (clippingId) {
-        const oldest = releases[releases.length - 1]
-        const before = oldest?.refTime ?? oldest?.createdAt ?? undefined
-        const data = await clippingService.listReleases(clippingId, { before })
-        const incoming: ReleaseItem[] = data.releases.map((r) => ({
-          id: r.id,
-          clippingName: r.clippingName,
-          articlesCount: r.articlesCount,
-          createdAt: r.createdAt,
-          releaseUrl: r.releaseUrl,
-          refTime: r.refTime,
-          sinceHours: r.sinceHours,
-        }))
-        setReleases((prev) => [...prev, ...incoming])
-        setHasMore(data.hasMore)
-        return
-      }
+      // Cursor `before`: o `refTime`/`createdAt` da release mais antiga já
+      // carregada (ambos os contextos paginam por cursor via GraphQL).
+      const oldest = releases[releases.length - 1]
+      const before = oldest?.refTime ?? oldest?.createdAt ?? undefined
 
-      // Contexto PÚBLICO (listing): caminho REST legado por página.
-      // GraphQL não expõe releases de um listing público para visitantes não
-      // inscritos (ver gap de schema em graphql-api).
-      const nextPage = page + 1
-      const basePath =
-        releasesApiPath ?? `/api/clippings/public/${listingId}/releases`
-      const response = await fetch(`${basePath}?page=${nextPage}`)
-      if (response.ok) {
-        const data = await response.json()
-        setReleases((prev) => [...prev, ...data.releases])
-        setHasMore(data.hasMore)
-        setPage(nextPage)
-      }
+      // Contexto do AUTOR: `clipping(id) { releases(before:) }` (área logada,
+      // exige acesso de autor/assinante).
+      // Contexto PÚBLICO (listing): `marketplaceListing(id) { releases(before:) }`
+      // (conteúdo público de um listing ativo, sem auth).
+      const data = clippingId
+        ? await clippingService.listReleases(clippingId, { before })
+        : await marketplaceService.listListingReleases(listingId, { before })
+
+      const incoming: ReleaseItem[] = data.releases.map((r) => ({
+        id: r.id,
+        clippingName: r.clippingName,
+        articlesCount: r.articlesCount,
+        createdAt: r.createdAt,
+        releaseUrl: r.releaseUrl,
+        refTime: r.refTime,
+        sinceHours: r.sinceHours,
+      }))
+      setReleases((prev) => [...prev, ...incoming])
+      setHasMore(data.hasMore)
     } finally {
       setLoading(false)
     }
-  }, [clippingId, clippingService, listingId, page, releases, releasesApiPath])
+  }, [clippingId, clippingService, marketplaceService, listingId, releases])
 
   if (releases.length === 0) {
     return (

--- a/src/components/clipping/__tests__/ReleaseList.test.tsx
+++ b/src/components/clipping/__tests__/ReleaseList.test.tsx
@@ -3,16 +3,25 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { render } from '@/__tests__/test-utils'
 import { ReleaseList } from '../ReleaseList'
 
-// Mock fetch globally (caminho REST público legado)
+// Sentinela: nenhum loadMore deve tocar REST (ambos os contextos usam o facade).
 const mockFetch = vi.fn()
 global.fetch = mockFetch
 
 // Mock do facade de clipping: o contexto do AUTOR usa
-// `useClippingService().listReleases(clippingId, { before })` em vez de REST.
+// `useClippingService().listReleases(clippingId, { before })`.
 const listReleasesMock = vi.fn()
 vi.mock('@/services/clipping', () => ({
   useClippingService: () => ({
     listReleases: listReleasesMock,
+  }),
+}))
+
+// Mock do facade de marketplace: o contexto PÚBLICO usa
+// `useMarketplaceService().listListingReleases(listingId, { before })`.
+const listListingReleasesMock = vi.fn()
+vi.mock('@/services/marketplace', () => ({
+  useMarketplaceService: () => ({
+    listListingReleases: listListingReleasesMock,
   }),
 }))
 
@@ -118,91 +127,110 @@ describe('ReleaseList', () => {
     ).not.toBeInTheDocument()
   })
 
-  it('fetches more releases on "Ver mais" click', async () => {
-    const newRelease = makeRelease('r2', {
-      createdAt: '2025-02-20T10:00:00.000Z',
-    })
-    mockFetch.mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({
-        releases: [newRelease],
+  describe('contexto público (facade marketplace)', () => {
+    it('carrega mais edições do listing via facade ao clicar "Ver mais" (sem REST)', async () => {
+      listListingReleasesMock.mockResolvedValueOnce({
+        releases: [
+          makeRelease('r2', {
+            createdAt: '2025-02-20T10:00:00.000Z',
+            refTime: null,
+            sinceHours: null,
+          }),
+        ],
         hasMore: false,
-      }),
-    })
-
-    const { user } = render(
-      <ReleaseList
-        listingId="listing-1"
-        initialReleases={[makeRelease('r1')]}
-        hasMore={true}
-      />,
-    )
-
-    await user.click(screen.getByRole('button', { name: /Ver mais/i }))
-
-    await waitFor(() => {
-      expect(mockFetch).toHaveBeenCalledWith(
-        '/api/clippings/public/listing-1/releases?page=2',
-      )
-    })
-
-    await waitFor(() => {
-      expect(screen.getByText(/20 de fevereiro de 2025/)).toBeInTheDocument()
-    })
-
-    // Button should be hidden after last page
-    expect(
-      screen.queryByRole('button', { name: /Ver mais/i }),
-    ).not.toBeInTheDocument()
-  })
-
-  it('appends releases and increments page on subsequent loads', async () => {
-    mockFetch
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({
-          releases: [makeRelease('r2')],
-          hasMore: true,
-        }),
-      })
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({
-          releases: [makeRelease('r3')],
-          hasMore: false,
-        }),
       })
 
-    const { user } = render(
-      <ReleaseList
-        listingId="listing-1"
-        initialReleases={[makeRelease('r1')]}
-        hasMore={true}
-      />,
-    )
-
-    // First load more
-    await user.click(screen.getByRole('button', { name: /Ver mais/i }))
-
-    await waitFor(() => {
-      expect(mockFetch).toHaveBeenCalledWith(
-        '/api/clippings/public/listing-1/releases?page=2',
+      const { user } = render(
+        <ReleaseList
+          listingId="listing-1"
+          initialReleases={[
+            makeRelease('r1', { createdAt: '2025-03-10T10:00:00.000Z' }),
+          ]}
+          hasMore={true}
+        />,
       )
-    })
 
-    // Second load more
-    await waitFor(() => {
+      await user.click(screen.getByRole('button', { name: /Ver mais/i }))
+
+      // Usa o facade público com cursor `before` (createdAt da mais antiga).
+      await waitFor(() => {
+        expect(listListingReleasesMock).toHaveBeenCalledWith('listing-1', {
+          before: '2025-03-10T10:00:00.000Z',
+        })
+      })
+
+      await waitFor(() => {
+        expect(screen.getByText(/20 de fevereiro de 2025/)).toBeInTheDocument()
+      })
+      // REST nunca é tocado.
+      expect(mockFetch).not.toHaveBeenCalled()
+
+      // Botão some após a última página.
       expect(
-        screen.getByRole('button', { name: /Ver mais/i }),
-      ).toBeInTheDocument()
+        screen.queryByRole('button', { name: /Ver mais/i }),
+      ).not.toBeInTheDocument()
     })
 
-    await user.click(screen.getByRole('button', { name: /Ver mais/i }))
+    it('pagina por cursor em cargas subsequentes (avança o before)', async () => {
+      listListingReleasesMock
+        .mockResolvedValueOnce({
+          releases: [
+            makeRelease('r2', {
+              createdAt: '2025-02-20T10:00:00.000Z',
+              refTime: null,
+            }),
+          ],
+          hasMore: true,
+        })
+        .mockResolvedValueOnce({
+          releases: [
+            makeRelease('r3', {
+              createdAt: '2025-01-10T10:00:00.000Z',
+              refTime: null,
+            }),
+          ],
+          hasMore: false,
+        })
 
-    await waitFor(() => {
-      expect(mockFetch).toHaveBeenCalledWith(
-        '/api/clippings/public/listing-1/releases?page=3',
+      const { user } = render(
+        <ReleaseList
+          listingId="listing-1"
+          initialReleases={[
+            makeRelease('r1', { createdAt: '2025-03-10T10:00:00.000Z' }),
+          ]}
+          hasMore={true}
+        />,
       )
+
+      // Primeira carga: cursor = createdAt da r1.
+      await user.click(screen.getByRole('button', { name: /Ver mais/i }))
+      await waitFor(() => {
+        expect(listListingReleasesMock).toHaveBeenNthCalledWith(
+          1,
+          'listing-1',
+          {
+            before: '2025-03-10T10:00:00.000Z',
+          },
+        )
+      })
+
+      // Segunda carga: cursor avança para o createdAt da r2 (mais antiga agora).
+      await waitFor(() => {
+        expect(
+          screen.getByRole('button', { name: /Ver mais/i }),
+        ).toBeInTheDocument()
+      })
+      await user.click(screen.getByRole('button', { name: /Ver mais/i }))
+      await waitFor(() => {
+        expect(listListingReleasesMock).toHaveBeenNthCalledWith(
+          2,
+          'listing-1',
+          {
+            before: '2025-02-20T10:00:00.000Z',
+          },
+        )
+      })
+      expect(mockFetch).not.toHaveBeenCalled()
     })
   })
 

--- a/src/lib/graphql/queries/marketplace.ts
+++ b/src/lib/graphql/queries/marketplace.ts
@@ -77,6 +77,38 @@ export const MARKETPLACE_LISTING_QUERY = gql`
   }
 `
 
+/**
+ * Lista as releases (edições) PÚBLICAS de um listing ativo do marketplace.
+ *
+ * Caminho público (sem auth): o campo `releases` vive em `MarketplaceListing`
+ * no graphql-api e só expõe edições de um listing `active`. Substitui a rota
+ * REST `GET /api/clippings/public/[listingId]/releases` no loadMore do
+ * `ReleaseList` (contexto público). Paginação por cursor `before: DateTime`,
+ * espelhando `clipping.releases`.
+ */
+export const MARKETPLACE_LISTING_RELEASES_QUERY = gql`
+  query MarketplaceListingReleases(
+    $id: String!
+    $limit: Int
+    $before: DateTime
+  ) {
+    marketplaceListing(id: $id) {
+      id
+      releases(limit: $limit, before: $before) {
+        id
+        clippingId
+        clippingName
+        digestHtml
+        articlesCount
+        releaseUrl
+        refTime
+        sinceHours
+        createdAt
+      }
+    }
+  }
+`
+
 // ---------- Mutations ----------
 
 /** Publica clipping no marketplace. */
@@ -186,6 +218,26 @@ export interface MarketplaceListingsQueryData {
 
 export interface MarketplaceListingQueryData {
   marketplaceListing: MarketplaceListingGraphQL | null
+}
+
+/** Shape de uma release retornada pelo campo `MarketplaceListing.releases`. */
+export interface MarketplaceReleaseGraphQL {
+  id: string
+  clippingId: string
+  clippingName: string
+  digestHtml: string
+  articlesCount: number
+  releaseUrl: string | null
+  refTime: string | null
+  sinceHours: number | null
+  createdAt: string
+}
+
+export interface MarketplaceListingReleasesQueryData {
+  marketplaceListing: {
+    id: string
+    releases: MarketplaceReleaseGraphQL[]
+  } | null
 }
 
 export interface PublishInputGraphQL {

--- a/src/lib/graphql/schema.graphql
+++ b/src/lib/graphql/schema.graphql
@@ -265,6 +265,11 @@ type MarketplaceListing {
   active: Boolean!
   hasLiked: Boolean
   hasFollowed: Boolean
+
+  """
+  Entregas historicas (releases) deste listing publico. Ordenadas por createdAt desc. Conteudo PUBLICO: nao exige autenticacao, pois um listing ativo ja e publico. Listing inativo/despublicado nunca expoe releases (retorna lista vazia).
+  """
+  releases(limit: Int! = 10, before: DateTime = null): [Release!]!
 }
 
 type MarketplaceListingsResult {

--- a/src/services/marketplace/__tests__/graphql.test.ts
+++ b/src/services/marketplace/__tests__/graphql.test.ts
@@ -157,6 +157,62 @@ describe('createGraphQLMarketplaceService', () => {
     expect(detail).toBeNull()
   })
 
+  it('listListingReleases: dispara MarketplaceListingReleases(id) e mapeia releases públicas', async () => {
+    const release = (id: string) => ({
+      id,
+      clippingId: 'src-1',
+      clippingName: 'Top Economia',
+      digestHtml: `<p>${id}</p>`,
+      articlesCount: 8,
+      releaseUrl: `/clipping/release/${id}`,
+      refTime: '2026-05-26T08:00:00Z',
+      sinceHours: 24,
+      createdAt: '2026-05-26T08:01:00Z',
+    })
+    const { client, queries } = makeClientStub({
+      onQuery: () => ({
+        marketplaceListing: {
+          id: 'l-1',
+          releases: [release('rel-1'), release('rel-2'), release('rel-3')],
+        },
+      }),
+    })
+
+    const service = createGraphQLMarketplaceService(client)
+    const result = await service.listListingReleases('l-1', { limit: 2 })
+
+    expect(queries[0].query).toContain('MarketplaceListingReleases')
+    expect(queries[0].query).toContain('articlesCount')
+    // pede limit+1 para detectar hasMore.
+    expect(queries[0].vars).toMatchObject({ id: 'l-1', limit: 3, before: null })
+    expect(result.releases).toHaveLength(2)
+    expect(result.hasMore).toBe(true)
+    expect(result.releases[0].articlesCount).toBe(8)
+    expect(result.releases[0].digestHtml).toBe('<p>rel-1</p>')
+  })
+
+  it('listListingReleases: listing inativo/inexistente (null) → sem releases', async () => {
+    const { client } = makeClientStub({
+      onQuery: () => ({ marketplaceListing: null }),
+    })
+    const service = createGraphQLMarketplaceService(client)
+    const result = await service.listListingReleases('inativo')
+    expect(result.releases).toEqual([])
+    expect(result.hasMore).toBe(false)
+  })
+
+  it('listListingReleases: encaminha o cursor before', async () => {
+    const { client, queries } = makeClientStub({
+      onQuery: () => ({ marketplaceListing: { id: 'l-1', releases: [] } }),
+    })
+    const service = createGraphQLMarketplaceService(client)
+    await service.listListingReleases('l-1', { before: '2026-05-26T08:00:00Z' })
+    expect(queries[0].vars).toMatchObject({
+      id: 'l-1',
+      before: '2026-05-26T08:00:00Z',
+    })
+  })
+
   it('test_publishToMarketplace_via_graphql: chama PublishToMarketplace', async () => {
     const { client, mutations } = makeClientStub({
       onMutation: () => ({

--- a/src/services/marketplace/graphql.ts
+++ b/src/services/marketplace/graphql.ts
@@ -18,9 +18,11 @@ import {
   LIKE_MARKETPLACE_LISTING_MUTATION,
   type LikeMarketplaceListingMutationData,
   MARKETPLACE_LISTING_QUERY,
+  MARKETPLACE_LISTING_RELEASES_QUERY,
   MARKETPLACE_LISTINGS_QUERY,
   type MarketplaceListingGraphQL,
   type MarketplaceListingQueryData,
+  type MarketplaceListingReleasesQueryData,
   type MarketplaceListingsQueryData,
   PUBLISH_TO_MARKETPLACE_MUTATION,
   type PublishToMarketplaceMutationData,
@@ -31,7 +33,7 @@ import {
   type UnpublishFromMarketplaceMutationData,
   type UnsubscribeFromClippingMutationData,
 } from '@/lib/graphql/queries/marketplace'
-import type { MarketplaceListing } from '@/types/clipping'
+import type { MarketplaceListing, Release } from '@/types/clipping'
 import type {
   CloneResult,
   LikeResult,
@@ -41,6 +43,7 @@ import type {
   MarketplaceService,
   PublishPayload,
   PublishResult,
+  ReleasesPage,
   SubscribeListingPayload,
   SubscribeListingResult,
 } from './types'
@@ -153,6 +156,40 @@ export function createGraphQLMarketplaceService(
       if (!node) return null
       sourceClippingByListing.set(node.id, node.sourceClippingId)
       return mapListingDetail(node)
+    },
+
+    async listListingReleases(
+      listingId: string,
+      opts: { limit?: number; before?: string } = {},
+    ): Promise<ReleasesPage> {
+      const limit = opts.limit ?? 10
+      const result = await client
+        .query<MarketplaceListingReleasesQueryData>(
+          MARKETPLACE_LISTING_RELEASES_QUERY,
+          { id: listingId, limit: limit + 1, before: opts.before ?? null },
+        )
+        .toPromise()
+      if (result.error) {
+        throw unwrapError(result.error, 'Erro ao buscar edições')
+      }
+      // Listing inativo/inexistente → `marketplaceListing` é null → sem releases.
+      const nodes = result.data?.marketplaceListing?.releases ?? []
+      const hasMore = nodes.length > limit
+      const visible = hasMore ? nodes.slice(0, limit) : nodes
+      const releases: Release[] = visible.map((r) => ({
+        id: r.id,
+        clippingId: r.clippingId,
+        userId: '', // não exposto pelo schema GraphQL (conteúdo público)
+        clippingName: r.clippingName,
+        digest: '',
+        digestHtml: r.digestHtml,
+        articlesCount: r.articlesCount,
+        createdAt: r.createdAt,
+        releaseUrl: r.releaseUrl ?? `/clipping/release/${r.id}`,
+        refTime: r.refTime,
+        sinceHours: r.sinceHours,
+      }))
+      return { releases, hasMore }
     },
 
     async publish(payload: PublishPayload): Promise<PublishResult> {

--- a/src/services/marketplace/types.ts
+++ b/src/services/marketplace/types.ts
@@ -11,11 +11,20 @@
  * transport é GraphQL.
  */
 
-import type { DeliveryChannels, MarketplaceListing } from '@/types/clipping'
+import type {
+  DeliveryChannels,
+  MarketplaceListing,
+  Release,
+} from '@/types/clipping'
 
 export interface ListingsPage {
   listings: MarketplaceListing[]
   total: number
+}
+
+export interface ReleasesPage {
+  releases: Release[]
+  hasMore: boolean
 }
 
 export interface ListingsQuery {
@@ -71,6 +80,19 @@ export interface MarketplaceService {
 
   /** Carrega um único listing. */
   getListing(listingId: string): Promise<ListingDetail | null>
+
+  /**
+   * Lista as releases (edições) PÚBLICAS de um listing ativo.
+   *
+   * Caminho público sem auth — usa o campo `MarketplaceListing.releases` do
+   * graphql-api (só expõe releases de listing `active`). Paginação por cursor
+   * `before` (DateTime ISO): para a próxima página, passe o `refTime`/
+   * `createdAt` da release mais antiga já recebida.
+   */
+  listListingReleases(
+    listingId: string,
+    opts?: { limit?: number; before?: string },
+  ): Promise<ReleasesPage>
 
   /** Publica um clipping no marketplace. */
   publish(payload: PublishPayload): Promise<PublishResult>


### PR DESCRIPTION
Fecha o último caminho REST client-side da UI: o `loadMore` ("Ver mais") da página **pública** de edições do listing. Depende do campo público `MarketplaceListing.releases` (graphql-api #10, já deployado).

- `loadMore` público do `ReleaseList` → `useMarketplaceService().listListingReleases(listingId, { before })` (cursor), sem REST. Contexto do dono (#246) inalterado.
- Snapshot SDL (`src/lib/graphql/schema.graphql`) sincronizado com o graphql-api (gate de codegen passa, sem drift).
- Nova query + método no facade (`listListingReleases`: cursor `before`, `articlesCount`, `hasMore` via limit+1).
- `ClippingDetailView`/página pública passam o `listingId` real; removidos `releasesApiPath`/`page` mortos.

## Validação local (graphql-api + portal locais)
- `e2e/graphql` serial (`--workers=1`): **19 passed** (+ teste da página pública de edições via facade).
- `pnpm exec vitest run`: **508 passed**. `graphql:codegen` sem drift · `lint` (arquivos tocados limpos) · `tsc` sem novos erros.

Rotas REST não deletadas (out of scope). Feeds RSS/JSON permanecem REST de propósito.