### PR TITLE
feature: SSR das features (clipping/marketplace) via GraphQL — Fase 1B

### DIFF
--- a/src/app/(logged-in)/minha-conta/clipping/[id]/editar/page.tsx
+++ b/src/app/(logged-in)/minha-conta/clipping/[id]/editar/page.tsx
@@ -1,7 +1,8 @@
 import { auth } from '@/auth'
 import { getAgenciesList } from '@/data/agencies-utils'
 import { getThemesWithHierarchy } from '@/data/themes-utils'
-import { getFirestoreDb } from '@/lib/firebase-admin'
+import { createSSRClient } from '@/lib/graphql/client'
+import { getHasTelegram } from '@/lib/graphql/user'
 import { EditarClippingClient } from './EditarClippingClient'
 
 interface Props {
@@ -18,18 +19,8 @@ export default async function EditarClippingPage({ params }: Props) {
 
   let hasTelegram = false
   if (session?.user?.id) {
-    try {
-      const db = getFirestoreDb()
-      const doc = await db
-        .collection('users')
-        .doc(session.user.id)
-        .collection('telegramLink')
-        .doc('account')
-        .get()
-      hasTelegram = doc.exists
-    } catch {
-      // non-fatal — show as unlinked
-    }
+    const ssrClient = createSSRClient(async () => session.accessToken ?? null)
+    hasTelegram = await getHasTelegram(ssrClient)
   }
 
   return (

--- a/src/app/(logged-in)/minha-conta/clipping/novo/page.tsx
+++ b/src/app/(logged-in)/minha-conta/clipping/novo/page.tsx
@@ -1,7 +1,8 @@
 import { auth } from '@/auth'
 import { getAgenciesList } from '@/data/agencies-utils'
 import { getThemesWithHierarchy } from '@/data/themes-utils'
-import { getFirestoreDb } from '@/lib/firebase-admin'
+import { createSSRClient } from '@/lib/graphql/client'
+import { getHasTelegram } from '@/lib/graphql/user'
 import { NovoClippingClient } from './NovoClippingClient'
 
 export default async function NovoClippingPage() {
@@ -13,18 +14,8 @@ export default async function NovoClippingPage() {
 
   let hasTelegram = false
   if (session?.user?.id) {
-    try {
-      const db = getFirestoreDb()
-      const doc = await db
-        .collection('users')
-        .doc(session.user.id)
-        .collection('telegramLink')
-        .doc('account')
-        .get()
-      hasTelegram = doc.exists
-    } catch {
-      // non-fatal — show as unlinked
-    }
+    const ssrClient = createSSRClient(async () => session.accessToken ?? null)
+    hasTelegram = await getHasTelegram(ssrClient)
   }
 
   return (

--- a/src/app/(logged-in)/minha-conta/clipping/page.tsx
+++ b/src/app/(logged-in)/minha-conta/clipping/page.tsx
@@ -6,7 +6,7 @@ import { getThemesWithHierarchy } from '@/data/themes-utils'
 import { createSSRClient } from '@/lib/graphql/client'
 import { getHasTelegram } from '@/lib/graphql/user'
 import { createGraphQLClippingService } from '@/services/clipping/graphql'
-import { getMarketplaceService } from '@/services/marketplace'
+import { createGraphQLMarketplaceService } from '@/services/marketplace/graphql'
 import type { Clipping } from '@/types/clipping'
 import { ClippingListClient } from './ClippingListClient'
 
@@ -36,7 +36,7 @@ export default async function ClippingPage() {
       getThemesWithHierarchy(),
       getAgenciesList(),
       userId
-        ? getMarketplaceService(ssrClient).listFollowedListings()
+        ? createGraphQLMarketplaceService(ssrClient).listFollowedListings()
         : Promise.resolve([]),
       userId ? getHasTelegram(ssrClient) : Promise.resolve(false),
     ],

--- a/src/app/(logged-in)/minha-conta/clipping/page.tsx
+++ b/src/app/(logged-in)/minha-conta/clipping/page.tsx
@@ -1,15 +1,13 @@
 import Link from 'next/link'
 import { auth } from '@/auth'
-import {
-  FollowCard,
-  type FollowedListing,
-} from '@/components/marketplace/FollowCard'
+import { FollowCard } from '@/components/marketplace/FollowCard'
 import { getAgenciesList } from '@/data/agencies-utils'
 import { getThemesWithHierarchy } from '@/data/themes-utils'
-import { getFirestoreDb } from '@/lib/firebase-admin'
 import { createSSRClient } from '@/lib/graphql/client'
+import { getHasTelegram } from '@/lib/graphql/user'
 import { createGraphQLClippingService } from '@/services/clipping/graphql'
-import type { Clipping, MarketplaceListing } from '@/types/clipping'
+import { getMarketplaceService } from '@/services/marketplace'
+import type { Clipping } from '@/types/clipping'
 import { ClippingListClient } from './ClippingListClient'
 
 export async function getClippings(): Promise<Clipping[]> {
@@ -27,89 +25,20 @@ export async function getClippings(): Promise<Clipping[]> {
   }
 }
 
-async function getFollows(userId: string): Promise<FollowedListing[]> {
-  try {
-    const db = getFirestoreDb()
-
-    // Query subscriptions where user is a subscriber
-    const subsSnap = await db
-      .collection('subscriptions')
-      .where('userId', '==', userId)
-      .where('role', '==', 'subscriber')
-      .where('active', '==', true)
-      .get()
-
-    if (subsSnap.empty) return []
-
-    // Get the clipping IDs and look up their marketplace listings
-    const follows = await Promise.all(
-      subsSnap.docs.map(async (subDoc) => {
-        const subData = subDoc.data()
-        const clippingId = subData.clippingId
-
-        // Find the marketplace listing for this clipping
-        const listingsSnap = await db
-          .collection('marketplace')
-          .where('sourceClippingId', '==', clippingId)
-          .where('active', '==', true)
-          .limit(1)
-          .get()
-
-        if (listingsSnap.empty) return null
-
-        const listingDoc = listingsSnap.docs[0]
-        const listingData = listingDoc.data()
-
-        return {
-          listingId: listingDoc.id,
-          listing: {
-            id: listingDoc.id,
-            ...listingData,
-            publishedAt:
-              listingData.publishedAt?.toDate?.()?.toISOString?.() ?? '',
-            updatedAt: listingData.updatedAt?.toDate?.()?.toISOString?.() ?? '',
-          } as MarketplaceListing,
-          deliveryChannels: subData.deliveryChannels,
-          extraEmails: subData.extraEmails ?? [],
-          webhookUrl: subData.webhookUrl ?? '',
-          followedAt: subData.subscribedAt?.toDate?.()?.toISOString?.() ?? '',
-        } satisfies FollowedListing
-      }),
-    )
-
-    return follows.filter(Boolean) as FollowedListing[]
-  } catch (error) {
-    console.error('Error reading follows:', error)
-    return []
-  }
-}
-
-async function getHasTelegram(userId: string): Promise<boolean> {
-  try {
-    const db = getFirestoreDb()
-    const tgDoc = await db
-      .collection('users')
-      .doc(userId)
-      .collection('telegramLink')
-      .doc('account')
-      .get()
-    return tgDoc.exists
-  } catch {
-    return false
-  }
-}
-
 export default async function ClippingPage() {
   const session = await auth()
   const userId = session?.user?.id
+  const ssrClient = createSSRClient(async () => session?.accessToken ?? null)
 
   const [clippings, themes, agencies, follows, hasTelegram] = await Promise.all(
     [
       getClippings(),
       getThemesWithHierarchy(),
       getAgenciesList(),
-      userId ? getFollows(userId) : Promise.resolve([]),
-      userId ? getHasTelegram(userId) : Promise.resolve(false),
+      userId
+        ? getMarketplaceService(ssrClient).listFollowedListings()
+        : Promise.resolve([]),
+      userId ? getHasTelegram(ssrClient) : Promise.resolve(false),
     ],
   )
   const themeMap = Object.fromEntries(themes.map((t) => [t.key, t.name]))

--- a/src/app/(public)/clippings/[listingId]/page.tsx
+++ b/src/app/(public)/clippings/[listingId]/page.tsx
@@ -3,10 +3,10 @@ import { auth } from '@/auth'
 import { ClippingDetailView } from '@/components/clipping/ClippingDetailView'
 import { ListingActions } from '@/components/marketplace/ListingActions'
 import { estimateTotalCount } from '@/lib/estimate-recorte-count'
-import { getFirestoreDb } from '@/lib/firebase-admin'
+import { createSSRClient } from '@/lib/graphql/client'
+import { getHasTelegram } from '@/lib/graphql/user'
 import { resolveRecorteLabels } from '@/lib/recorte-utils'
-import { fetchReleasesForClipping } from '@/lib/release-utils'
-import type { MarketplaceListing } from '@/types/clipping'
+import { getMarketplaceService } from '@/services/marketplace'
 
 export const revalidate = 600
 
@@ -17,15 +17,16 @@ interface Props {
 export async function generateMetadata({ params }: Props) {
   const { listingId } = await params
   try {
-    const db = getFirestoreDb()
-    const snap = await db.collection('marketplace').doc(listingId).get()
-    if (!snap.exists || !snap.data()?.active) {
+    // Caminho público (sem token) — só precisamos dos metadados.
+    const listing = await getMarketplaceService(createSSRClient()).getListing(
+      listingId,
+    )
+    if (!listing || !listing.active) {
       return { title: 'Listing não encontrado — DestaquesGovBr' }
     }
-    const data = snap.data()!
     return {
-      title: `${data.name} — Marketplace — DestaquesGovBr`,
-      description: data.shortDescription ?? data.description,
+      title: `${listing.name} — Marketplace — DestaquesGovBr`,
+      description: listing.description,
     }
   } catch {
     return { title: 'Marketplace — DestaquesGovBr' }
@@ -34,65 +35,46 @@ export async function generateMetadata({ params }: Props) {
 
 export default async function ListingDetailPage({ params }: Props) {
   const { listingId } = await params
-  const db = getFirestoreDb()
-
-  const snap = await db.collection('marketplace').doc(listingId).get()
-  if (!snap.exists || !snap.data()?.active) notFound()
-
-  const data = snap.data()!
-  const listing: MarketplaceListing = {
-    id: snap.id,
-    ...data,
-    publishedAt: data.publishedAt?.toDate?.()?.toISOString?.() ?? '',
-    updatedAt: data.updatedAt?.toDate?.()?.toISOString?.() ?? '',
-  } as MarketplaceListing
-
-  // User state (optional)
-  let userFollows = false
-  let userHasLiked = false
-  let hasTelegram = false
-
   const session = await auth()
-  if (session?.user?.id) {
-    const userId = session.user.id
-    const [likeSnap, followerSnap] = await Promise.all([
-      db
-        .collection('marketplace')
-        .doc(listingId)
-        .collection('likes')
-        .doc(userId)
-        .get(),
-      db
-        .collection('subscriptions')
-        .where('clippingId', '==', listing.sourceClippingId)
-        .where('userId', '==', userId)
-        .where('role', '==', 'subscriber')
-        .limit(1)
-        .get(),
-    ])
-    userHasLiked = likeSnap.exists
-    userFollows = !followerSnap.empty
-    try {
-      const tgDoc = await db
-        .collection('users')
-        .doc(userId)
-        .collection('telegramLink')
-        .doc('account')
-        .get()
-      hasTelegram = tgDoc.exists
-    } catch {}
-  }
+
+  // SSR client com token (se logado) → `hasLiked`/`hasFollowed` resolvidos pelo
+  // schema; público sem token continua funcionando (flags vêm null → false).
+  const client = createSSRClient(async () => session?.accessToken ?? null)
+  const service = getMarketplaceService(client)
+
+  const listing = await service.getListing(listingId)
+  if (!listing || !listing.active) notFound()
+
+  const userHasLiked = listing.userHasLiked ?? false
+  const userFollows = listing.userFollows ?? false
+
+  // Flag de Telegram só faz sentido para usuário logado.
+  const hasTelegram = session?.user?.id ? await getHasTelegram(client) : false
 
   // Shared data
-  const [resolvedRecortes, { releases, hasMore }, estimation] =
-    await Promise.all([
-      resolveRecorteLabels(listing.recortes),
-      fetchReleasesForClipping(listing.sourceClippingId, listing.name),
-      estimateTotalCount(listing.recortes).catch(() => ({
-        total: 0,
-        perRecorte: [],
-      })),
-    ])
+  const [resolvedRecortes, releasesPage, estimation] = await Promise.all([
+    resolveRecorteLabels(listing.recortes),
+    // Caminho PÚBLICO: `MarketplaceListing.releases` (público para listing
+    // ativo). NÃO usamos `clipping.releases` (gated a autor/assinante →
+    // UNAUTHENTICATED para anônimo). O preview vem no campo `digest` do Release.
+    service.listListingReleases(listingId, { limit: 10 }),
+    estimateTotalCount(listing.recortes).catch(() => ({
+      total: 0,
+      perRecorte: [],
+    })),
+  ])
+
+  const releases = releasesPage.releases.map((r) => ({
+    id: r.id,
+    clippingName: r.clippingName || listing.name,
+    articlesCount: r.articlesCount,
+    createdAt: r.createdAt,
+    releaseUrl: r.releaseUrl || `/clipping/release/${r.id}`,
+    refTime: r.refTime ?? null,
+    sinceHours: r.sinceHours ?? null,
+    digestPreview: r.digest || undefined,
+  }))
+  const hasMore = releasesPage.hasMore
 
   return (
     <ClippingDetailView

--- a/src/app/(public)/clippings/[listingId]/page.tsx
+++ b/src/app/(public)/clippings/[listingId]/page.tsx
@@ -6,7 +6,7 @@ import { estimateTotalCount } from '@/lib/estimate-recorte-count'
 import { createSSRClient } from '@/lib/graphql/client'
 import { getHasTelegram } from '@/lib/graphql/user'
 import { resolveRecorteLabels } from '@/lib/recorte-utils'
-import { getMarketplaceService } from '@/services/marketplace'
+import { createGraphQLMarketplaceService } from '@/services/marketplace/graphql'
 
 export const revalidate = 600
 
@@ -18,9 +18,9 @@ export async function generateMetadata({ params }: Props) {
   const { listingId } = await params
   try {
     // Caminho público (sem token) — só precisamos dos metadados.
-    const listing = await getMarketplaceService(createSSRClient()).getListing(
-      listingId,
-    )
+    const listing = await createGraphQLMarketplaceService(
+      createSSRClient(),
+    ).getListing(listingId)
     if (!listing || !listing.active) {
       return { title: 'Listing não encontrado — DestaquesGovBr' }
     }
@@ -40,7 +40,7 @@ export default async function ListingDetailPage({ params }: Props) {
   // SSR client com token (se logado) → `hasLiked`/`hasFollowed` resolvidos pelo
   // schema; público sem token continua funcionando (flags vêm null → false).
   const client = createSSRClient(async () => session?.accessToken ?? null)
-  const service = getMarketplaceService(client)
+  const service = createGraphQLMarketplaceService(client)
 
   const listing = await service.getListing(listingId)
   if (!listing || !listing.active) notFound()

--- a/src/app/(public)/clippings/[listingId]/releases/page.tsx
+++ b/src/app/(public)/clippings/[listingId]/releases/page.tsx
@@ -1,6 +1,8 @@
 import { notFound } from 'next/navigation'
+import { auth } from '@/auth'
 import { ReleaseList } from '@/components/clipping/ReleaseList'
-import { getFirestoreDb } from '@/lib/firebase-admin'
+import { createSSRClient } from '@/lib/graphql/client'
+import { getMarketplaceService } from '@/services/marketplace'
 
 export const revalidate = 600
 
@@ -11,13 +13,15 @@ interface Props {
 export async function generateMetadata({ params }: Props) {
   const { listingId } = await params
   try {
-    const db = getFirestoreDb()
-    const snap = await db.collection('marketplace').doc(listingId).get()
-    if (!snap.exists || !snap.data()?.active) {
+    // Caminho público (sem token) — só precisamos dos metadados do listing.
+    const listing = await getMarketplaceService(createSSRClient()).getListing(
+      listingId,
+    )
+    if (!listing || !listing.active) {
       return { title: 'Edições — DestaquesGovBr' }
     }
     return {
-      title: `Edições — ${snap.data()!.name} — DestaquesGovBr`,
+      title: `Edições — ${listing.name} — DestaquesGovBr`,
     }
   } catch {
     return { title: 'Edições — DestaquesGovBr' }
@@ -26,12 +30,12 @@ export async function generateMetadata({ params }: Props) {
 
 export default async function ReleasesPage({ params }: Props) {
   const { listingId } = await params
-  const db = getFirestoreDb()
+  const session = await auth()
+  const client = createSSRClient(async () => session?.accessToken ?? null)
 
-  const listingSnap = await db.collection('marketplace').doc(listingId).get()
-  if (!listingSnap.exists || !listingSnap.data()?.active) notFound()
-
-  const listing = listingSnap.data()!
+  const service = getMarketplaceService(client)
+  const listing = await service.getListing(listingId)
+  if (!listing || !listing.active) notFound()
 
   let initialReleases: Array<{
     id: string
@@ -46,33 +50,24 @@ export default async function ReleasesPage({ params }: Props) {
   let hasMoreReleases = false
 
   try {
-    const releasesSnap = await db
-      .collection('releases')
-      .where('clippingId', '==', listing.sourceClippingId)
-      .orderBy('createdAt', 'desc')
-      .limit(21)
-      .get()
-    hasMoreReleases = releasesSnap.docs.length > 20
-    initialReleases = releasesSnap.docs.slice(0, 20).map((doc) => {
-      const d = doc.data()
-      return {
-        id: doc.id,
-        clippingName: d.clippingName ?? listing.name,
-        articlesCount: d.articlesCount ?? 0,
-        createdAt: d.createdAt?.toDate?.()?.toISOString?.() ?? '',
-        releaseUrl: d.releaseUrl ?? `/clipping/release/${doc.id}`,
-        refTime: d.refTime?.toDate?.()?.toISOString?.() ?? null,
-        sinceHours: d.sinceHours ?? null,
-        digestPreview: (() => {
-          try {
-            const parsed = JSON.parse(d.digest ?? '{}')
-            return parsed.intro?.slice(0, 150) ?? ''
-          } catch {
-            return (d.digest ?? '').slice(0, 150)
-          }
-        })(),
-      }
+    // Caminho PÚBLICO: `MarketplaceListing.releases` (público para listing
+    // ativo, paginação por cursor `before`). NÃO usamos `clipping.releases`
+    // (gated a autor/assinante → UNAUTHENTICATED para anônimo). O preview vem
+    // no campo `digest` do `Release` (convenção do facade).
+    const { releases, hasMore } = await service.listListingReleases(listingId, {
+      limit: 20,
     })
+    initialReleases = releases.map((r) => ({
+      id: r.id,
+      clippingName: r.clippingName || listing.name,
+      articlesCount: r.articlesCount,
+      createdAt: r.createdAt,
+      releaseUrl: r.releaseUrl || `/clipping/release/${r.id}`,
+      refTime: r.refTime ?? null,
+      sinceHours: r.sinceHours ?? null,
+      digestPreview: r.digest || undefined,
+    }))
+    hasMoreReleases = hasMore
   } catch (error) {
     console.error('Failed to load releases:', error)
   }

--- a/src/app/(public)/clippings/[listingId]/releases/page.tsx
+++ b/src/app/(public)/clippings/[listingId]/releases/page.tsx
@@ -2,7 +2,7 @@ import { notFound } from 'next/navigation'
 import { auth } from '@/auth'
 import { ReleaseList } from '@/components/clipping/ReleaseList'
 import { createSSRClient } from '@/lib/graphql/client'
-import { getMarketplaceService } from '@/services/marketplace'
+import { createGraphQLMarketplaceService } from '@/services/marketplace/graphql'
 
 export const revalidate = 600
 
@@ -14,9 +14,9 @@ export async function generateMetadata({ params }: Props) {
   const { listingId } = await params
   try {
     // Caminho público (sem token) — só precisamos dos metadados do listing.
-    const listing = await getMarketplaceService(createSSRClient()).getListing(
-      listingId,
-    )
+    const listing = await createGraphQLMarketplaceService(
+      createSSRClient(),
+    ).getListing(listingId)
     if (!listing || !listing.active) {
       return { title: 'Edições — DestaquesGovBr' }
     }
@@ -33,7 +33,7 @@ export default async function ReleasesPage({ params }: Props) {
   const session = await auth()
   const client = createSSRClient(async () => session?.accessToken ?? null)
 
-  const service = getMarketplaceService(client)
+  const service = createGraphQLMarketplaceService(client)
   const listing = await service.getListing(listingId)
   if (!listing || !listing.active) notFound()
 

--- a/src/app/(public)/clippings/page.tsx
+++ b/src/app/(public)/clippings/page.tsx
@@ -1,6 +1,11 @@
 import { auth } from '@/auth'
 import { getThemeNameByCode } from '@/data/themes-utils'
-import { getFirestoreDb } from '@/lib/firebase-admin'
+import { createSSRClient } from '@/lib/graphql/client'
+import {
+  MARKETPLACE_LISTINGS_QUERY,
+  type MarketplaceListingGraphQL,
+  type MarketplaceListingsQueryData,
+} from '@/lib/graphql/queries/marketplace'
 import type { MarketplaceListing } from '@/types/clipping'
 import { ClippingsPageClient } from './ClippingsPageClient'
 
@@ -8,28 +13,75 @@ export const revalidate = 600
 
 export type ThemeChip = { code: string; label: string; count: number }
 
+/** Trava de segurança contra loop infinito caso `total` venha inconsistente. */
+const MAX_PAGES = 50
+
+function mapListing(node: MarketplaceListingGraphQL): MarketplaceListing {
+  return {
+    id: node.id,
+    authorUserId: node.authorUserId,
+    authorDisplayName: node.authorDisplayName,
+    sourceClippingId: node.sourceClippingId,
+    name: node.name,
+    description: node.description ?? '',
+    recortes: node.recortes.map((r) => ({
+      id: r.id,
+      title: r.title,
+      themes: r.themes ?? [],
+      agencies: r.agencies ?? [],
+      keywords: r.keywords ?? [],
+    })),
+    prompt: node.prompt ?? '',
+    schedule: node.schedule ?? undefined,
+    likeCount: node.likeCount,
+    followerCount: node.followerCount,
+    cloneCount: node.cloneCount,
+    publishedAt: node.publishedAt ?? '',
+    updatedAt: node.updatedAt ?? '',
+    active: node.active,
+  }
+}
+
 export default async function MarketplacePage() {
   const session = await auth()
-  const userId = session?.user?.id
   let listings: MarketplaceListing[] = []
+  let followedIds: string[] = []
+  let likedIds: string[] = []
 
   try {
-    const db = getFirestoreDb()
-    const snapshot = await db
-      .collection('marketplace')
-      .where('active', '==', true)
-      .orderBy('publishedAt', 'desc')
-      .get()
+    // Caminho público; se logado, o token habilita `hasLiked`/`hasFollowed`.
+    const client = createSSRClient(async () => session?.accessToken ?? null)
 
-    listings = snapshot.docs.map((doc) => {
-      const data = doc.data()
-      return {
-        id: doc.id,
-        ...data,
-        publishedAt: data.publishedAt?.toDate?.()?.toISOString?.() ?? '',
-        updatedAt: data.updatedAt?.toDate?.()?.toISOString?.() ?? '',
-      } as MarketplaceListing
-    })
+    // A galeria precisa de TODAS as listings ativas (deriva os theme-chips do
+    // conjunto completo e filtra client-side). O resolver `marketplaceListings`
+    // é paginado e a operação não aceita `limit`, então acumulamos páginas até
+    // termos buscado o `total` reportado (com trava `MAX_PAGES`).
+    const nodes: MarketplaceListingGraphQL[] = []
+    let page = 1
+    let total = Number.POSITIVE_INFINITY
+    while (nodes.length < total && page <= MAX_PAGES) {
+      const result = await client
+        .query<MarketplaceListingsQueryData>(MARKETPLACE_LISTINGS_QUERY, {
+          page,
+        })
+        .toPromise()
+      if (result.error) {
+        throw result.error
+      }
+      const data = result.data?.marketplaceListings
+      const pageNodes = data?.listings ?? []
+      total = data?.total ?? nodes.length + pageNodes.length
+      nodes.push(...pageNodes)
+      // Página vazia → não há mais o que buscar (evita loop se `total` mentir).
+      if (pageNodes.length === 0) break
+      page += 1
+    }
+
+    listings = nodes.map(mapListing)
+    // `hasLiked`/`hasFollowed` vêm do schema (resolvidos para o usuário logado),
+    // substituindo o batch manual por-usuário de likes/follows do Firestore.
+    followedIds = nodes.filter((n) => n.hasFollowed).map((n) => n.id)
+    likedIds = nodes.filter((n) => n.hasLiked).map((n) => n.id)
   } catch (error) {
     console.error('Failed to load marketplace:', error)
   }
@@ -54,39 +106,6 @@ export default async function MarketplacePage() {
       count,
     })),
   )
-
-  // Fetch user's follows and likes
-  let followedIds: string[] = []
-  let likedIds: string[] = []
-
-  if (userId && listings.length > 0) {
-    const db = getFirestoreDb()
-    const checks = listings.map(async (listing) => {
-      const [followerSnap, likeSnap] = await Promise.all([
-        db
-          .collection('subscriptions')
-          .where('clippingId', '==', listing.sourceClippingId)
-          .where('userId', '==', userId)
-          .where('role', '==', 'subscriber')
-          .limit(1)
-          .get(),
-        db
-          .collection('marketplace')
-          .doc(listing.id)
-          .collection('likes')
-          .doc(userId)
-          .get(),
-      ])
-      return {
-        listingId: listing.id,
-        follows: !followerSnap.empty,
-        liked: likeSnap.exists,
-      }
-    })
-    const results = await Promise.all(checks)
-    followedIds = results.filter((r) => r.follows).map((r) => r.listingId)
-    likedIds = results.filter((r) => r.liked).map((r) => r.listingId)
-  }
 
   return (
     <div className="container mx-auto px-4 py-8">

--- a/src/app/clipping/release/[releaseId]/actions.ts
+++ b/src/app/clipping/release/[releaseId]/actions.ts
@@ -1,58 +1,41 @@
 'use server'
 
-import { getFirestoreDb } from '@/lib/firebase-admin'
-import type { Recorte, Release } from '@/types/clipping'
+import { auth } from '@/auth'
+import { createSSRClient } from '@/lib/graphql/client'
+import { getClippingService } from '@/services/clipping'
+import type { ReleaseWithContext } from '@/services/clipping/types'
 
-export type ReleaseWithContext = Release & {
-  recortes: Recorte[]
-  marketplaceListingId?: string | null
-}
-
+/**
+ * Busca um release por ID via GraphQL (substitui o acesso direto ao Firestore).
+ *
+ * Caminho server-side: monta um `createSSRClient` com o token da sessão (quando
+ * logado) para que o resolver `release(id)` aplique a autorização correta —
+ * público quando o listing fonte está ativo; autor/assinante caso contrário.
+ *
+ * O resolver agora popula `recortes` (filtros do clipping fonte) e
+ * `marketplaceListingId` (listing ativo, ou null), então a seção de recortes e
+ * o link "ver no marketplace" da página voltam a funcionar.
+ *
+ * Nota sobre metadata: `page.tsx#generateMetadata` lê `release.digest` para
+ * derivar a description. O resolver NÃO expõe o `digest` (texto puro) — só
+ * `digestPreview` (computado no servidor, ≤150 chars). Como não podemos editar
+ * `page.tsx` neste stream, populamos `digest` com o valor de `digestPreview`
+ * como fallback seguro, mantendo a metadata funcional sem tocar na página.
+ */
 export async function getReleaseById(
   releaseId: string,
 ): Promise<ReleaseWithContext | null> {
   try {
-    const db = getFirestoreDb()
-    const doc = await db.collection('releases').doc(releaseId).get()
+    const session = await auth()
+    const client = createSSRClient(async () => session?.accessToken ?? null)
+    const release = await getClippingService(client).getReleaseById(releaseId)
+    if (!release) return null
 
-    if (!doc.exists) return null
-
-    const data = doc.data()!
-
-    // Fetch clipping data
-    let recortes: Recorte[] = []
-    let marketplaceListingId: string | null = null
-    if (data.clippingId) {
-      const clippingDoc = await db
-        .collection('clippings')
-        .doc(data.clippingId)
-        .get()
-      if (clippingDoc.exists) {
-        const clippingData = clippingDoc.data()!
-        recortes = clippingData.recortes ?? []
-        if (
-          clippingData.publishedToMarketplace &&
-          clippingData.marketplaceListingId
-        ) {
-          marketplaceListingId = clippingData.marketplaceListingId
-        }
-      }
-    }
-
+    // `page.tsx#generateMetadata` ainda lê `release.digest` (texto puro), que o
+    // resolver não expõe. Usamos `digestPreview` como fallback para a metadata.
     return {
-      id: doc.id,
-      clippingId: data.clippingId ?? '',
-      userId: data.userId ?? '',
-      clippingName: data.clippingName ?? '',
-      digest: data.digest ?? '',
-      digestHtml: data.digestHtml ?? '',
-      articlesCount: data.articlesCount ?? 0,
-      createdAt: data.createdAt?.toDate?.()?.toISOString?.() ?? '',
-      releaseUrl: data.releaseUrl ?? '',
-      refTime: data.refTime?.toDate?.()?.toISOString?.() ?? null,
-      sinceHours: data.sinceHours ?? null,
-      recortes,
-      marketplaceListingId,
+      ...release,
+      digest: release.digest || release.digestPreview || '',
     }
   } catch (error) {
     console.error('Error fetching release:', error)

--- a/src/app/clipping/release/[releaseId]/actions.ts
+++ b/src/app/clipping/release/[releaseId]/actions.ts
@@ -2,7 +2,7 @@
 
 import { auth } from '@/auth'
 import { createSSRClient } from '@/lib/graphql/client'
-import { getClippingService } from '@/services/clipping'
+import { createGraphQLClippingService } from '@/services/clipping/graphql'
 import type { ReleaseWithContext } from '@/services/clipping/types'
 
 /**
@@ -28,7 +28,8 @@ export async function getReleaseById(
   try {
     const session = await auth()
     const client = createSSRClient(async () => session?.accessToken ?? null)
-    const release = await getClippingService(client).getReleaseById(releaseId)
+    const release =
+      await createGraphQLClippingService(client).getReleaseById(releaseId)
     if (!release) return null
 
     // `page.tsx#generateMetadata` ainda lê `release.digest` (texto puro), que o

--- a/src/lib/graphql/__tests__/user.test.ts
+++ b/src/lib/graphql/__tests__/user.test.ts
@@ -1,0 +1,66 @@
+/**
+ * Testes do helper compartilhado `getHasTelegram` (Fase 1B).
+ *
+ * Substitui as ~4 leituras Firestore duplicadas (`getHasTelegram`) espalhadas
+ * pelas páginas. Server-importável: aceita um urql Client injetado.
+ */
+
+import type { Client } from '@urql/core'
+import { describe, expect, it } from 'vitest'
+import { getHasTelegram } from '../user'
+
+interface Op {
+  query: string
+  vars: unknown
+}
+
+function makeClientStub(handlers: {
+  onQuery?: (query: string, vars: unknown) => unknown
+  queryError?: unknown
+}): { client: Client; queries: Op[] } {
+  const queries: Op[] = []
+  const client = {
+    query: (doc: { loc?: { source?: { body: string } } }, vars: unknown) => ({
+      toPromise: async () => {
+        const body = doc?.loc?.source?.body ?? ''
+        queries.push({ query: body, vars })
+        return {
+          data: handlers.onQuery?.(body, vars) ?? {},
+          error: handlers.queryError,
+        }
+      },
+    }),
+  } as unknown as Client
+  return { client, queries }
+}
+
+describe('getHasTelegram', () => {
+  it('dispara CurrentUserHasTelegram e retorna true', async () => {
+    const { client, queries } = makeClientStub({
+      onQuery: () => ({ currentUserHasTelegramLinked: true }),
+    })
+    const result = await getHasTelegram(client)
+    expect(queries).toHaveLength(1)
+    expect(queries[0].query).toContain('CurrentUserHasTelegram')
+    expect(result).toBe(true)
+  })
+
+  it('retorna false quando o schema retorna false', async () => {
+    const { client } = makeClientStub({
+      onQuery: () => ({ currentUserHasTelegramLinked: false }),
+    })
+    expect(await getHasTelegram(client)).toBe(false)
+  })
+
+  it('degradação graciosa: erro do urql → false (drop-in do getHasTelegram antigo)', async () => {
+    const { client } = makeClientStub({
+      queryError: { graphQLErrors: [{ message: 'falhou' }] },
+    })
+    expect(await getHasTelegram(client)).toBe(false)
+  })
+
+  it('false quando data ausente/undefined', async () => {
+    const { client } = makeClientStub({ onQuery: () => ({}) })
+    expect(await getHasTelegram(client)).toBe(false)
+  })
+})

--- a/src/lib/graphql/queries/clippings.ts
+++ b/src/lib/graphql/queries/clippings.ts
@@ -98,6 +98,7 @@ export const CLIPPING_RELEASES_QUERY = gql`
         clippingId
         clippingName
         digestHtml
+        digestPreview
         articlesCount
         releaseUrl
         refTime
@@ -122,6 +123,38 @@ export const CLIPPING_ESTIMATE_QUERY = gql`
   ) {
     clippingEstimate(themes: $themes, agencies: $agencies, keywords: $keywords) {
       totalEstimate
+    }
+  }
+`
+
+/**
+ * Busca um release por ID. Substitui o `getReleaseById` do portal (que lia
+ * Firestore). O campo `digestPreview` agora é computado no servidor (o portal
+ * removerá a derivação local). Autorização: público se o listing fonte do
+ * clipping está ativo; caso contrário só autor/subscriber. Retorna null se o
+ * release não existe OU o caller não está autorizado.
+ */
+export const RELEASE_BY_ID_QUERY = gql`
+  query ReleaseById($id: String!) {
+    release(id: $id) {
+      id
+      clippingId
+      clippingName
+      digestHtml
+      digestPreview
+      articlesCount
+      createdAt
+      releaseUrl
+      refTime
+      sinceHours
+      recortes {
+        id
+        title
+        themes
+        agencies
+        keywords
+      }
+      marketplaceListingId
     }
   }
 `
@@ -258,11 +291,27 @@ export interface ReleaseGraphQL {
   clippingId: string
   clippingName: string
   digestHtml: string
+  /** Computado no servidor; só selecionado por `RELEASE_BY_ID_QUERY`. */
+  digestPreview?: string | null
   articlesCount: number
   releaseUrl: string | null
   refTime: string | null
   sinceHours: number | null
   createdAt: string
+  /**
+   * Recortes do clipping fonte. Só selecionado por `RELEASE_BY_ID_QUERY`
+   * (o resolver os popula para o caller autorizado).
+   */
+  recortes?: RecorteGraphQL[]
+  /**
+   * ID do listing ativo do marketplace (ou null). Só selecionado por
+   * `RELEASE_BY_ID_QUERY`.
+   */
+  marketplaceListingId?: string | null
+}
+
+export interface ReleaseByIdQueryData {
+  release: ReleaseGraphQL | null
 }
 
 /** RecorteInput do schema NÃO tem `id` (diferente do `Recorte` de saída). */

--- a/src/lib/graphql/queries/marketplace.ts
+++ b/src/lib/graphql/queries/marketplace.ts
@@ -99,6 +99,7 @@ export const MARKETPLACE_LISTING_RELEASES_QUERY = gql`
         clippingId
         clippingName
         digestHtml
+        digestPreview
         articlesCount
         releaseUrl
         refTime
@@ -106,6 +107,60 @@ export const MARKETPLACE_LISTING_RELEASES_QUERY = gql`
         createdAt
       }
     }
+  }
+`
+
+/**
+ * Lista os listings que o usuário autenticado segue, com os campos da
+ * subscription dele (canais, emails extras, webhook, data). Substitui o
+ * `getFollows` do portal (que lia Firestore). Exclui follows cujo listing
+ * está inativo ou ausente.
+ */
+export const MY_FOLLOWED_LISTINGS_QUERY = gql`
+  query MyFollowedListings {
+    myFollowedListings {
+      id
+      authorUserId
+      authorDisplayName
+      sourceClippingId
+      name
+      description
+      recortes {
+        id
+        title
+        themes
+        agencies
+        keywords
+      }
+      prompt
+      schedule
+      likeCount
+      followerCount
+      cloneCount
+      publishedAt
+      updatedAt
+      active
+      deliveryChannels {
+        email
+        telegram
+        push
+        webhook
+      }
+      extraEmails
+      webhookUrl
+      followedAt
+    }
+  }
+`
+
+/**
+ * True se o usuário autenticado tem o Telegram vinculado. Substitui o
+ * `getHasTelegram` do portal (que lia Firestore). Retorna False se não logado
+ * ou sem doc.
+ */
+export const CURRENT_USER_HAS_TELEGRAM_QUERY = gql`
+  query CurrentUserHasTelegram {
+    currentUserHasTelegramLinked
   }
 `
 
@@ -226,6 +281,8 @@ export interface MarketplaceReleaseGraphQL {
   clippingId: string
   clippingName: string
   digestHtml: string
+  /** Computado no servidor (≤150 chars); usado para o preview nos cards. */
+  digestPreview?: string | null
   articlesCount: number
   releaseUrl: string | null
   refTime: string | null
@@ -238,6 +295,41 @@ export interface MarketplaceListingReleasesQueryData {
     id: string
     releases: MarketplaceReleaseGraphQL[]
   } | null
+}
+
+/**
+ * Shape de um `FollowedListing` — todos os campos escalares de
+ * `MarketplaceListing` mais os da subscription do usuário (`deliveryChannels`,
+ * `extraEmails`, `webhookUrl`, `followedAt`).
+ */
+export interface FollowedListingGraphQL {
+  id: string
+  authorUserId: string
+  authorDisplayName: string
+  sourceClippingId: string
+  name: string
+  description: string | null
+  recortes: MarketplaceRecorteGraphQL[]
+  prompt: string | null
+  schedule: string | null
+  likeCount: number
+  followerCount: number
+  cloneCount: number
+  publishedAt: string | null
+  updatedAt: string | null
+  active: boolean
+  deliveryChannels: DeliveryChannelsInputGraphQL | null
+  extraEmails: string[]
+  webhookUrl: string | null
+  followedAt: string | null
+}
+
+export interface MyFollowedListingsQueryData {
+  myFollowedListings: FollowedListingGraphQL[]
+}
+
+export interface CurrentUserHasTelegramQueryData {
+  currentUserHasTelegramLinked: boolean
 }
 
 export interface PublishInputGraphQL {

--- a/src/lib/graphql/schema.graphql
+++ b/src/lib/graphql/schema.graphql
@@ -81,6 +81,14 @@ type Article {
   agencyName: String
   publishedAt: DateTime
   extractedAt: DateTime
+  theme1Level1Code: String
+  theme1Level1Label: String
+  theme1Level2Code: String
+  theme1Level2Label: String
+  theme1Level3Code: String
+  theme1Level3Label: String
+  mostSpecificThemeCode: String
+  mostSpecificThemeLabel: String
 }
 
 input ArticleFilter {
@@ -89,6 +97,8 @@ input ArticleFilter {
   tags: [String!] = null
   startDate: String = null
   endDate: String = null
+  themeLabel: String = null
+  dedup: Boolean = null
 }
 
 type ArticlesResult {
@@ -229,6 +239,28 @@ type EstimateResult {
 input FeatureUpsertInput {
   uniqueId: String!
   features: JSON!
+}
+
+type FollowedListing {
+  id: String!
+  authorUserId: String!
+  authorDisplayName: String!
+  sourceClippingId: String!
+  name: String!
+  description: String
+  recortes: [MarketplaceRecorte!]!
+  prompt: String
+  schedule: String
+  likeCount: Int!
+  followerCount: Int!
+  cloneCount: Int!
+  publishedAt: DateTime
+  updatedAt: DateTime
+  active: Boolean!
+  deliveryChannels: DeliveryChannels
+  extraEmails: [String!]!
+  webhookUrl: String
+  followedAt: DateTime
 }
 
 type IntegrityCandidateType {
@@ -473,6 +505,8 @@ type Query {
     filter: ArticleFilter = null
     page: Int! = 1
     semantic: Boolean! = false
+    alpha: Float = null
+    dedup: Boolean! = false
   ): ArticlesResult!
 
   """
@@ -526,6 +560,11 @@ type Query {
   clipping(id: String!): Clipping
 
   """
+  Busca um release por ID. Autorizacao espelha `MarketplaceListing.releases`: PUBLICO se o listing fonte do clipping esta ativo; caso contrario somente autor ou subscriber. Substitui o `getReleaseById` do portal. Retorna None se o release nao existe OU o caller nao esta autorizado. Para o caller autorizado, popula `recortes` (filtros do clipping fonte) e `marketplaceListingId` (id do listing ativo, ou null).
+  """
+  release(id: String!): Release
+
+  """
   Estima o numero de artigos para um clipping
   """
   clippingEstimate(
@@ -543,6 +582,11 @@ type Query {
   Busca um listing do marketplace por ID
   """
   marketplaceListing(id: String!): MarketplaceListing
+
+  """
+  Listings que o usuario autenticado segue, com os campos da subscription dele (canais, emails extras, webhook, data). Substitui o `getFollows` do portal. Exclui follows cujo listing esta inativo ou ausente.
+  """
+  myFollowedListings: [FollowedListing!]!
 
   """
   Preferencias de push notification do usuario autenticado
@@ -566,6 +610,11 @@ type Query {
     config: WidgetConfigInput!
     page: Int! = 1
   ): WidgetArticlesResult!
+
+  """
+  True se o usuario autenticado tem o Telegram vinculado (`users/{id}/telegramLink/account` existe). Substitui o `getHasTelegram` do portal. Retorna False se nao logado ou sem doc.
+  """
+  currentUserHasTelegramLinked: Boolean!
 
   """
   Fetch a single news record by unique_id
@@ -605,6 +654,31 @@ type Query {
   Fetch a batch of articles needing integrity checks
   """
   integrityBatch(batchSize: Int! = 50): [IntegrityCandidateType!]!
+
+  """
+  Artigos relacionados a `uniqueId`, baseados no theme-code (Typesense). Replica a logica do portal: usa most_specific_theme_code quando presente, senao theme_1_level_1_code; exclui o proprio artigo; ordena por publishedAt desc; deduplica por content_hash. PUBLICO. (Distinto do `similarArticles` interno, baseado em embedding postgres.)
+  """
+  relatedArticles(uniqueId: String!, limit: Int! = 4): [Article!]!
+
+  """
+  Contagem de artigos por code de tema (nivel `level`) nos ultimos `days` dias. `label` e None (o portal mapeia pela config). PUBLICO.
+  """
+  themeArticleCounts(days: Int! = 30, level: Int! = 1): [ThemeCount!]!
+
+  """
+  Artigos de um release (pagina de artigos do release). Autorizacao espelha `release(id)`: PUBLICO se o listing fonte do clipping esta ativo; caso contrario somente autor ou subscriber. Retorna [] se negado ou inexistente. Janela temporal [refTime - sinceHours, refTime] (default ultimas 24h). Para cada recorte: se tem keywords, uma busca por keyword (q em title,summary) + filtro (themes OR-levels + agencies + janela); senao, uma busca q=* filter-only. Une tudo, deduplica por uniqueId, ordena por publishedAt desc. PUBLICO (sujeito a auth do release).
+  """
+  releaseArticles(id: String!): [Article!]!
+
+  """
+  Estima quantos artigos um recorte capturaria nas ultimas `sinceHours` horas. Replica `lib/estimate-recorte-count.ts`: filtro = themes OR-levels + agencies OR'd + published_at >= now-sinceHours; para keywords, conta por keyword (q em title,summary) e retorna o MAX; sem keywords, uma unica contagem. Substitui o mock `clippingEstimate`. PUBLICO.
+  """
+  estimateRecorteCount(
+    themes: [String!]!
+    agencies: [String!]!
+    keywords: [String!]!
+    sinceHours: Int! = 24
+  ): Int!
 }
 
 type Recorte {
@@ -623,6 +697,9 @@ input RecorteInput {
 }
 
 type Release {
+  digestPreview: String
+  recortes: [Recorte!]!
+  marketplaceListingId: String
   id: String!
   clippingId: String!
   clippingName: String!
@@ -671,6 +748,12 @@ type Tag {
 type Theme {
   code: String!
   label: String!
+}
+
+type ThemeCount {
+  code: String!
+  label: String
+  count: Int!
 }
 
 """

--- a/src/lib/graphql/user.ts
+++ b/src/lib/graphql/user.ts
@@ -1,0 +1,42 @@
+/**
+ * Helpers GraphQL relativos ao usuário autenticado.
+ *
+ * Server-importável (sem `'use client'`): pode ser chamado de Server
+ * Components, Server Actions e Route Handlers passando um cliente SSR
+ * (`createSSRClient(getToken)`), e também do browser usando o singleton
+ * `getClient()`.
+ */
+
+import type { Client } from '@urql/core'
+import {
+  CURRENT_USER_HAS_TELEGRAM_QUERY,
+  type CurrentUserHasTelegramQueryData,
+} from '@/lib/graphql/queries/marketplace'
+import { getClient } from './client'
+
+/**
+ * True se o usuário autenticado tem o Telegram vinculado.
+ *
+ * Substitui as ~4 leituras Firestore duplicadas (`getHasTelegram`) das páginas.
+ * Drop-in: degrada graciosamente para `false` em qualquer erro (não logado,
+ * sem doc, falha de rede) — mesma semântica do helper antigo.
+ *
+ * @param client Cliente urql. Default: `getClient()` (singleton browser). Em
+ *   contexto server-side, passe `createSSRClient(getToken)`.
+ */
+export async function getHasTelegram(
+  client: Client = getClient(),
+): Promise<boolean> {
+  try {
+    const result = await client
+      .query<CurrentUserHasTelegramQueryData>(
+        CURRENT_USER_HAS_TELEGRAM_QUERY,
+        {},
+      )
+      .toPromise()
+    if (result.error) return false
+    return result.data?.currentUserHasTelegramLinked ?? false
+  } catch {
+    return false
+  }
+}

--- a/src/lib/release-utils.ts
+++ b/src/lib/release-utils.ts
@@ -1,4 +1,6 @@
-import { getFirestoreDb } from '@/lib/firebase-admin'
+import { auth } from '@/auth'
+import { createSSRClient } from '@/lib/graphql/client'
+import { getClippingService } from '@/services/clipping'
 
 export type ReleaseItem = {
   id: string
@@ -11,43 +13,51 @@ export type ReleaseItem = {
   digestPreview?: string
 }
 
+/**
+ * Busca as releases (edições) de um clipping via GraphQL (substitui o acesso
+ * direto ao Firestore).
+ *
+ * **Contexto AUTOR/AUTENTICADO apenas.** Usa o facade
+ * `clipping(id) { releases(limit, before) }`, que o graphql-api GATEIA a
+ * autor/assinante (anônimo recebe UNAUTHENTICATED). Por isso esta função serve
+ * só a página do dono (`/minha-conta/clipping/[id]`). Páginas PÚBLICAS do
+ * marketplace devem usar `MarketplaceService.listListingReleases(listingId)`
+ * (campo `MarketplaceListing.releases`, público para listing ativo).
+ *
+ * Monta um `createSSRClient` com o token da sessão. Paginação: o schema usa
+ * cursor `before` (DateTime ISO) em vez de offset. Para a primeira página,
+ * omitimos `before`; o `hasMore` vem do facade, que pede `limit + 1`
+ * internamente e fatia o excedente. O `loadMore` do `ReleaseList` (client)
+ * continua a paginação passando o `refTime`/`createdAt` da release mais antiga
+ * como cursor.
+ */
 export async function fetchReleasesForClipping(
   clippingId: string,
   clippingName: string,
   limit = 10,
 ): Promise<{ releases: ReleaseItem[]; hasMore: boolean }> {
-  const db = getFirestoreDb()
+  const session = await auth()
+  const client = createSSRClient(async () => session?.accessToken ?? null)
 
-  const snap = await db
-    .collection('releases')
-    .where('clippingId', '==', clippingId)
-    .orderBy('createdAt', 'desc')
-    .limit(limit + 1)
-    .get()
+  const { releases, hasMore } = await getClippingService(client).listReleases(
+    clippingId,
+    { limit },
+  )
 
-  const hasMore = snap.docs.length > limit
-  const docs = hasMore ? snap.docs.slice(0, limit) : snap.docs
+  const items: ReleaseItem[] = releases.map((r) => ({
+    id: r.id,
+    clippingName: r.clippingName || clippingName,
+    articlesCount: r.articlesCount,
+    createdAt: r.createdAt,
+    releaseUrl: r.releaseUrl || `/clipping/release/${r.id}`,
+    refTime: r.refTime ?? null,
+    sinceHours: r.sinceHours ?? null,
+    // `digestPreview` agora vem computado do servidor (campo `Release.digestPreview`);
+    // a derivação local (parse do digest) foi removida. O facade `listReleases`
+    // carrega o preview no campo `digest` do `Release` (o tipo não tem campo
+    // próprio para o preview).
+    digestPreview: r.digest || undefined,
+  }))
 
-  const releases: ReleaseItem[] = docs.map((doc) => {
-    const d = doc.data()
-    return {
-      id: doc.id,
-      clippingName: d.clippingName ?? clippingName,
-      articlesCount: d.articlesCount ?? 0,
-      createdAt: d.createdAt?.toDate?.()?.toISOString?.() ?? '',
-      releaseUrl: d.releaseUrl ?? `/clipping/release/${doc.id}`,
-      refTime: d.refTime?.toDate?.()?.toISOString?.() ?? null,
-      sinceHours: d.sinceHours ?? null,
-      digestPreview: (() => {
-        try {
-          const parsed = JSON.parse(d.digest ?? '{}')
-          return parsed.intro?.slice(0, 150) ?? ''
-        } catch {
-          return (d.digest ?? '').slice(0, 150)
-        }
-      })(),
-    }
-  })
-
-  return { releases, hasMore }
+  return { releases: items, hasMore }
 }

--- a/src/lib/release-utils.ts
+++ b/src/lib/release-utils.ts
@@ -1,6 +1,6 @@
 import { auth } from '@/auth'
 import { createSSRClient } from '@/lib/graphql/client'
-import { getClippingService } from '@/services/clipping'
+import { createGraphQLClippingService } from '@/services/clipping/graphql'
 
 export type ReleaseItem = {
   id: string
@@ -39,10 +39,9 @@ export async function fetchReleasesForClipping(
   const session = await auth()
   const client = createSSRClient(async () => session?.accessToken ?? null)
 
-  const { releases, hasMore } = await getClippingService(client).listReleases(
-    clippingId,
-    { limit },
-  )
+  const { releases, hasMore } = await createGraphQLClippingService(
+    client,
+  ).listReleases(clippingId, { limit })
 
   const items: ReleaseItem[] = releases.map((r) => ({
     id: r.id,

--- a/src/services/clipping/__tests__/graphql.test.ts
+++ b/src/services/clipping/__tests__/graphql.test.ts
@@ -362,6 +362,7 @@ describe('graphqlClippingService — listReleases', () => {
       clippingId: 'c1',
       clippingName: 'Meu Clipping',
       digestHtml: `<p>${id}</p>`,
+      digestPreview: `Prévia ${id}`,
       articlesCount: 9,
       releaseUrl: `/clipping/release/${id}`,
       refTime: '2026-05-26T08:00:00Z',
@@ -382,11 +383,15 @@ describe('graphqlClippingService — listReleases', () => {
 
     expect(queries[0].query).toContain('ClippingReleases')
     expect(queries[0].query).toContain('articlesCount')
+    expect(queries[0].query).toContain('digestPreview')
     expect(result.releases).toHaveLength(2)
     expect(result.hasMore).toBe(true)
     expect(result.releases[0].digestHtml).toBe('<p>rel-1</p>')
     // articlesCount agora vem do schema (antes era hardcoded 0).
     expect(result.releases[0].articlesCount).toBe(9)
+    // `digestPreview` é carregado no campo `digest` do Release (o tipo não tem
+    // campo próprio para o preview).
+    expect(result.releases[0].digest).toBe('Prévia rel-1')
   })
 
   it('passa o cursor `before` para a query quando fornecido', async () => {
@@ -401,5 +406,105 @@ describe('graphqlClippingService — listReleases', () => {
       id: 'c1',
       before: '2026-05-26T08:00:00Z',
     })
+  })
+
+  it('getReleaseById: dispara ReleaseById(id) e mapeia Release → ReleaseWithContext (incl. digestPreview)', async () => {
+    const { client, queries } = makeClientStub({
+      onQuery: (q) => {
+        if (q.includes('ReleaseById')) {
+          return {
+            release: {
+              id: 'rel-1',
+              clippingId: 'c1',
+              clippingName: 'Top Economia',
+              digestHtml: '<p>conteúdo</p>',
+              digestPreview: 'Prévia do digest',
+              articlesCount: 12,
+              createdAt: '2026-05-26T08:01:00Z',
+              releaseUrl: '/clipping/release/rel-1',
+              refTime: '2026-05-26T08:00:00Z',
+              sinceHours: 24,
+              recortes: [
+                {
+                  id: 'rec-1',
+                  title: 'Economia',
+                  themes: ['economia'],
+                  agencies: ['ME'],
+                  keywords: ['pib'],
+                },
+              ],
+              marketplaceListingId: 'listing-1',
+            },
+          }
+        }
+        return {}
+      },
+    })
+
+    const service = createGraphQLClippingService(client)
+    const result = await service.getReleaseById('rel-1')
+
+    expect(queries).toHaveLength(1)
+    expect(queries[0].query).toContain('ReleaseById')
+    expect(queries[0].query).toContain('digestPreview')
+    expect(queries[0].query).toContain('recortes')
+    expect(queries[0].query).toContain('marketplaceListingId')
+    expect(queries[0].vars).toMatchObject({ id: 'rel-1' })
+    expect(result).toEqual({
+      id: 'rel-1',
+      clippingId: 'c1',
+      userId: '',
+      clippingName: 'Top Economia',
+      digest: '',
+      digestHtml: '<p>conteúdo</p>',
+      digestPreview: 'Prévia do digest',
+      articlesCount: 12,
+      createdAt: '2026-05-26T08:01:00Z',
+      releaseUrl: '/clipping/release/rel-1',
+      refTime: '2026-05-26T08:00:00Z',
+      sinceHours: 24,
+      recortes: [
+        {
+          id: 'rec-1',
+          title: 'Economia',
+          themes: ['economia'],
+          agencies: ['ME'],
+          keywords: ['pib'],
+        },
+      ],
+      marketplaceListingId: 'listing-1',
+    })
+  })
+
+  it('getReleaseById: retorna null quando o release não existe / sem acesso', async () => {
+    const { client } = makeClientStub({
+      onQuery: () => ({ release: null }),
+    })
+    const service = createGraphQLClippingService(client)
+    const result = await service.getReleaseById('inexistente')
+    expect(result).toBeNull()
+  })
+
+  it('getReleaseById: releaseUrl default quando o schema retorna null', async () => {
+    const { client } = makeClientStub({
+      onQuery: () => ({
+        release: {
+          id: 'rel-2',
+          clippingId: 'c1',
+          clippingName: 'Top',
+          digestHtml: '<p>x</p>',
+          digestPreview: null,
+          articlesCount: 0,
+          createdAt: '2026-05-26T08:01:00Z',
+          releaseUrl: null,
+          refTime: null,
+          sinceHours: null,
+        },
+      }),
+    })
+    const service = createGraphQLClippingService(client)
+    const result = await service.getReleaseById('rel-2')
+    expect(result?.releaseUrl).toBe('/clipping/release/rel-2')
+    expect(result?.digestPreview).toBeNull()
   })
 })

--- a/src/services/clipping/graphql.ts
+++ b/src/services/clipping/graphql.ts
@@ -25,6 +25,8 @@ import {
   type DeleteClippingMutationData,
   MY_CLIPPINGS_QUERY,
   type MyClippingsQueryData,
+  RELEASE_BY_ID_QUERY,
+  type ReleaseByIdQueryData,
   SEND_CLIPPING_NOW_MUTATION,
   SET_CLIPPING_ACTIVE_MUTATION,
   type SendClippingNowMutationData,
@@ -45,6 +47,7 @@ import type {
   ClippingService,
   EstimateResult,
   ReleasesPage,
+  ReleaseWithContext,
   SubscriptionUpdate,
 } from './types'
 
@@ -340,7 +343,11 @@ export function createGraphQLClippingService(
         clippingId: r.clippingId,
         userId: '', // não exposto pelo schema GraphQL (autor é resolvido contextualmente)
         clippingName: r.clippingName,
-        digest: '',
+        // `Release` (tipo do portal) não tem campo próprio para o preview; o
+        // schema só expõe `digestPreview` (computado no servidor, ≤150 chars),
+        // não o `digest` cru. Carregamos o preview em `digest` para que os
+        // consumidores SSR (release-utils) o usem sem alterar o tipo `Release`.
+        digest: r.digestPreview ?? '',
         digestHtml: r.digestHtml,
         articlesCount: r.articlesCount,
         createdAt: r.createdAt,
@@ -349,6 +356,43 @@ export function createGraphQLClippingService(
         sinceHours: r.sinceHours,
       }))
       return { releases, hasMore }
+    },
+
+    async getReleaseById(id: string): Promise<ReleaseWithContext | null> {
+      const result = await client
+        .query<ReleaseByIdQueryData>(RELEASE_BY_ID_QUERY, { id })
+        .toPromise()
+      if (result.error) {
+        throw unwrapError(result.error, 'Erro ao buscar release')
+      }
+      const r = result.data?.release
+      // null = release inexistente OU sem autorização (semântica do resolver).
+      if (!r) return null
+      return {
+        id: r.id,
+        clippingId: r.clippingId,
+        userId: '', // não exposto pelo schema GraphQL (autor resolvido contextualmente)
+        clippingName: r.clippingName,
+        digest: '', // schema só expõe digestHtml/digestPreview, não o texto puro
+        digestHtml: r.digestHtml,
+        digestPreview: r.digestPreview ?? null,
+        articlesCount: r.articlesCount,
+        createdAt: r.createdAt,
+        releaseUrl: r.releaseUrl ?? `/clipping/release/${r.id}`,
+        refTime: r.refTime,
+        sinceHours: r.sinceHours,
+        // O resolver `Release` agora expõe `recortes` (filtros do clipping fonte)
+        // e `marketplaceListingId` (listing ativo, ou null) para o caller
+        // autorizado — selecionados por `RELEASE_BY_ID_QUERY`.
+        recortes: (r.recortes ?? []).map((rec) => ({
+          id: rec.id,
+          title: rec.title,
+          themes: rec.themes ?? [],
+          agencies: rec.agencies ?? [],
+          keywords: rec.keywords ?? [],
+        })),
+        marketplaceListingId: r.marketplaceListingId ?? null,
+      }
     },
   }
 }

--- a/src/services/clipping/index.ts
+++ b/src/services/clipping/index.ts
@@ -25,6 +25,7 @@ export type {
   ClippingService,
   EstimateResult,
   ReleasesPage,
+  ReleaseWithContext,
   SubscriptionUpdate,
 } from './types'
 

--- a/src/services/clipping/types.ts
+++ b/src/services/clipping/types.ts
@@ -22,6 +22,24 @@ export interface ReleasesPage {
   hasMore: boolean
 }
 
+/**
+ * Release com contexto adicional, retornado por `getReleaseById`. Substitui o
+ * antigo `getReleaseById` (Firestore) da página de release.
+ *
+ * `digestPreview` agora vem computado do servidor (campo `Release.digestPreview`
+ * do schema) — o consumidor pode remover a derivação local.
+ *
+ * GAP vs. o antigo shape Firestore: o resolver GraphQL `Release` NÃO expõe
+ * `recortes`, `marketplaceListingId`, `userId` nem `digest` (texto puro). Aqui
+ * `recortes` vem `[]` e `marketplaceListingId` vem `null` — o stream que
+ * consome deve buscá-los por outra via se ainda precisar deles.
+ */
+export type ReleaseWithContext = Release & {
+  digestPreview: string | null
+  recortes: Recorte[]
+  marketplaceListingId?: string | null
+}
+
 /** Dados aceitos por `updateMySubscription` — só canais de entrega. */
 export interface SubscriptionUpdate {
   deliveryChannels: {
@@ -74,4 +92,11 @@ export interface ClippingService {
     clippingId: string,
     opts?: { limit?: number; before?: string },
   ): Promise<ReleasesPage>
+
+  /**
+   * Busca um release por ID. Substitui o `getReleaseById` (Firestore) da página
+   * de release. Retorna `null` se o release não existe OU o caller não está
+   * autorizado (mesma semântica do resolver `release(id)`).
+   */
+  getReleaseById(id: string): Promise<ReleaseWithContext | null>
 }

--- a/src/services/marketplace/__tests__/graphql.test.ts
+++ b/src/services/marketplace/__tests__/graphql.test.ts
@@ -163,6 +163,7 @@ describe('createGraphQLMarketplaceService', () => {
       clippingId: 'src-1',
       clippingName: 'Top Economia',
       digestHtml: `<p>${id}</p>`,
+      digestPreview: `Prévia ${id}`,
       articlesCount: 8,
       releaseUrl: `/clipping/release/${id}`,
       refTime: '2026-05-26T08:00:00Z',
@@ -183,12 +184,16 @@ describe('createGraphQLMarketplaceService', () => {
 
     expect(queries[0].query).toContain('MarketplaceListingReleases')
     expect(queries[0].query).toContain('articlesCount')
+    expect(queries[0].query).toContain('digestPreview')
     // pede limit+1 para detectar hasMore.
     expect(queries[0].vars).toMatchObject({ id: 'l-1', limit: 3, before: null })
     expect(result.releases).toHaveLength(2)
     expect(result.hasMore).toBe(true)
     expect(result.releases[0].articlesCount).toBe(8)
     expect(result.releases[0].digestHtml).toBe('<p>rel-1</p>')
+    // `digestPreview` é carregado no campo `digest` do Release (o tipo não tem
+    // campo próprio para o preview).
+    expect(result.releases[0].digest).toBe('Prévia rel-1')
   })
 
   it('listListingReleases: listing inativo/inexistente (null) → sem releases', async () => {
@@ -426,6 +431,141 @@ describe('createGraphQLMarketplaceService', () => {
     expect(mutations).toHaveLength(1)
     expect(mutations[0].query).toContain('CloneFromListing')
     expect(mutations[0].vars).toMatchObject({ listingId: 'l-5' })
+  })
+
+  it('listFollowedListings: dispara MyFollowedListings e mapeia para o shape do FollowCard', async () => {
+    const { client, queries } = makeClientStub({
+      onQuery: (q) => {
+        if (q.includes('MyFollowedListings')) {
+          return {
+            myFollowedListings: [
+              {
+                id: 'l-1',
+                authorUserId: 'u-1',
+                authorDisplayName: 'Author One',
+                sourceClippingId: 'c-1',
+                name: 'Listing 1',
+                description: 'desc',
+                recortes: [
+                  {
+                    id: 'r1',
+                    title: 'Recorte 1',
+                    themes: ['01'],
+                    agencies: [],
+                    keywords: [],
+                  },
+                ],
+                prompt: null,
+                schedule: '0 8 * * *',
+                likeCount: 3,
+                followerCount: 2,
+                cloneCount: 1,
+                publishedAt: '2026-05-01T10:00:00Z',
+                updatedAt: '2026-05-02T10:00:00Z',
+                active: true,
+                deliveryChannels: {
+                  email: true,
+                  telegram: false,
+                  push: false,
+                  webhook: false,
+                },
+                extraEmails: ['extra@example.test'],
+                webhookUrl: 'https://hooks.example.test/wh',
+                followedAt: '2026-05-03T10:00:00Z',
+              },
+            ],
+          }
+        }
+        return {}
+      },
+    })
+
+    const service = createGraphQLMarketplaceService(client)
+    const result = await service.listFollowedListings()
+
+    expect(queries).toHaveLength(1)
+    expect(queries[0].query).toContain('MyFollowedListings')
+    expect(result).toHaveLength(1)
+    expect(result[0]).toEqual({
+      listingId: 'l-1',
+      listing: {
+        id: 'l-1',
+        authorUserId: 'u-1',
+        authorDisplayName: 'Author One',
+        sourceClippingId: 'c-1',
+        name: 'Listing 1',
+        description: 'desc',
+        recortes: [
+          {
+            id: 'r1',
+            title: 'Recorte 1',
+            themes: ['01'],
+            agencies: [],
+            keywords: [],
+          },
+        ],
+        prompt: '',
+        schedule: '0 8 * * *',
+        likeCount: 3,
+        followerCount: 2,
+        cloneCount: 1,
+        publishedAt: '2026-05-01T10:00:00Z',
+        updatedAt: '2026-05-02T10:00:00Z',
+        active: true,
+      },
+      deliveryChannels: {
+        email: true,
+        telegram: false,
+        push: false,
+        webhook: false,
+      },
+      extraEmails: ['extra@example.test'],
+      webhookUrl: 'https://hooks.example.test/wh',
+      followedAt: '2026-05-03T10:00:00Z',
+    })
+  })
+
+  it('listFollowedListings: aplica defaults quando campos da subscription vêm nulos', async () => {
+    const { client } = makeClientStub({
+      onQuery: () => ({
+        myFollowedListings: [
+          {
+            id: 'l-2',
+            authorUserId: 'u-2',
+            authorDisplayName: 'Author Two',
+            sourceClippingId: 'c-2',
+            name: 'Listing 2',
+            description: null,
+            recortes: [],
+            prompt: null,
+            schedule: null,
+            likeCount: 0,
+            followerCount: 0,
+            cloneCount: 0,
+            publishedAt: null,
+            updatedAt: null,
+            active: true,
+            deliveryChannels: null,
+            extraEmails: [],
+            webhookUrl: null,
+            followedAt: null,
+          },
+        ],
+      }),
+    })
+
+    const service = createGraphQLMarketplaceService(client)
+    const result = await service.listFollowedListings()
+
+    expect(result[0].deliveryChannels).toEqual({
+      email: false,
+      telegram: false,
+      push: false,
+      webhook: false,
+    })
+    expect(result[0].webhookUrl).toBe('')
+    expect(result[0].followedAt).toBe('')
+    expect(result[0].listing.description).toBe('')
   })
 
   it('propaga erro do urql como Error legível', async () => {

--- a/src/services/marketplace/graphql.ts
+++ b/src/services/marketplace/graphql.ts
@@ -15,6 +15,7 @@ import { getClient } from '@/lib/graphql/client'
 import {
   CLONE_FROM_LISTING_MUTATION,
   type CloneFromListingMutationData,
+  type FollowedListingGraphQL,
   LIKE_MARKETPLACE_LISTING_MUTATION,
   type LikeMarketplaceListingMutationData,
   MARKETPLACE_LISTING_QUERY,
@@ -24,6 +25,8 @@ import {
   type MarketplaceListingQueryData,
   type MarketplaceListingReleasesQueryData,
   type MarketplaceListingsQueryData,
+  MY_FOLLOWED_LISTINGS_QUERY,
+  type MyFollowedListingsQueryData,
   PUBLISH_TO_MARKETPLACE_MUTATION,
   type PublishToMarketplaceMutationData,
   SUBSCRIBE_TO_CLIPPING_MUTATION,
@@ -36,6 +39,7 @@ import {
 import type { MarketplaceListing, Release } from '@/types/clipping'
 import type {
   CloneResult,
+  FollowedListing,
   LikeResult,
   ListingDetail,
   ListingsPage,
@@ -81,6 +85,30 @@ function mapListingDetail(node: MarketplaceListingGraphQL): ListingDetail {
     ...mapListing(node),
     userHasLiked: node.hasLiked ?? undefined,
     userFollows: node.hasFollowed ?? undefined,
+  }
+}
+
+/**
+ * Mapeia um `FollowedListing` (GraphQL) → shape consumido pelo `FollowCard`.
+ * Os campos escalares do listing reusam o mapeamento de `mapListing`; os campos
+ * da subscription (`deliveryChannels`/`extraEmails`/`webhookUrl`/`followedAt`)
+ * recebem defaults quando nulos, espelhando o antigo `getFollows`.
+ */
+function mapFollowedListing(node: FollowedListingGraphQL): FollowedListing {
+  return {
+    listingId: node.id,
+    // `FollowedListing` tem os mesmos campos escalares de `MarketplaceListing`,
+    // então reaproveitamos `mapListing` (ignora os campos extras da subscription).
+    listing: mapListing(node as unknown as MarketplaceListingGraphQL),
+    deliveryChannels: node.deliveryChannels ?? {
+      email: false,
+      telegram: false,
+      push: false,
+      webhook: false,
+    },
+    extraEmails: node.extraEmails ?? [],
+    webhookUrl: node.webhookUrl ?? '',
+    followedAt: node.followedAt ?? '',
   }
 }
 
@@ -143,6 +171,21 @@ export function createGraphQLMarketplaceService(
       return { listings, total: data?.total ?? 0 }
     },
 
+    async listFollowedListings(): Promise<FollowedListing[]> {
+      const result = await client
+        .query<MyFollowedListingsQueryData>(MY_FOLLOWED_LISTINGS_QUERY, {})
+        .toPromise()
+      if (result.error) {
+        throw unwrapError(result.error, 'Erro ao listar clippings seguidos')
+      }
+      const nodes = result.data?.myFollowedListings ?? []
+      // Aquece o cache listing → sourceClippingId p/ unsubscribe sem roundtrip.
+      for (const node of nodes) {
+        sourceClippingByListing.set(node.id, node.sourceClippingId)
+      }
+      return nodes.map(mapFollowedListing)
+    },
+
     async getListing(listingId: string): Promise<ListingDetail | null> {
       const result = await client
         .query<MarketplaceListingQueryData>(MARKETPLACE_LISTING_QUERY, {
@@ -181,7 +224,11 @@ export function createGraphQLMarketplaceService(
         clippingId: r.clippingId,
         userId: '', // não exposto pelo schema GraphQL (conteúdo público)
         clippingName: r.clippingName,
-        digest: '',
+        // `Release` (tipo do portal) não tem campo próprio para o preview; o
+        // schema só expõe `digestPreview` (computado no servidor, ≤150 chars).
+        // Carregamos o preview em `digest` para que os cards o exibam (mesma
+        // convenção do facade de clipping).
+        digest: r.digestPreview ?? '',
         digestHtml: r.digestHtml,
         articlesCount: r.articlesCount,
         createdAt: r.createdAt,

--- a/src/services/marketplace/index.ts
+++ b/src/services/marketplace/index.ts
@@ -29,6 +29,7 @@ import type { MarketplaceService } from './types'
 
 export type {
   CloneResult,
+  FollowedListing,
   LikeResult,
   ListingDetail,
   ListingsPage,

--- a/src/services/marketplace/types.ts
+++ b/src/services/marketplace/types.ts
@@ -22,6 +22,21 @@ export interface ListingsPage {
   total: number
 }
 
+/**
+ * Listing que o usuário autenticado segue, com os campos da subscription dele.
+ * Espelha o shape `FollowedListing` consumido pelo `FollowCard` — substitui o
+ * antigo `getFollows` (Firestore). `listing` reusa o `MarketplaceListing` do
+ * portal; os demais campos vêm da subscription.
+ */
+export interface FollowedListing {
+  listingId: string
+  listing: MarketplaceListing
+  deliveryChannels: DeliveryChannels
+  extraEmails: string[]
+  webhookUrl: string
+  followedAt: string
+}
+
 export interface ReleasesPage {
   releases: Release[]
   hasMore: boolean
@@ -77,6 +92,12 @@ export interface CloneResult {
 export interface MarketplaceService {
   /** Lista listings públicos com paginação. */
   listListings(query?: ListingsQuery): Promise<ListingsPage>
+
+  /**
+   * Lista os listings que o usuário autenticado segue, com os campos da
+   * subscription dele. Substitui o `getFollows` do portal (Firestore).
+   */
+  listFollowedListings(): Promise<FollowedListing[]>
 
   /** Carrega um único listing. */
   getListing(listingId: string): Promise<ListingDetail | null>


### PR DESCRIPTION
## Contexto

Fase 1B do desacoplamento BD→GraphQL (`_plan/desacoplamento-bd-graphql.md`). Remove o acesso **direto ao Firestore** nas páginas SSR das features de clipping/marketplace, consumindo o graphql-api (resolvers da Fase 1A + `release(id)` enriquecido, já deployados em prod).

## O que muda

**Fundação:**
- `schema.graphql` snapshot atualizado; novas operations `MY_FOLLOWED_LISTINGS`, `CURRENT_USER_HAS_TELEGRAM`, `RELEASE_BY_ID` (com `recortes` + `marketplaceListingId`).
- Fachadas: `marketplaceService.listFollowedListings()`, `clippingService.getReleaseById()`, helper central `getHasTelegram()` (server-importable, substitui 4 leituras Firestore duplicadas).

**Páginas migradas (sem `getFirestoreDb`):**
- `(logged-in)/minha-conta/clipping` — `getFollows`→`myFollowedListings`, `getHasTelegram`→resolver; `editar`/`novo` só telegram.
- `(public)/clippings` galeria + detalhe — `marketplaceListings`/`marketplaceListing` com `hasLiked`/`hasFollowed` do schema (remove batch manual de likes/follows); telegram via resolver.
- `(public)/clippings/[listingId]/releases` + detalhe — releases públicas via `MarketplaceListing.releases` (público, cursor `before`).
- `clipping/release/[releaseId]` — `release(id)` via fachada; seção de recortes e link "ver no marketplace" voltam a funcionar.

## Decisões / correções de risco

- **Auth de releases:** `Clipping.releases` é **gated** (autor/subscriber); `MarketplaceListing.releases` é **público**. As páginas públicas usam o caminho público; a página do dono (`minha-conta`) continua em `clipping.releases` (autenticado). Pego no gate de build, corrigido.
- **`release(id)` agora autoriza** (público se listing-fonte ativo; senão autor/subscriber) — antes `getReleaseById` não autorizava. **Validar no E2E (1C):** página pública de release de listing ativo continua acessível anonimamente.
- **digestPreview** vem do servidor (removida a derivação local em `release-utils.ts`).
- **RSC boundary:** fachadas server-side não são `'use client'`; `pnpm build` verde (pegou e corrigiu um re-export de tipo num módulo `'use server'`).

## Validação

- `biome` ✓ · `pnpm lint` ✓ (só warnings pré-existentes) · `pnpm exec vitest run` → **517 passed** · `pnpm exec tsc --noEmit` (34 erros **pré-existentes** em testes não tocados; 0 nos arquivos desta PR) · `pnpm graphql:codegen` ✓ (sem drift) · `pnpm build` ✓.

Gate real = **E2E `e2e/graphql` (1C)** contra staging após deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
