### PR TITLE
feature: conteudo publico via GraphQL (Typesense desacoplado) — Fase 2B

### DIFF
--- a/e2e/graphql/public-content.spec.ts
+++ b/e2e/graphql/public-content.spec.ts
@@ -1,0 +1,326 @@
+/**
+ * E2E — Páginas de conteúdo PÚBLICO via GraphQL. Público (sem auth).
+ *
+ * Gate de regressão da migração Fase 2 (conteúdo público: notícias, busca,
+ * detalhe de artigo, temas, órgãos) de Typesense direto → `graphql-api`.
+ *
+ * Estratégia: antes de assertar cada página, deriva DADOS REAIS chamando o
+ * graphql-api direto (queries públicas, sem token) — nada de IDs/labels
+ * hardcoded e nada de `test.skip` data-dependent. Se o índice de produção não
+ * tiver os dados mínimos, FALHAMOS com mensagem acionável (a pré-condição é que
+ * o ambiente tenha conteúdo).
+ *
+ * As operações espelham as que o portal usa em `src/services/content/graphql.ts`
+ * e `src/lib/graphql/queries/articles.ts`.
+ */
+
+import { expect, type Page, test } from '@playwright/test'
+import { assertDataPreconditions, graphqlApiUrl } from '../fixtures'
+
+// ---------- Cliente GraphQL público (sem auth) ----------
+
+async function publicGraphQL<T>(
+  query: string,
+  variables: Record<string, unknown> = {},
+): Promise<T> {
+  const url = graphqlApiUrl()
+  let res: Response
+  try {
+    res = await fetch(url, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Accept: 'application/json',
+      },
+      body: JSON.stringify({ query, variables }),
+    })
+  } catch (err) {
+    throw new Error(
+      `Falha de rede ao chamar ${url}: ${(err as Error).message}. ` +
+        'O graphql-api está no ar? (make dev / E2E_GRAPHQL_URL)',
+    )
+  }
+  if (!res.ok) {
+    throw new Error(`graphql-api HTTP ${res.status} em ${url}`)
+  }
+  const json = (await res.json()) as {
+    data?: T
+    errors?: Array<{ message: string }>
+  }
+  if (json.errors?.length) {
+    throw new Error(
+      `GraphQL errors: ${json.errors.map((e) => e.message).join('; ')}`,
+    )
+  }
+  if (json.data == null) throw new Error('GraphQL retornou data vazio')
+  return json.data
+}
+
+// ---------- Queries de derivação (espelham o portal) ----------
+
+const ARTICLES_QUERY = /* GraphQL */ `
+  query DeriveArticles($page: Int!, $limit: Int!, $filter: ArticleFilter) {
+    articles(page: $page, limit: $limit, filter: $filter) {
+      articles { uniqueId title }
+      found
+    }
+  }
+`
+
+const THEMES_QUERY = /* GraphQL */ `
+  query DeriveThemes { themes { code label } }
+`
+
+const AGENCIES_QUERY = /* GraphQL */ `
+  query DeriveAgencies { agencies { code label } }
+`
+
+const RELATED_ARTICLES_QUERY = /* GraphQL */ `
+  query DeriveRelated($uniqueId: String!, $limit: Int!) {
+    relatedArticles(uniqueId: $uniqueId, limit: $limit) { uniqueId }
+  }
+`
+
+type ArticlesData = {
+  articles: {
+    articles: Array<{ uniqueId: string; title: string }>
+    found: number
+  }
+}
+
+// ---------- Helpers de derivação ----------
+
+/** Primeiro artigo deduplicado do índice (uniqueId + title). FALHA se vazio. */
+async function deriveFirstArticle(): Promise<{
+  uniqueId: string
+  title: string
+}> {
+  const data = await publicGraphQL<ArticlesData>(ARTICLES_QUERY, {
+    page: 1,
+    limit: 1,
+    filter: { dedup: true },
+  })
+  if (data.articles.found <= 0 || data.articles.articles.length === 0) {
+    throw new Error(
+      'Pré-condição falhou: `articles(dedup:true)` não retornou artigos. ' +
+        'O índice (Typesense) precisa estar populado para este gate.',
+    )
+  }
+  const first = data.articles.articles[0]
+  expect(first.uniqueId, 'artigo derivado deve ter uniqueId').toBeTruthy()
+  expect(first.title, 'artigo derivado deve ter title').toBeTruthy()
+  return first
+}
+
+/**
+ * Extrai um termo de busca "estável" do título de um artigo real: a primeira
+ * palavra com >= 4 chars apenas alfabéticos (evita stopwords/pontuação/números
+ * que podem não casar no Typesense).
+ */
+function deriveSearchTerm(title: string): string {
+  const word = title
+    .split(/\s+/)
+    .map((w) => w.replace(/[^\p{L}]/gu, ''))
+    .find((w) => w.length >= 4)
+  if (!word) {
+    throw new Error(
+      `Não consegui derivar um termo de busca do título "${title}". ` +
+        'Título sem palavra alfabética >= 4 chars — improvável; investigue o índice.',
+    )
+  }
+  return word
+}
+
+/**
+ * Acha o primeiro tema (label) que efetivamente retorna artigos pelo filtro
+ * `themeLabel` — o mesmo filtro que a página `/temas/[label]` usa. Garante que
+ * a página detalhe terá conteúdo a renderizar. FALHA se nenhum tema tiver dados.
+ */
+async function deriveThemeWithArticles(): Promise<string> {
+  const { themes } = await publicGraphQL<{
+    themes: Array<{ code: string; label: string }>
+  }>(THEMES_QUERY)
+  const labeled = themes.filter((t) => t.label?.trim())
+  if (labeled.length === 0) {
+    throw new Error(
+      'Pré-condição falhou: `themes` não retornou nenhum tema com label. ' +
+        'O Postgres (govbrnews) precisa estar populado.',
+    )
+  }
+  for (const theme of labeled) {
+    const data = await publicGraphQL<ArticlesData>(ARTICLES_QUERY, {
+      page: 1,
+      limit: 1,
+      filter: { themeLabel: theme.label, dedup: true },
+    })
+    if (data.articles.found > 0) return theme.label
+  }
+  throw new Error(
+    'Pré-condição falhou: nenhum tema retornado por `themes` tem artigos ' +
+      `(testados ${labeled.length} temas via filtro themeLabel). Índice vazio?`,
+  )
+}
+
+/**
+ * Acha a primeira agência (code) que retorna artigos pelo filtro `agencies` —
+ * o mesmo filtro que `/orgaos/[key]` usa. FALHA se nenhuma tiver dados.
+ */
+async function deriveAgencyWithArticles(): Promise<{
+  code: string
+  label: string
+}> {
+  const { agencies } = await publicGraphQL<{
+    agencies: Array<{ code: string; label: string }>
+  }>(AGENCIES_QUERY)
+  if (agencies.length === 0) {
+    throw new Error(
+      'Pré-condição falhou: `agencies` não retornou nenhuma agência. ' +
+        'O Postgres (govbrnews) precisa estar populado.',
+    )
+  }
+  for (const agency of agencies) {
+    if (!agency.code?.trim()) continue
+    const data = await publicGraphQL<ArticlesData>(ARTICLES_QUERY, {
+      page: 1,
+      limit: 1,
+      filter: { agencies: [agency.code], dedup: true },
+    })
+    if (data.articles.found > 0) return agency
+  }
+  throw new Error(
+    'Pré-condição falhou: nenhuma agência de `agencies` tem artigos ' +
+      `(testadas ${agencies.length}). Índice vazio?`,
+  )
+}
+
+/** Locator de qualquer card de notícia: um link para `/artigos/<id>`. */
+function articleLinks(page: Page) {
+  return page.locator('a[href^="/artigos/"]')
+}
+
+// ---------- Suíte ----------
+
+test.beforeAll(async () => {
+  await assertDataPreconditions()
+})
+
+test.describe('Conteúdo público via GraphQL', () => {
+  test('feed /noticias renderiza cards de notícia (links /artigos/)', async ({
+    page,
+  }) => {
+    // `/noticias` é o feed migrado (getLatestArticles → graphql-api). A landing
+    // `/` é institucional e não lista artigos; o feed real de cards é este.
+    await page.goto('/noticias')
+    const cards = articleLinks(page)
+    await expect(cards.first()).toBeVisible({ timeout: 20_000 })
+    expect(
+      await cards.count(),
+      'feed deve ter ao menos um card',
+    ).toBeGreaterThan(0)
+    // O href deve apontar para um detalhe de artigo concreto.
+    const href = await cards.first().getAttribute('href')
+    expect(href).toMatch(/^\/artigos\/.+/)
+  })
+
+  test('busca /busca?q=<termo> renderiza resultados (links /artigos/)', async ({
+    page,
+  }) => {
+    const article = await deriveFirstArticle()
+    const term = deriveSearchTerm(article.title)
+
+    await page.goto(`/busca?q=${encodeURIComponent(term)}`)
+
+    // Cabeçalho da página de busca confirma o termo (QueryPageClient).
+    await expect(
+      page.getByRole('heading', { name: `Resultados para "${term}"` }),
+    ).toBeVisible({ timeout: 20_000 })
+
+    // Resultados: ao menos um card de artigo para um termo tirado de um título real.
+    const cards = articleLinks(page)
+    await expect(cards.first()).toBeVisible({ timeout: 20_000 })
+    expect(
+      await cards.count(),
+      `busca por "${term}" (do título "${article.title}") deveria ter resultados`,
+    ).toBeGreaterThan(0)
+  })
+
+  test('detalhe /artigos/[uniqueId] renderiza título e relacionados', async ({
+    page,
+  }) => {
+    const article = await deriveFirstArticle()
+    const related = await publicGraphQL<{
+      relatedArticles: Array<{ uniqueId: string }>
+    }>(RELATED_ARTICLES_QUERY, { uniqueId: article.uniqueId, limit: 4 })
+
+    await page.goto(`/artigos/${encodeURIComponent(article.uniqueId)}`)
+
+    // O título do artigo é o <h1> da página (ClientArticle).
+    await expect(
+      page.getByRole('heading', { level: 1, name: article.title }),
+    ).toBeVisible({ timeout: 20_000 })
+
+    // Seção de relacionados só renderiza quando `relatedArticles` retorna dados.
+    if (related.relatedArticles.length > 0) {
+      await expect(
+        page.getByRole('heading', { name: 'Notícias relacionadas' }),
+      ).toBeVisible({ timeout: 20_000 })
+      // E os cards relacionados são links para outros artigos.
+      const relatedSection = page
+        .locator('section')
+        .filter({ hasText: 'Notícias relacionadas' })
+      await expect(
+        relatedSection.locator('a[href^="/artigos/"]').first(),
+      ).toBeVisible({ timeout: 20_000 })
+    }
+  })
+
+  test('listagem /temas renderiza e /temas/[label] renderiza artigos', async ({
+    page,
+  }) => {
+    const themeLabel = await deriveThemeWithArticles()
+
+    // Listagem de temas: deve linkar para detalhes de tema.
+    await page.goto('/temas')
+    await expect(page.locator('a[href^="/temas/"]').first()).toBeVisible({
+      timeout: 20_000,
+    })
+
+    // Detalhe do tema (label URL-encoded). Cabeçalho = label; deve listar artigos.
+    await page.goto(`/temas/${encodeURIComponent(themeLabel)}`)
+    await expect(page.getByRole('heading', { name: themeLabel })).toBeVisible({
+      timeout: 20_000,
+    })
+
+    const cards = articleLinks(page)
+    await expect(cards.first()).toBeVisible({ timeout: 20_000 })
+    expect(
+      await cards.count(),
+      `tema "${themeLabel}" deveria listar artigos`,
+    ).toBeGreaterThan(0)
+  })
+
+  test('detalhe /orgaos/[key] renderiza artigos do órgão', async ({ page }) => {
+    const agency = await deriveAgencyWithArticles()
+
+    await page.goto(`/orgaos/${encodeURIComponent(agency.code)}`)
+
+    // Cabeçalho do órgão = nome da agência (h2, AgencyPageClient). O nome vem do
+    // YAML do portal (agencies-utils), então assertamos no subtítulo institucional
+    // estável em vez do label do GraphQL para evitar divergência de fonte.
+    await expect(
+      page.getByText(
+        'Acompanhe as notícias e publicações oficiais deste órgão.',
+      ),
+    ).toBeVisible({ timeout: 20_000 })
+    await expect(page.getByRole('heading', { level: 2 }).first()).toBeVisible({
+      timeout: 20_000,
+    })
+
+    const cards = articleLinks(page)
+    await expect(cards.first()).toBeVisible({ timeout: 20_000 })
+    expect(
+      await cards.count(),
+      `órgão "${agency.code}" (${agency.label}) deveria listar artigos`,
+    ).toBeGreaterThan(0)
+  })
+})

--- a/src/app/(public)/actions.ts
+++ b/src/app/(public)/actions.ts
@@ -6,11 +6,12 @@ import { getPrioritizedArticles } from '@/config/prioritization'
 import { loadConfig } from '@/config/prioritization-config'
 import { createSSRClient } from '@/lib/graphql/client'
 import { withResult } from '@/lib/result'
-import { getContentService } from '@/services/content'
+import { createGraphQLContentService } from '@/services/content/graphql'
 import type { ArticleRow } from '@/types/article'
 
 // Conteúdo público não precisa de token de autenticação.
-const content = () => getContentService(createSSRClient(async () => null))
+const content = () =>
+  createGraphQLContentService(createSSRClient(async () => null))
 
 // Internal function for fetching latest articles
 const fetchLatestArticles = cache(async (): Promise<ArticleRow[]> => {

--- a/src/app/(public)/actions.ts
+++ b/src/app/(public)/actions.ts
@@ -4,9 +4,13 @@ import { startOfMonth, subDays } from 'date-fns'
 import { cache } from 'react'
 import { getPrioritizedArticles } from '@/config/prioritization'
 import { loadConfig } from '@/config/prioritization-config'
+import { createSSRClient } from '@/lib/graphql/client'
 import { withResult } from '@/lib/result'
-import { typesense } from '@/services/typesense/client'
+import { getContentService } from '@/services/content'
 import type { ArticleRow } from '@/types/article'
+
+// Conteúdo público não precisa de token de autenticação.
+const content = () => getContentService(createSSRClient(async () => null))
 
 // Internal function for fetching latest articles
 const fetchLatestArticles = cache(async (): Promise<ArticleRow[]> => {
@@ -16,20 +20,11 @@ const fetchLatestArticles = cache(async (): Promise<ArticleRow[]> => {
 
     // Buscar mais artigos para ter pool maior para scoring
     // (buscamos 50 para garantir diversidade após filtros)
-    const result = await typesense
-      .collections<ArticleRow>('news')
-      .documents()
-      .search({
-        q: '*',
-        limit: 50,
-        sort_by: 'published_at:desc',
-        group_by: 'content_hash',
-        group_limit: 1,
-      })
-
-    const articles = result.grouped_hits?.flatMap((group) =>
-      group.hits.map((hit) => hit.document),
-    ) as ArticleRow[]
+    // O resolver ordena por published_at desc; dedup por content_hash.
+    const { articles } = await content().listArticles({
+      limit: 50,
+      dedup: true,
+    })
 
     // Aplicar priorização
     const prioritized = getPrioritizedArticles(articles, config, 11)
@@ -39,19 +34,11 @@ const fetchLatestArticles = cache(async (): Promise<ArticleRow[]> => {
     console.error('[getLatestArticles] Error applying prioritization:', error)
 
     // Fallback: retornar ordenação cronológica
-    const result = await typesense
-      .collections<ArticleRow>('news')
-      .documents()
-      .search({
-        q: '*',
-        limit: 11,
-        sort_by: 'published_at:desc',
-        group_by: 'content_hash',
-        group_limit: 1,
-      })
-    return result.grouped_hits?.flatMap((group) =>
-      group.hits.map((hit) => hit.document),
-    ) as ArticleRow[]
+    const { articles } = await content().listArticles({
+      limit: 11,
+      dedup: true,
+    })
+    return articles
   }
 })
 
@@ -69,20 +56,18 @@ const fetchThemes = cache(async (): Promise<GetThemesResult> => {
     // Carregar configuração de priorização
     const config = await loadConfig()
 
-    const sevenDaysAgo = subDays(new Date(), 7).getTime()
+    const sevenDaysAgo = subDays(new Date(), 7).toISOString()
 
-    // Buscar artigos dos últimos 7 dias
-    const result = await typesense
-      .collections<ArticleRow>('news')
-      .documents()
-      .search({
-        q: '*',
-        filter_by: `published_at:>${Math.floor(sevenDaysAgo / 1000)}`,
-        limit: 250, // Buscar mais artigos para melhor análise
-        sort_by: 'published_at:desc',
-      })
-
-    const articles = result.hits?.map((hit) => hit.document) as ArticleRow[]
+    // Buscar artigos dos últimos 7 dias.
+    // NOTA: usamos `listArticles` (artigos crus) em vez de
+    // `getThemeArticleCounts` porque `calculateThemeScores` precisa pontuar
+    // cada artigo individualmente (peso de órgão/tema, recência, boosts). O
+    // endpoint de contagens só devolve totais — insuficiente para os modos
+    // `weighted`/`volume` configurados. Isso preserva o output atual.
+    const { articles } = await content().listArticles({
+      filter: { startDate: sevenDaysAgo },
+      limit: 250, // Buscar mais artigos para melhor análise
+    })
 
     // Usar calculateThemeScores para selecionar temas baseado no modo configurado
     const { calculateThemeScores } = await import('@/config/prioritization')
@@ -121,34 +106,20 @@ const fetchThemes = cache(async (): Promise<GetThemesResult> => {
   } catch (error) {
     console.error('[getThemes] Error applying prioritization:', error)
 
-    // Fallback: usar método original (volume)
-    const sevenDaysAgo = subDays(new Date(), 7).getTime()
+    // Fallback: usar método original (volume) — contagem por tema dos últimos
+    // 7 dias, nível 1.
+    try {
+      const counts = await content().getThemeArticleCounts(7, 1)
 
-    const result = await typesense
-      .collections<ArticleRow>('news')
-      .documents()
-      .search({
-        q: '*',
-        group_by: 'theme_1_level_1_label',
-        filter_by: `published_at:>${Math.floor(sevenDaysAgo / 1000)}`,
-        limit: 26,
-      })
-
-    const themesCount: Record<string, number> = {}
-
-    for (const group of result.grouped_hits ?? []) {
-      themesCount[group.group_key[0]] = group.found ?? 0
+      return counts
+        .filter((t) => t.label)
+        .map((t) => ({ name: t.label as string, count: t.count }))
+        .sort((a, b) => b.count - a.count)
+        .slice(0, 4)
+    } catch (fallbackError) {
+      console.error('[getThemes] Fallback also failed:', fallbackError)
+      return []
     }
-
-    delete themesCount.undefined
-    delete themesCount['']
-
-    const countResult = Object.keys(themesCount)
-      .map((themeName) => ({ name: themeName, count: themesCount[themeName] }))
-      .sort((a, b) => b.count - a.count)
-      .slice(0, 4)
-
-    return countResult
   }
 })
 
@@ -157,17 +128,14 @@ export const getThemes = withResult(fetchThemes)
 
 // Internal function for counting monthly news
 const fetchMonthlyNews = cache(async (): Promise<number> => {
-  const thisMonth = startOfMonth(new Date()).getTime() / 1000
+  const thisMonth = startOfMonth(new Date()).toISOString()
 
-  const result = await typesense
-    .collections<ArticleRow>('news')
-    .documents()
-    .search({
-      q: '*',
-      filter_by: `published_at:>${thisMonth}`,
-    })
+  const { found } = await content().listArticles({
+    limit: 0,
+    filter: { startDate: thisMonth },
+  })
 
-  return result.found
+  return found
 })
 
 // Public API with Result wrapper
@@ -175,15 +143,9 @@ export const countMonthlyNews = withResult(fetchMonthlyNews)
 
 // Internal function for counting total news
 const fetchTotalNews = cache(async (): Promise<number> => {
-  const result = await typesense
-    .collections<ArticleRow>('news')
-    .documents()
-    .search({
-      q: '*',
-      limit: 0,
-    })
+  const { found } = await content().listArticles({ limit: 0 })
 
-  return result.found
+  return found
 })
 
 // Public API with Result wrapper
@@ -194,17 +156,12 @@ const fetchLatestByTheme = cache(
   async (theme: string, limit: number | null): Promise<ArticleRow[]> => {
     if (!theme) return []
 
-    const result = await typesense
-      .collections<ArticleRow>('news')
-      .documents()
-      .search({
-        q: '*',
-        filter_by: `theme_1_level_1_label:=${theme}`,
-        sort_by: 'published_at:desc',
-        limit: limit ?? 2,
-      })
+    const { articles } = await content().listArticles({
+      filter: { themeLabel: theme },
+      limit: limit ?? 2,
+    })
 
-    return result.hits?.map((hit) => hit.document) as ArticleRow[]
+    return articles
   },
 )
 
@@ -214,30 +171,28 @@ export const getLatestByTheme = withResult(fetchLatestByTheme)
 // Type for batch theme articles result
 export type ThemesWithArticles = Record<string, ArticleRow[]>
 
-// Internal function for fetching articles for multiple themes in a single query
+// Internal function for fetching articles for multiple themes
 const fetchLatestByThemes = cache(
   async (themes: string[], limitPerTheme = 2): Promise<ThemesWithArticles> => {
     if (!themes.length) return {}
 
-    // Single query with group_by for all themes
-    const result = await typesense
-      .collections<ArticleRow>('news')
-      .documents()
-      .search({
-        q: '*',
-        filter_by: `theme_1_level_1_label:[${themes.join(',')}]`,
-        group_by: 'theme_1_level_1_label',
-        group_limit: limitPerTheme,
-        sort_by: 'published_at:desc',
-        limit: themes.length * limitPerTheme,
-      })
+    const svc = content()
 
-    // Transform grouped results into a record
+    // Uma query por tema. A landing é ISR-cacheada, então o loop é aceitável.
+    const entries = await Promise.all(
+      themes.map(async (theme) => {
+        const { articles } = await svc.listArticles({
+          filter: { themeLabel: theme },
+          limit: limitPerTheme,
+          dedup: true,
+        })
+        return [theme, articles] as const
+      }),
+    )
+
     const grouped: ThemesWithArticles = {}
-    for (const group of result.grouped_hits ?? []) {
-      const themeName = group.group_key[0]
-      grouped[themeName] = (group.hits?.map((h) => h.document) ??
-        []) as ArticleRow[]
+    for (const [theme, articles] of entries) {
+      grouped[theme] = articles
     }
 
     return grouped

--- a/src/app/(public)/artigos/[articleId]/__tests__/actions.test.ts
+++ b/src/app/(public)/artigos/[articleId]/__tests__/actions.test.ts
@@ -23,8 +23,8 @@ vi.mock('@/lib/graphql/client', () => ({
   createSSRClient: vi.fn(() => ({}) as unknown),
 }))
 
-vi.mock('@/services/content', () => ({
-  getContentService: vi.fn(() => fakeService),
+vi.mock('@/services/content/graphql', () => ({
+  createGraphQLContentService: vi.fn(() => fakeService),
 }))
 
 vi.mock('@/data/agencies-utils', () => ({

--- a/src/app/(public)/artigos/[articleId]/__tests__/actions.test.ts
+++ b/src/app/(public)/artigos/[articleId]/__tests__/actions.test.ts
@@ -1,0 +1,114 @@
+/**
+ * Testes das server actions de detalhe de artigo (Fase 2B — Typesense → GraphQL).
+ *
+ * Mockamos o facade `@/services/content`, `createSSRClient` e a enriquecimento
+ * de agência (`getAgencyField`) para asserir o tratamento de erro (`Result`),
+ * o enrich de nome de agência e o repasse a `getRelatedArticles`.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { ContentService } from '@/services/content'
+import type { ArticleRow } from '@/types/article'
+
+const getArticle = vi.fn()
+const getRelatedArticles = vi.fn()
+const getAgencyField = vi.fn()
+
+const fakeService = {
+  getArticle,
+  getRelatedArticles,
+} as unknown as ContentService
+
+vi.mock('@/lib/graphql/client', () => ({
+  createSSRClient: vi.fn(() => ({}) as unknown),
+}))
+
+vi.mock('@/services/content', () => ({
+  getContentService: vi.fn(() => fakeService),
+}))
+
+vi.mock('@/data/agencies-utils', () => ({
+  getAgencyField: (...args: unknown[]) => getAgencyField(...args),
+}))
+
+import { getArticleById, getSimilarArticles } from '../actions'
+
+function row(overrides: Partial<ArticleRow> = {}): ArticleRow {
+  return {
+    unique_id: 'a-1',
+    title: 'Título',
+    agency: 'min-saude',
+    published_at: 1000,
+    ...overrides,
+  } as ArticleRow
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('getArticleById', () => {
+  it('retorna ok com nome de agência enriquecido', async () => {
+    getArticle.mockResolvedValue(row({ agency: 'min-saude' }))
+    getAgencyField.mockResolvedValue('Ministério da Saúde')
+
+    const result = await getArticleById('a-1')
+
+    expect(getArticle).toHaveBeenCalledWith('a-1')
+    expect(getAgencyField).toHaveBeenCalledWith('min-saude', 'name')
+    expect(result.type).toBe('ok')
+    if (result.type === 'ok') {
+      expect(result.data.agency).toBe('Ministério da Saúde')
+      expect(result.data.unique_id).toBe('a-1')
+    }
+  })
+
+  it('faz fallback do nome de agência quando getAgencyField não resolve', async () => {
+    getArticle.mockResolvedValue(row())
+    getAgencyField.mockResolvedValue(undefined)
+
+    const result = await getArticleById('a-1')
+    expect(result.type).toBe('ok')
+    if (result.type === 'ok') {
+      expect(result.data.agency).toBe('Órgão público federal')
+    }
+  })
+
+  it('retorna err not_found quando o artigo não existe', async () => {
+    getArticle.mockResolvedValue(null)
+
+    const result = await getArticleById('missing')
+    expect(result.type).toBe('err')
+    if (result.type === 'err') {
+      expect(result.error).toBe('not_found')
+    }
+  })
+
+  it('retorna err db_error quando o facade lança', async () => {
+    getArticle.mockRejectedValue(new Error('network'))
+
+    const result = await getArticleById('a-1')
+    expect(result.type).toBe('err')
+    if (result.type === 'err') {
+      expect(result.error).toBe('db_error')
+    }
+  })
+})
+
+describe('getSimilarArticles', () => {
+  it('repassa para getRelatedArticles com unique_id e limit', async () => {
+    const related = [row({ unique_id: 'b-1' })]
+    getRelatedArticles.mockResolvedValue(related)
+
+    const out = await getSimilarArticles(row({ unique_id: 'a-1' }), 6)
+
+    expect(getRelatedArticles).toHaveBeenCalledWith('a-1', 6)
+    expect(out).toBe(related)
+  })
+
+  it('usa limit default 4', async () => {
+    getRelatedArticles.mockResolvedValue([])
+    await getSimilarArticles(row({ unique_id: 'a-1' }))
+    expect(getRelatedArticles).toHaveBeenCalledWith('a-1', 4)
+  })
+})

--- a/src/app/(public)/artigos/[articleId]/actions.ts
+++ b/src/app/(public)/artigos/[articleId]/actions.ts
@@ -3,14 +3,14 @@
 import { getAgencyField } from '@/data/agencies-utils'
 import { createSSRClient } from '@/lib/graphql/client'
 import { ResultError, withResult } from '@/lib/result'
-import { getContentService } from '@/services/content'
+import { createGraphQLContentService } from '@/services/content/graphql'
 import type { ArticleRow } from '@/types/article'
 
 export type GetArticleError = 'not_found' | 'db_error'
 
 /** Cliente GraphQL público (sem token) para as server actions de artigo. */
 function content() {
-  return getContentService(createSSRClient(async () => null))
+  return createGraphQLContentService(createSSRClient(async () => null))
 }
 
 export const getArticleById = withResult(

--- a/src/app/(public)/artigos/[articleId]/actions.ts
+++ b/src/app/(public)/artigos/[articleId]/actions.ts
@@ -1,32 +1,33 @@
 'use server'
 
 import { getAgencyField } from '@/data/agencies-utils'
+import { createSSRClient } from '@/lib/graphql/client'
 import { ResultError, withResult } from '@/lib/result'
-import { typesense } from '@/services/typesense/client'
+import { getContentService } from '@/services/content'
 import type { ArticleRow } from '@/types/article'
 
 export type GetArticleError = 'not_found' | 'db_error'
 
+/** Cliente GraphQL público (sem token) para as server actions de artigo. */
+function content() {
+  return getContentService(createSSRClient(async () => null))
+}
+
 export const getArticleById = withResult(
   async (id: string): Promise<ArticleRow> => {
-    const result = await typesense
-      .collections<ArticleRow>('news')
-      .documents()
-      .search({
-        q: '*',
-        filter_by: `unique_id:=${id}`,
-      })
+    let article: ArticleRow | null
+    try {
+      article = await content().getArticle(id)
+    } catch {
+      throw new ResultError<GetArticleError>('db_error')
+    }
 
-    if (!result.hits || result.hits.length === 0)
-      throw new ResultError<GetArticleError>('not_found')
+    if (!article) throw new ResultError<GetArticleError>('not_found')
 
-    const agencyName = await getAgencyField(
-      result.hits[0].document.agency,
-      'name',
-    )
+    const agencyName = await getAgencyField(article.agency, 'name')
 
     return {
-      ...result.hits[0].document,
+      ...article,
       agency: agencyName || 'Órgão público federal',
     }
   },
@@ -37,31 +38,7 @@ export async function getSimilarArticles(
   article: ArticleRow,
   limit = 4,
 ): Promise<ArticleRow[]> {
-  const filters: string[] = [`unique_id:!=${article.unique_id}`]
-
-  if (article.most_specific_theme_code) {
-    filters.push(
-      `(theme_1_level_1_code:=${article.most_specific_theme_code} || theme_1_level_2_code:=${article.most_specific_theme_code} || theme_1_level_3_code:=${article.most_specific_theme_code})`,
-    )
-  } else if (article.theme_1_level_1_code) {
-    filters.push(`theme_1_level_1_code:=${article.theme_1_level_1_code}`)
-  }
-
-  const result = await typesense
-    .collections<ArticleRow>('news')
-    .documents()
-    .search({
-      q: '*',
-      filter_by: filters.join(' && '),
-      sort_by: 'published_at:desc',
-      group_by: 'content_hash',
-      group_limit: 1,
-      limit,
-    })
-
-  return (
-    result.grouped_hits?.flatMap((group) =>
-      group.hits.map((hit) => hit.document),
-    ) ?? []
-  )
+  // O graphql-api `relatedArticles` replica server-side a lógica baseada em
+  // tema (mesmo `most_specific_theme_code`/nível 1) que antes vivia aqui.
+  return content().getRelatedArticles(article.unique_id, limit)
 }

--- a/src/app/(public)/busca/__tests__/actions.test.ts
+++ b/src/app/(public)/busca/__tests__/actions.test.ts
@@ -1,0 +1,213 @@
+/**
+ * Testes das server actions de busca (Fase 2B — migração Typesense → GraphQL).
+ *
+ * Mockamos o facade `@/services/content` e o `createSSRClient` para asserir
+ * o mapeamento de argumentos e a preservação dos formatos de retorno, sem
+ * tocar no GraphQL real.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { ContentService } from '@/services/content'
+import type { ArticleRow } from '@/types/article'
+
+// ---------- Mocks ----------
+
+const searchArticles = vi.fn()
+const getSearchSuggestions = vi.fn()
+
+const fakeService = {
+  searchArticles,
+  getSearchSuggestions,
+} as unknown as ContentService
+
+vi.mock('@/lib/graphql/client', () => ({
+  createSSRClient: vi.fn(() => ({}) as unknown),
+}))
+
+vi.mock('@/services/content', () => ({
+  getContentService: vi.fn(() => fakeService),
+}))
+
+// removeDiacritics é usado pela derivação de autocomplete — usamos o real.
+
+import {
+  getCombinedSearchResults,
+  getInlineAutocompleteSuggestion,
+  getSearchSuggestions as getSearchSuggestionsAction,
+  queryArticles,
+} from '../actions'
+
+function row(overrides: Partial<ArticleRow> = {}): ArticleRow {
+  return {
+    unique_id: 'a-1',
+    title: 'Título',
+    agency: 'ag',
+    published_at: 1000,
+  } as ArticleRow
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('queryArticles', () => {
+  it('mapeia para searchArticles com semantic+alpha:0.8+dedup e filtros', async () => {
+    searchArticles.mockResolvedValue({
+      articles: [row()],
+      found: 5,
+      page: 2,
+    })
+
+    const result = await queryArticles({
+      query: '  inteligência   artificial ',
+      page: 2,
+      startDate: 1_700_000_000_000,
+      endDate: 1_700_086_400_000,
+      agencies: ['min-a'],
+      themes: ['01'],
+    })
+
+    expect(searchArticles).toHaveBeenCalledTimes(1)
+    const arg = searchArticles.mock.calls[0][0]
+    expect(arg.query).toBe('inteligência artificial')
+    expect(arg.page).toBe(2)
+    expect(arg.semantic).toBe(true)
+    expect(arg.alpha).toBe(0.8)
+    expect(arg.dedup).toBe(true)
+    expect(arg.filter.agencies).toEqual(['min-a'])
+    expect(arg.filter.themes).toEqual(['01'])
+    // endDate é exclusivo do dia seguinte (+ 86.400.000 ms)
+    expect(arg.filter.startDate).toBe(new Date(1_700_000_000_000).toISOString())
+    expect(arg.filter.endDate).toBe(
+      new Date(1_700_086_400_000 + 86_400_000).toISOString(),
+    )
+
+    // Contrato preservado: page é o cursor da PRÓXIMA página (page + 1)
+    expect(result).toEqual({
+      articles: [row()],
+      page: 3,
+      found: 5,
+    })
+  })
+
+  it('passa filtros nulos e query vazia quando não fornecidos; semantic default true', async () => {
+    searchArticles.mockResolvedValue({ articles: [], found: 0, page: 1 })
+
+    const result = await queryArticles({ page: 1 })
+
+    const arg = searchArticles.mock.calls[0][0]
+    expect(arg.query).toBe('')
+    expect(arg.semantic).toBe(true)
+    expect(arg.filter.agencies).toBeNull()
+    expect(arg.filter.themes).toBeNull()
+    expect(arg.filter.startDate).toBeNull()
+    expect(arg.filter.endDate).toBeNull()
+    expect(result.page).toBe(2)
+  })
+
+  it('respeita semantic:false explícito', async () => {
+    searchArticles.mockResolvedValue({ articles: [], found: 0, page: 1 })
+    await queryArticles({ page: 1, query: 'x', semantic: false })
+    expect(searchArticles.mock.calls[0][0].semantic).toBe(false)
+  })
+})
+
+describe('getSearchSuggestions', () => {
+  it('retorna [] para query curta sem chamar o facade', async () => {
+    expect(await getSearchSuggestionsAction('a')).toEqual([])
+    expect(getSearchSuggestions).not.toHaveBeenCalled()
+  })
+
+  it('mapeia uniqueId→unique_id e limita a 7', async () => {
+    const many = Array.from({ length: 10 }, (_, i) => ({
+      uniqueId: `id-${i}`,
+      title: `Título ${i}`,
+    }))
+    getSearchSuggestions.mockResolvedValue(many)
+
+    const out = await getSearchSuggestionsAction('inteligencia')
+
+    expect(getSearchSuggestions).toHaveBeenCalledWith('inteligencia')
+    expect(out).toHaveLength(7)
+    expect(out[0]).toEqual({ unique_id: 'id-0', title: 'Título 0' })
+  })
+
+  it('retorna [] em erro do facade', async () => {
+    getSearchSuggestions.mockRejectedValue(new Error('boom'))
+    expect(await getSearchSuggestionsAction('teste')).toEqual([])
+  })
+})
+
+describe('getInlineAutocompleteSuggestion', () => {
+  it('deriva completude da última palavra a partir dos títulos das sugestões', async () => {
+    getSearchSuggestions.mockResolvedValue([
+      { uniqueId: '1', title: 'Diplomacia brasileira avança' },
+    ])
+
+    const out = await getInlineAutocompleteSuggestion('Diplo')
+
+    expect(getSearchSuggestions).toHaveBeenCalledWith('Diplo')
+    expect(out).toEqual({ completion: 'Diplomacia', suffix: 'macia' })
+  })
+
+  it('respeita palavras anteriores na frase', async () => {
+    getSearchSuggestions.mockResolvedValue([
+      { uniqueId: '1', title: 'Inteligência artificial no governo' },
+      { uniqueId: '2', title: 'Saúde pública nacional' },
+    ])
+
+    const out = await getInlineAutocompleteSuggestion('Inteligência art')
+
+    expect(out).toEqual({
+      completion: 'Inteligência artificial',
+      suffix: 'ificial',
+    })
+  })
+
+  it('retorna null para query curta', async () => {
+    expect(await getInlineAutocompleteSuggestion('a')).toBeNull()
+  })
+
+  it('retorna null em erro do facade', async () => {
+    getSearchSuggestions.mockRejectedValue(new Error('boom'))
+    expect(await getInlineAutocompleteSuggestion('diplo')).toBeNull()
+  })
+})
+
+describe('getCombinedSearchResults', () => {
+  it('faz uma única chamada e retorna sugestões (top-7) + autocomplete', async () => {
+    const data = [
+      { uniqueId: '1', title: 'Diplomacia brasileira' },
+      ...Array.from({ length: 9 }, (_, i) => ({
+        uniqueId: `x-${i}`,
+        title: `Outro ${i}`,
+      })),
+    ]
+    getSearchSuggestions.mockResolvedValue(data)
+
+    const out = await getCombinedSearchResults('Diplo')
+
+    expect(getSearchSuggestions).toHaveBeenCalledTimes(1)
+    expect(out.suggestions).toHaveLength(7)
+    expect(out.suggestions[0]).toEqual({
+      unique_id: '1',
+      title: 'Diplomacia brasileira',
+    })
+    expect(out.inlineAutocomplete).toEqual({
+      completion: 'Diplomacia',
+      suffix: 'macia',
+    })
+  })
+
+  it('retorna vazio para query curta', async () => {
+    const out = await getCombinedSearchResults('a')
+    expect(out).toEqual({ suggestions: [], inlineAutocomplete: null })
+    expect(getSearchSuggestions).not.toHaveBeenCalled()
+  })
+
+  it('retorna vazio em erro do facade', async () => {
+    getSearchSuggestions.mockRejectedValue(new Error('boom'))
+    const out = await getCombinedSearchResults('diplo')
+    expect(out).toEqual({ suggestions: [], inlineAutocomplete: null })
+  })
+})

--- a/src/app/(public)/busca/__tests__/actions.test.ts
+++ b/src/app/(public)/busca/__tests__/actions.test.ts
@@ -24,8 +24,8 @@ vi.mock('@/lib/graphql/client', () => ({
   createSSRClient: vi.fn(() => ({}) as unknown),
 }))
 
-vi.mock('@/services/content', () => ({
-  getContentService: vi.fn(() => fakeService),
+vi.mock('@/services/content/graphql', () => ({
+  createGraphQLContentService: vi.fn(() => fakeService),
 }))
 
 // removeDiacritics é usado pela derivação de autocomplete — usamos o real.

--- a/src/app/(public)/busca/actions.ts
+++ b/src/app/(public)/busca/actions.ts
@@ -2,7 +2,7 @@
 
 import { createSSRClient } from '@/lib/graphql/client'
 import { removeDiacritics } from '@/lib/utils'
-import { getContentService } from '@/services/content'
+import { createGraphQLContentService } from '@/services/content/graphql'
 import type {
   CombinedSearchResults,
   InlineAutocompleteSuggestion,
@@ -13,7 +13,7 @@ import type {
 
 /** Cliente GraphQL público (sem token) para as server actions de busca. */
 function content() {
-  return getContentService(createSSRClient(async () => null))
+  return createGraphQLContentService(createSSRClient(async () => null))
 }
 
 /**

--- a/src/app/(public)/busca/actions.ts
+++ b/src/app/(public)/busca/actions.ts
@@ -1,10 +1,8 @@
 'use server'
 
-import { getPrioritizedArticles } from '@/config/prioritization'
-import { DEFAULT_CONFIG } from '@/config/prioritization-config'
+import { createSSRClient } from '@/lib/graphql/client'
 import { removeDiacritics } from '@/lib/utils'
-import { typesense } from '@/services/typesense/client'
-import type { ArticleRow } from '@/types/article'
+import { getContentService } from '@/services/content'
 import type {
   CombinedSearchResults,
   InlineAutocompleteSuggestion,
@@ -13,48 +11,72 @@ import type {
   SearchSuggestion,
 } from '@/types/search'
 
-const PAGE_SIZE = 40
-
-async function getQueryEmbedding(query: string): Promise<number[] | null> {
-  const apiUrl = process.env.EMBEDDINGS_API_URL
-  const apiKey = process.env.EMBEDDINGS_API_KEY
-  if (!apiUrl || !apiKey) return null
-
-  try {
-    const response = await fetch(`${apiUrl.replace(/\/$/, '')}/generate`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json', 'X-API-Key': apiKey },
-      body: JSON.stringify({ texts: [query] }),
-      signal: AbortSignal.timeout(5000),
-    })
-    if (!response.ok) return null
-    const data = await response.json()
-    return (data.embeddings?.[0] as number[]) ?? null
-  } catch {
-    return null
-  }
+/** Cliente GraphQL público (sem token) para as server actions de busca. */
+function content() {
+  return getContentService(createSSRClient(async () => null))
 }
 
 /**
- * Shared search function to avoid duplicate Typesense queries.
- * Used by both inline autocomplete and search suggestions.
+ * Deriva uma sugestão de autocomplete inline a partir de uma lista de títulos.
+ * Retorna a completude da palavra que está a ser digitada (não o título inteiro).
+ * Ex.: se o usuário digita "Diplo" e um título contém "Diplomacia", sugere "Diplomacia".
+ * Comparação insensível a acentos (texto em português).
  */
-async function searchArticles(query: string): Promise<ArticleRow[]> {
-  const result = await typesense
-    .collections<ArticleRow>('news')
-    .documents()
-    .search({
-      q: query,
-      query_by: 'title,content',
-      query_by_weights: '3,1',
-      prefix: true,
-      prioritize_exact_match: true,
-      drop_tokens_threshold: 5,
-      limit: 50,
-      pre_segmented_query: false,
-    })
+function deriveInlineAutocomplete(
+  normalizedQuery: string,
+  titles: string[],
+): InlineAutocompleteSuggestion | null {
+  const queryWords = normalizedQuery.split(' ')
+  const lastWord = queryWords[queryWords.length - 1]
 
-  return result.hits?.map((hit) => hit.document as ArticleRow) ?? []
+  // Só sugere se a última palavra tem pelo menos 2 caracteres
+  if (lastWord.length < 2) return null
+
+  const normalizedLastWord = removeDiacritics(lastWord.toLowerCase())
+  const previousWords = queryWords.slice(0, -1)
+  const hasPreviousWords = previousWords.length > 0
+
+  for (const title of titles) {
+    const normalizedTitle = removeDiacritics(title.toLowerCase())
+
+    // Se há palavras anteriores, o título precisa contê-las
+    if (hasPreviousWords) {
+      const normalizedPreviousPhrase = removeDiacritics(
+        previousWords.join(' ').toLowerCase(),
+      )
+
+      if (!normalizedTitle.includes(normalizedPreviousPhrase)) {
+        continue
+      }
+    }
+
+    const titleWords = title.split(/\s+/)
+
+    for (const titleWord of titleWords) {
+      // Limpa a palavra do título (remove pontuação no final)
+      const cleanTitleWord = titleWord.replace(/[.,;:!?"')\]]+$/, '')
+      const normalizedTitleWord = removeDiacritics(cleanTitleWord.toLowerCase())
+
+      // A palavra do título começa com o que o usuário digitou?
+      if (
+        normalizedTitleWord.startsWith(normalizedLastWord) &&
+        normalizedTitleWord.length > normalizedLastWord.length
+      ) {
+        // Monta a completude: tudo antes da última palavra + a palavra completada
+        const prefix = queryWords.slice(0, -1).join(' ')
+        const completion = prefix
+          ? `${prefix} ${cleanTitleWord}`
+          : cleanTitleWord
+
+        // O sufixo é apenas a parte restante da palavra
+        const suffix = cleanTitleWord.slice(lastWord.length)
+
+        return { completion, suffix }
+      }
+    }
+  }
+
+  return null
 }
 
 /**
@@ -68,74 +90,19 @@ export async function getInlineAutocompleteSuggestion(
 ): Promise<InlineAutocompleteSuggestion | null> {
   if (!query || query.length < 2) return null
 
-  // Normalize multiple spaces to single space and trim
+  // Normaliza múltiplos espaços para um único espaço e faz trim
   const trimmedQuery = query.trim().replace(/\s+/g, ' ')
-  // Get the last word being typed (the one we want to complete)
+  // Pega a última palavra digitada (a que queremos completar)
   const queryWords = trimmedQuery.split(' ')
   const lastWord = queryWords[queryWords.length - 1]
 
-  // Only suggest if the last word has at least 2 characters
+  // Só sugere se a última palavra tem pelo menos 2 caracteres
   if (lastWord.length < 2) return null
 
-  const normalizedLastWord = removeDiacritics(lastWord.toLowerCase())
-
   try {
-    const articles = await searchArticles(trimmedQuery)
-
-    // If we have previous words (e.g., "Inteligência" in "Inteligência art")
-    // we should only suggest completions from titles that contain those previous words
-    const previousWords = queryWords.slice(0, -1)
-    const hasPreviousWords = previousWords.length > 0
-
-    // Find a word in any title that starts with the last word the user is typing
-    for (const article of articles) {
-      const title = article.title ?? ''
-      const normalizedTitle = removeDiacritics(title.toLowerCase())
-
-      // If we have previous words, check if the title contains them
-      if (hasPreviousWords) {
-        const normalizedPreviousPhrase = removeDiacritics(
-          previousWords.join(' ').toLowerCase(),
-        )
-
-        // Skip this article if it doesn't contain the previous words
-        if (!normalizedTitle.includes(normalizedPreviousPhrase)) {
-          continue
-        }
-      }
-
-      const titleWords = title.split(/\s+/)
-
-      for (const titleWord of titleWords) {
-        // Clean the title word (remove punctuation at the end)
-        const cleanTitleWord = titleWord.replace(/[.,;:!?"')\]]+$/, '')
-        const normalizedTitleWord = removeDiacritics(
-          cleanTitleWord.toLowerCase(),
-        )
-
-        // Check if this title word starts with what the user typed
-        if (
-          normalizedTitleWord.startsWith(normalizedLastWord) &&
-          normalizedTitleWord.length > normalizedLastWord.length
-        ) {
-          // Build the completion: everything before the last word + the completed word
-          const prefix = queryWords.slice(0, -1).join(' ')
-          const completion = prefix
-            ? `${prefix} ${cleanTitleWord}`
-            : cleanTitleWord
-
-          // The suffix is just the remaining part of the word
-          const suffix = cleanTitleWord.slice(lastWord.length)
-
-          return {
-            completion,
-            suffix,
-          }
-        }
-      }
-    }
-
-    return null
+    const suggestions = await content().getSearchSuggestions(trimmedQuery)
+    const titles = suggestions.map((s) => s.title)
+    return deriveInlineAutocomplete(trimmedQuery, titles)
   } catch {
     return null
   }
@@ -146,18 +113,16 @@ export async function getSearchSuggestions(
 ): Promise<SearchSuggestion[]> {
   if (!query || query.length < 2) return []
 
-  // Normalize multiple spaces to single space
+  // Normaliza múltiplos espaços para um único espaço
   const normalizedQuery = query.trim().replace(/\s+/g, ' ')
 
   try {
-    const articles = await searchArticles(normalizedQuery)
+    const suggestions = await content().getSearchSuggestions(normalizedQuery)
 
-    // Apply prioritization to results
-    const prioritized = getPrioritizedArticles(articles, DEFAULT_CONFIG, 7)
-
-    return prioritized.map((article) => ({
-      unique_id: article.unique_id,
-      title: article.title ?? '',
+    // O facade já ordena/limita server-side; aplicamos o top-7 do portal.
+    return suggestions.slice(0, 7).map((s) => ({
+      unique_id: s.uniqueId,
+      title: s.title,
     }))
   } catch {
     return []
@@ -166,7 +131,7 @@ export async function getSearchSuggestions(
 
 /**
  * Combined search that returns both suggestions and inline autocomplete in a single request.
- * This avoids duplicate Typesense queries and improves performance.
+ * This avoids duplicate queries and improves performance.
  */
 export async function getCombinedSearchResults(
   query: string,
@@ -178,71 +143,25 @@ export async function getCombinedSearchResults(
     }
   }
 
-  // Normalize multiple spaces to single space and trim
+  // Normaliza múltiplos espaços para um único espaço e faz trim
   const normalizedQuery = query.trim().replace(/\s+/g, ' ')
 
   try {
-    // Make a single Typesense query
-    const articles = await searchArticles(normalizedQuery)
+    // Uma única chamada ao facade
+    const raw = await content().getSearchSuggestions(normalizedQuery)
 
-    // Process suggestions
-    const prioritized = getPrioritizedArticles(articles, DEFAULT_CONFIG, 7)
-    const suggestions = prioritized.map((article) => ({
-      unique_id: article.unique_id,
-      title: article.title ?? '',
+    // Sugestões (top-7, espelhando o comportamento do portal)
+    const top = raw.slice(0, 7)
+    const suggestions = top.map((s) => ({
+      unique_id: s.uniqueId,
+      title: s.title,
     }))
 
-    // Process inline autocomplete
-    const queryWords = normalizedQuery.split(' ')
-    const lastWord = queryWords[queryWords.length - 1]
-    let inlineAutocomplete: InlineAutocompleteSuggestion | null = null
-
-    if (lastWord.length >= 2) {
-      const normalizedLastWord = removeDiacritics(lastWord.toLowerCase())
-      const previousWords = queryWords.slice(0, -1)
-      const hasPreviousWords = previousWords.length > 0
-
-      for (const article of articles) {
-        const title = article.title ?? ''
-        const normalizedTitle = removeDiacritics(title.toLowerCase())
-
-        // If we have previous words, check if the title contains them
-        if (hasPreviousWords) {
-          const normalizedPreviousPhrase = removeDiacritics(
-            previousWords.join(' ').toLowerCase(),
-          )
-
-          if (!normalizedTitle.includes(normalizedPreviousPhrase)) {
-            continue
-          }
-        }
-
-        const titleWords = title.split(/\s+/)
-
-        for (const titleWord of titleWords) {
-          const cleanTitleWord = titleWord.replace(/[.,;:!?"')\]]+$/, '')
-          const normalizedTitleWord = removeDiacritics(
-            cleanTitleWord.toLowerCase(),
-          )
-
-          if (
-            normalizedTitleWord.startsWith(normalizedLastWord) &&
-            normalizedTitleWord.length > normalizedLastWord.length
-          ) {
-            const prefix = queryWords.slice(0, -1).join(' ')
-            const completion = prefix
-              ? `${prefix} ${cleanTitleWord}`
-              : cleanTitleWord
-            const suffix = cleanTitleWord.slice(lastWord.length)
-
-            inlineAutocomplete = { completion, suffix }
-            break
-          }
-        }
-
-        if (inlineAutocomplete) break
-      }
-    }
+    // Autocomplete inline derivado dos títulos das sugestões
+    const inlineAutocomplete = deriveInlineAutocomplete(
+      normalizedQuery,
+      raw.map((s) => s.title),
+    )
 
     return {
       suggestions,
@@ -269,88 +188,35 @@ export async function queryArticles(
     semantic = true,
   } = args
 
-  const filter_by: string[] = []
-
-  if (startDate) {
-    filter_by.push(`published_at:>=${Math.floor(startDate / 1000)}`)
-  }
-
-  if (endDate) {
-    filter_by.push(`published_at:<${Math.floor(endDate / 1000) + 86400}`)
-  }
-
-  if (agencies && agencies.length > 0) {
-    filter_by.push(`agency:[${agencies.join(',')}]`)
-  }
-
-  if (themes && themes.length > 0) {
-    // Filter by any theme level - level 1, 2, or 3
-    const themeFilters = themes.map(
-      (theme) =>
-        `(theme_1_level_1_code:${theme} || theme_1_level_2_code:${theme} || theme_1_level_3_code:${theme})`,
-    )
-    filter_by.push(`(${themeFilters.join(' || ')})`)
-  }
-
   const normalizedQuery = query ? query.trim().replace(/\s+/g, ' ') : null
-  const filterByStr = filter_by.join(' && ')
 
-  // Hybrid search: keyword + semantic when query is provided and semantic is enabled
-  if (normalizedQuery && semantic) {
-    const embedding = await getQueryEmbedding(normalizedQuery)
-    if (embedding) {
-      // biome-ignore format: true
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const response = await (typesense.multiSearch as any).perform({
-        searches: [{
-          collection: 'news',
-          q: normalizedQuery,
-          query_by: 'title,content',
-          query_by_weights: '3,1',
-          vector_query: `content_embedding:([${embedding.join(',')}], alpha:0.8)`,
-          filter_by: filterByStr || undefined,
-          exclude_fields: 'content_embedding',
-          group_by: 'content_hash',
-          group_limit: 1,
-          limit: PAGE_SIZE,
-          page,
-        }],
-      })
-      const result = response.results?.[0]
-      return {
-        articles:
-          // biome-ignore lint/suspicious/noExplicitAny: multiSearch response types are not fully typed
-          result?.grouped_hits?.flatMap((group: any) =>
-            group.hits.map((hit: { document: ArticleRow }) => hit.document),
-          ) ?? [],
-        page: page + 1,
-        found: result?.found ?? 0,
-      }
-    }
-  }
+  // Datas: o filtro do facade usa strings ISO (DateTime do schema).
+  // startDate/endDate chegam em ms; endDate é exclusivo do dia seguinte no
+  // comportamento original (`< endDate + 1 dia`).
+  const startIso = startDate ? new Date(startDate).toISOString() : null
+  const endIso = endDate ? new Date(endDate + 86400000).toISOString() : null
 
-  // Fallback: keyword-only search, sorted by date
-  // biome-ignore format: true
-  const result = await typesense
-    .collections<ArticleRow>('news')
-    .documents()
-    .search({
-      q: normalizedQuery ?? '*',
-      query_by: 'title, content',
-      sort_by: 'published_at:desc, unique_id:desc',
-      filter_by: filterByStr,
-      group_by: 'content_hash',
-      group_limit: 1,
-      limit: PAGE_SIZE,
-      page
-    })
+  const result = await content().searchArticles({
+    query: normalizedQuery ?? '',
+    page,
+    // graphql-api faz embeddings + híbrido server-side (alpha:0.8, group_by content_hash).
+    semantic,
+    alpha: 0.8,
+    dedup: true,
+    filter: {
+      agencies: agencies && agencies.length > 0 ? agencies : null,
+      themes: themes && themes.length > 0 ? themes : null,
+      startDate: startIso,
+      endDate: endIso,
+    },
+  })
 
+  // Preserva o contrato original: `page` é o cursor da PRÓXIMA página
+  // (a server action antiga retornava `page + 1`). React Query usa este
+  // valor em `getNextPageParam` para o scroll infinito.
   return {
-    articles:
-      result.grouped_hits?.flatMap((group) =>
-        group.hits.map((hit) => hit.document),
-      ) ?? [],
+    articles: result.articles,
     page: page + 1,
-    found: result.found ?? 0,
+    found: result.found,
   }
 }

--- a/src/app/(public)/orgaos/[agencyKey]/__tests__/actions.test.ts
+++ b/src/app/(public)/orgaos/[agencyKey]/__tests__/actions.test.ts
@@ -17,8 +17,8 @@ vi.mock('@/lib/graphql/client', () => ({
   createSSRClient: () => ({}) as unknown,
 }))
 
-vi.mock('@/services/content', () => ({
-  getContentService: () => ({ listArticles: listArticlesMock }),
+vi.mock('@/services/content/graphql', () => ({
+  createGraphQLContentService: () => ({ listArticles: listArticlesMock }),
 }))
 
 import { getArticles } from '../actions'

--- a/src/app/(public)/orgaos/[agencyKey]/__tests__/actions.test.ts
+++ b/src/app/(public)/orgaos/[agencyKey]/__tests__/actions.test.ts
@@ -1,0 +1,72 @@
+/**
+ * Testes da server action `getArticles` do detalhe de órgão (migração Fase 2B).
+ *
+ * Verifica o mapeamento para `listArticles`: filtro por agência, SEM dedup,
+ * temas por código (OR através de L1/L2/L3 resolvido server-side), conversão de
+ * datas ms→ISO (endDate +1 dia) e shape `{ articles, page: page + 1 }`.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { ArticlesPage, ListArticlesArgs } from '@/services/content'
+import type { ArticleRow } from '@/types/article'
+
+const listArticlesMock =
+  vi.fn<(args?: ListArticlesArgs) => Promise<ArticlesPage>>()
+
+vi.mock('@/lib/graphql/client', () => ({
+  createSSRClient: () => ({}) as unknown,
+}))
+
+vi.mock('@/services/content', () => ({
+  getContentService: () => ({ listArticles: listArticlesMock }),
+}))
+
+import { getArticles } from '../actions'
+
+const row = { unique_id: 'a-1' } as ArticleRow
+
+beforeEach(() => {
+  listArticlesMock.mockReset()
+  listArticlesMock.mockResolvedValue({ articles: [row], found: 1 })
+})
+
+describe('getArticles (órgão)', () => {
+  it('filtra por agência sem dedup, limit 40, retorna page+1', async () => {
+    const result = await getArticles({ agency: 'min-saude', page: 1 })
+
+    expect(listArticlesMock).toHaveBeenCalledTimes(1)
+    const args = listArticlesMock.mock.calls[0][0]!
+    expect(args.page).toBe(1)
+    expect(args.limit).toBe(40)
+    expect(args.dedup).toBe(false)
+    expect(args.filter?.agencies).toEqual(['min-saude'])
+    expect(args.filter?.themes).toBeNull()
+    expect(args.filter?.startDate).toBeNull()
+    expect(args.filter?.endDate).toBeNull()
+
+    expect(result).toEqual({ articles: [row], page: 2 })
+  })
+
+  it('passa temas por código e converte datas ms→ISO (endDate +1 dia)', async () => {
+    const start = Date.UTC(2026, 0, 1)
+    const end = Date.UTC(2026, 0, 31)
+
+    await getArticles({
+      agency: 'min-saude',
+      page: 2,
+      startDate: start,
+      endDate: end,
+      themes: ['01', '0101'],
+    })
+
+    const args = listArticlesMock.mock.calls[0][0]!
+    expect(args.filter?.themes).toEqual(['01', '0101'])
+    expect(args.filter?.startDate).toBe(new Date(start).toISOString())
+    expect(args.filter?.endDate).toBe(new Date(end + 86400000).toISOString())
+  })
+
+  it('temas vazio vira null', async () => {
+    await getArticles({ agency: 'min-saude', page: 1, themes: [] })
+    expect(listArticlesMock.mock.calls[0][0]!.filter?.themes).toBeNull()
+  })
+})

--- a/src/app/(public)/orgaos/[agencyKey]/actions.ts
+++ b/src/app/(public)/orgaos/[agencyKey]/actions.ts
@@ -1,6 +1,7 @@
 'use server'
 
-import { typesense } from '@/services/typesense/client'
+import { createSSRClient } from '@/lib/graphql/client'
+import { getContentService } from '@/services/content'
 import type { ArticleRow } from '@/types/article'
 
 export type GetArticlesArgs = {
@@ -18,44 +19,38 @@ export type GetArticlesResult = {
 
 const PAGE_SIZE = 40
 
+/** Cliente GraphQL público (sem token) para a server action do órgão. */
+function content() {
+  return getContentService(createSSRClient(async () => null))
+}
+
 export async function getArticles(
   args: GetArticlesArgs,
 ): Promise<GetArticlesResult> {
   const { agency, page, startDate, endDate, themes } = args
 
-  const filter_by: string[] = [`agency:=${agency}`]
+  // Datas: o filtro do facade usa strings ISO (DateTime do schema).
+  // startDate/endDate chegam em ms; endDate é exclusivo do dia seguinte no
+  // comportamento original (`< endDate + 1 dia`).
+  const startIso = startDate ? new Date(startDate).toISOString() : null
+  const endIso = endDate ? new Date(endDate + 86400000).toISOString() : null
 
-  if (startDate) {
-    filter_by.push(`published_at:>=${Math.floor(startDate / 1000)}`)
-  }
-
-  if (endDate) {
-    filter_by.push(`published_at:<${Math.floor(endDate / 1000) + 86400}`)
-  }
-
-  if (themes && themes.length > 0) {
-    // Filter by any theme level - level 1, 2, or 3
-    const themeFilters = themes.map(
-      (theme) =>
-        `(theme_1_level_1_code:${theme} || theme_1_level_2_code:${theme} || theme_1_level_3_code:${theme})`,
-    )
-    filter_by.push(`(${themeFilters.join(' || ')})`)
-  }
-
-  // biome-ignore format: true
-  const result = await typesense
-    .collections<ArticleRow>('news')
-    .documents()
-    .search({
-      q: '*',
-      sort_by: 'published_at:desc, unique_id:desc',
-      filter_by: filter_by.join(" && "),
-      limit: PAGE_SIZE,
-      page
-    })
+  const result = await content().listArticles({
+    page,
+    limit: PAGE_SIZE,
+    // Órgão não deduplica por content_hash (comportamento original sem group_by).
+    dedup: false,
+    filter: {
+      agencies: [agency],
+      // themes filtra por código, OR através de L1/L2/L3 (resolvido server-side).
+      themes: themes && themes.length > 0 ? themes : null,
+      startDate: startIso,
+      endDate: endIso,
+    },
+  })
 
   return {
-    articles: result.hits?.map((hit) => hit.document) ?? [],
+    articles: result.articles,
     page: page + 1,
   }
 }

--- a/src/app/(public)/orgaos/[agencyKey]/actions.ts
+++ b/src/app/(public)/orgaos/[agencyKey]/actions.ts
@@ -1,7 +1,7 @@
 'use server'
 
 import { createSSRClient } from '@/lib/graphql/client'
-import { getContentService } from '@/services/content'
+import { createGraphQLContentService } from '@/services/content/graphql'
 import type { ArticleRow } from '@/types/article'
 
 export type GetArticlesArgs = {
@@ -21,7 +21,7 @@ const PAGE_SIZE = 40
 
 /** Cliente GraphQL público (sem token) para a server action do órgão. */
 function content() {
-  return getContentService(createSSRClient(async () => null))
+  return createGraphQLContentService(createSSRClient(async () => null))
 }
 
 export async function getArticles(

--- a/src/app/(public)/temas/[themeLabel]/__tests__/actions.test.ts
+++ b/src/app/(public)/temas/[themeLabel]/__tests__/actions.test.ts
@@ -1,0 +1,72 @@
+/**
+ * Testes da server action `getArticles` do detalhe de tema (migração Fase 2B).
+ *
+ * Verifica o mapeamento para `listArticles`: filtro por `themeLabel` (L1 label),
+ * `dedup: true`, conversão de datas ms→ISO (endDate +1 dia inclusivo) e o shape
+ * de retorno `{ articles, page: page + 1 }`.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { ArticlesPage, ListArticlesArgs } from '@/services/content'
+import type { ArticleRow } from '@/types/article'
+
+const listArticlesMock =
+  vi.fn<(args?: ListArticlesArgs) => Promise<ArticlesPage>>()
+
+vi.mock('@/lib/graphql/client', () => ({
+  createSSRClient: () => ({}) as unknown,
+}))
+
+vi.mock('@/services/content', () => ({
+  getContentService: () => ({ listArticles: listArticlesMock }),
+}))
+
+import { getArticles } from '../actions'
+
+const row = { unique_id: 'a-1' } as ArticleRow
+
+beforeEach(() => {
+  listArticlesMock.mockReset()
+  listArticlesMock.mockResolvedValue({ articles: [row], found: 1 })
+})
+
+describe('getArticles (tema)', () => {
+  it('filtra por themeLabel com dedup e limit 40, retorna page+1', async () => {
+    const result = await getArticles({ theme_1_level_1: 'Saúde', page: 1 })
+
+    expect(listArticlesMock).toHaveBeenCalledTimes(1)
+    const args = listArticlesMock.mock.calls[0][0]!
+    expect(args.page).toBe(1)
+    expect(args.limit).toBe(40)
+    expect(args.dedup).toBe(true)
+    expect(args.filter?.themeLabel).toBe('Saúde')
+    expect(args.filter?.startDate).toBeNull()
+    expect(args.filter?.endDate).toBeNull()
+    expect(args.filter?.agencies).toBeNull()
+
+    expect(result).toEqual({ articles: [row], page: 2 })
+  })
+
+  it('converte datas ms→ISO (endDate +1 dia) e passa agencies', async () => {
+    const start = Date.UTC(2026, 0, 1)
+    const end = Date.UTC(2026, 0, 31)
+
+    await getArticles({
+      theme_1_level_1: 'Saúde',
+      page: 3,
+      startDate: start,
+      endDate: end,
+      agencies: ['min-saude'],
+    })
+
+    const args = listArticlesMock.mock.calls[0][0]!
+    expect(args.filter?.startDate).toBe(new Date(start).toISOString())
+    expect(args.filter?.endDate).toBe(new Date(end + 86400000).toISOString())
+    expect(args.filter?.agencies).toEqual(['min-saude'])
+  })
+
+  it('agencies vazio vira null', async () => {
+    await getArticles({ theme_1_level_1: 'Saúde', page: 1, agencies: [] })
+    expect(listArticlesMock.mock.calls[0][0]!.filter?.agencies).toBeNull()
+  })
+})

--- a/src/app/(public)/temas/[themeLabel]/__tests__/actions.test.ts
+++ b/src/app/(public)/temas/[themeLabel]/__tests__/actions.test.ts
@@ -17,8 +17,8 @@ vi.mock('@/lib/graphql/client', () => ({
   createSSRClient: () => ({}) as unknown,
 }))
 
-vi.mock('@/services/content', () => ({
-  getContentService: () => ({ listArticles: listArticlesMock }),
+vi.mock('@/services/content/graphql', () => ({
+  createGraphQLContentService: () => ({ listArticles: listArticlesMock }),
 }))
 
 import { getArticles } from '../actions'

--- a/src/app/(public)/temas/[themeLabel]/actions.ts
+++ b/src/app/(public)/temas/[themeLabel]/actions.ts
@@ -1,7 +1,7 @@
 'use server'
 
 import { createSSRClient } from '@/lib/graphql/client'
-import { getContentService } from '@/services/content'
+import { createGraphQLContentService } from '@/services/content/graphql'
 import type { ArticleRow } from '@/types/article'
 
 export type GetArticlesArgs = {
@@ -21,7 +21,7 @@ const PAGE_SIZE = 40
 
 /** Cliente GraphQL público (sem token) para a server action do tema. */
 function content() {
-  return getContentService(createSSRClient(async () => null))
+  return createGraphQLContentService(createSSRClient(async () => null))
 }
 
 export async function getArticles(

--- a/src/app/(public)/temas/[themeLabel]/actions.ts
+++ b/src/app/(public)/temas/[themeLabel]/actions.ts
@@ -1,6 +1,7 @@
 'use server'
 
-import { typesense } from '@/services/typesense/client'
+import { createSSRClient } from '@/lib/graphql/client'
+import { getContentService } from '@/services/content'
 import type { ArticleRow } from '@/types/article'
 
 export type GetArticlesArgs = {
@@ -18,44 +19,37 @@ export type GetArticlesResult = {
 
 const PAGE_SIZE = 40
 
+/** Cliente GraphQL público (sem token) para a server action do tema. */
+function content() {
+  return getContentService(createSSRClient(async () => null))
+}
+
 export async function getArticles(
   args: GetArticlesArgs,
 ): Promise<GetArticlesResult> {
   const { theme_1_level_1, page, startDate, endDate, agencies } = args
 
-  const filter_by: string[] = [`theme_1_level_1_label:=${theme_1_level_1}`]
+  // Datas: o filtro do facade usa strings ISO (DateTime do schema).
+  // startDate/endDate chegam em ms; endDate é exclusivo do dia seguinte no
+  // comportamento original (`< endDate + 1 dia`).
+  const startIso = startDate ? new Date(startDate).toISOString() : null
+  const endIso = endDate ? new Date(endDate + 86400000).toISOString() : null
 
-  if (startDate) {
-    filter_by.push(`published_at:>=${Math.floor(startDate / 1000)}`)
-  }
-
-  if (endDate) {
-    filter_by.push(`published_at:<${Math.floor(endDate / 1000) + 86400}`)
-  }
-
-  if (agencies && agencies.length > 0) {
-    filter_by.push(`agency:[${agencies.join(',')}]`)
-  }
-
-  // biome-ignore format: true
-  const result = await typesense
-    .collections<ArticleRow>('news')
-    .documents()
-    .search({
-      q: '*',
-      sort_by: 'published_at:desc, unique_id:desc',
-      filter_by: filter_by.join(" && "),
-      group_by: 'content_hash',
-      group_limit: 1,
-      limit: PAGE_SIZE,
-      page
-    })
+  const result = await content().listArticles({
+    page,
+    limit: PAGE_SIZE,
+    // dedup por content_hash (group_by + group_limit:1 no comportamento original).
+    dedup: true,
+    filter: {
+      themeLabel: theme_1_level_1,
+      startDate: startIso,
+      endDate: endIso,
+      agencies: agencies && agencies.length > 0 ? agencies : null,
+    },
+  })
 
   return {
-    articles:
-      result.grouped_hits?.flatMap((group) =>
-        group.hits.map((hit) => hit.document),
-      ) ?? [],
+    articles: result.articles,
     page: page + 1,
   }
 }

--- a/src/app/(public)/temas/__tests__/actions.test.ts
+++ b/src/app/(public)/temas/__tests__/actions.test.ts
@@ -16,8 +16,8 @@ vi.mock('@/lib/graphql/client', () => ({
   createSSRClient: () => ({}) as unknown,
 }))
 
-vi.mock('@/services/content', () => ({
-  getContentService: () => ({
+vi.mock('@/services/content/graphql', () => ({
+  createGraphQLContentService: () => ({
     getThemeArticleCounts: getThemeArticleCountsMock,
   }),
 }))

--- a/src/app/(public)/temas/__tests__/actions.test.ts
+++ b/src/app/(public)/temas/__tests__/actions.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Testes da server action `getThemeArticleCounts` (migração Fase 2B).
+ *
+ * Verifica que: (a) consulta os 3 níveis com janela de 30 dias, (b) mescla os
+ * resultados num único `Map<code, count>`, (c) ignora códigos vazios/`null`,
+ * (d) devolve um Map vazio quando o facade lança erro.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { ThemeCount } from '@/services/content'
+
+const getThemeArticleCountsMock =
+  vi.fn<(days?: number, level?: number) => Promise<ThemeCount[]>>()
+
+vi.mock('@/lib/graphql/client', () => ({
+  createSSRClient: () => ({}) as unknown,
+}))
+
+vi.mock('@/services/content', () => ({
+  getContentService: () => ({
+    getThemeArticleCounts: getThemeArticleCountsMock,
+  }),
+}))
+
+import { getThemeArticleCounts } from '../actions'
+
+beforeEach(() => {
+  getThemeArticleCountsMock.mockReset()
+})
+
+describe('getThemeArticleCounts', () => {
+  it('consulta os 3 níveis (30 dias) e mescla num único Map code→count', async () => {
+    getThemeArticleCountsMock.mockImplementation(
+      async (_days?: number, level?: number) => {
+        if (level === 1) return [{ code: '01', label: 'L1', count: 10 }]
+        if (level === 2) return [{ code: '0101', label: 'L2', count: 5 }]
+        return [{ code: '010101', label: 'L3', count: 2 }]
+      },
+    )
+
+    const result = await getThemeArticleCounts()
+
+    expect(getThemeArticleCountsMock).toHaveBeenCalledWith(30, 1)
+    expect(getThemeArticleCountsMock).toHaveBeenCalledWith(30, 2)
+    expect(getThemeArticleCountsMock).toHaveBeenCalledWith(30, 3)
+    expect(result).toBeInstanceOf(Map)
+    expect(result.get('01')).toBe(10)
+    expect(result.get('0101')).toBe(5)
+    expect(result.get('010101')).toBe(2)
+    expect(result.size).toBe(3)
+  })
+
+  it('ignora códigos vazios, "null" e string vazia', async () => {
+    getThemeArticleCountsMock.mockResolvedValue([
+      { code: '01', label: 'ok', count: 7 },
+      { code: 'null', label: 'x', count: 3 },
+      { code: '', label: 'y', count: 1 },
+    ])
+
+    const result = await getThemeArticleCounts()
+
+    expect(result.get('01')).toBe(7)
+    expect(result.has('null')).toBe(false)
+    expect(result.has('')).toBe(false)
+    expect(result.size).toBe(1)
+  })
+
+  it('devolve Map vazio quando o facade lança erro', async () => {
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    getThemeArticleCountsMock.mockRejectedValue(new Error('boom'))
+
+    const result = await getThemeArticleCounts()
+
+    expect(result).toBeInstanceOf(Map)
+    expect(result.size).toBe(0)
+    spy.mockRestore()
+  })
+})

--- a/src/app/(public)/temas/actions.ts
+++ b/src/app/(public)/temas/actions.ts
@@ -1,11 +1,11 @@
 'use server'
 
 import { createSSRClient } from '@/lib/graphql/client'
-import { getContentService } from '@/services/content'
+import { createGraphQLContentService } from '@/services/content/graphql'
 
 /** Cliente GraphQL público (sem token) para as server actions de temas. */
 function content() {
-  return getContentService(createSSRClient(async () => null))
+  return createGraphQLContentService(createSSRClient(async () => null))
 }
 
 /**

--- a/src/app/(public)/temas/actions.ts
+++ b/src/app/(public)/temas/actions.ts
@@ -1,8 +1,12 @@
 'use server'
 
-import { subDays } from 'date-fns'
-import { typesense } from '@/services/typesense/client'
-import type { ArticleRow } from '@/types/article'
+import { createSSRClient } from '@/lib/graphql/client'
+import { getContentService } from '@/services/content'
+
+/** Cliente GraphQL público (sem token) para as server actions de temas. */
+function content() {
+  return getContentService(createSSRClient(async () => null))
+}
 
 /**
  * Get article counts by theme code for the last 30 days
@@ -12,69 +16,21 @@ import type { ArticleRow } from '@/types/article'
 export async function getThemeArticleCounts(): Promise<Map<string, number>> {
   const counts = new Map<string, number>()
 
-  // Calculate date range (last 30 days)
-  const endDate = new Date()
-  const startDate = subDays(endDate, 30)
-  const startSeconds = Math.floor(startDate.getTime() / 1000)
-  const endSeconds = Math.floor(endDate.getTime() / 1000)
-
-  const filter = `published_at:>=${startSeconds} && published_at:<${endSeconds}`
-
   try {
-    // Query for level 1 themes
-    const level1Res = await typesense
-      .collections<ArticleRow>('news')
-      .documents()
-      .search({
-        q: '*',
-        filter_by: filter,
-        group_by: 'theme_1_level_1_code',
-        per_page: 250,
-      })
+    const svc = content()
 
-    // Query for level 2 themes
-    const level2Res = await typesense
-      .collections<ArticleRow>('news')
-      .documents()
-      .search({
-        q: '*',
-        filter_by: filter,
-        group_by: 'theme_1_level_2_code',
-        per_page: 250,
-      })
+    // Conta cada nível separadamente (1, 2 e 3), janela de 30 dias.
+    const [level1, level2, level3] = await Promise.all([
+      svc.getThemeArticleCounts(30, 1),
+      svc.getThemeArticleCounts(30, 2),
+      svc.getThemeArticleCounts(30, 3),
+    ])
 
-    // Query for level 3 themes
-    const level3Res = await typesense
-      .collections<ArticleRow>('news')
-      .documents()
-      .search({
-        q: '*',
-        filter_by: filter,
-        group_by: 'theme_1_level_3_code',
-        per_page: 250,
-      })
-
-    // Process level 1 results
-    for (const group of level1Res.grouped_hits ?? []) {
-      const code = group.group_key?.[0]
-      if (code && code !== 'null' && code !== '') {
-        counts.set(code, group.found ?? 0)
-      }
-    }
-
-    // Process level 2 results
-    for (const group of level2Res.grouped_hits ?? []) {
-      const code = group.group_key?.[0]
-      if (code && code !== 'null' && code !== '') {
-        counts.set(code, group.found ?? 0)
-      }
-    }
-
-    // Process level 3 results
-    for (const group of level3Res.grouped_hits ?? []) {
-      const code = group.group_key?.[0]
-      if (code && code !== 'null' && code !== '') {
-        counts.set(code, group.found ?? 0)
+    for (const level of [level1, level2, level3]) {
+      for (const { code, count } of level) {
+        if (code && code !== 'null' && code !== '') {
+          counts.set(code, count)
+        }
       }
     }
 

--- a/src/app/clipping/release/[releaseId]/artigos/page.tsx
+++ b/src/app/clipping/release/[releaseId]/artigos/page.tsx
@@ -1,134 +1,38 @@
-import { format, subHours } from 'date-fns'
-import { ptBR } from 'date-fns/locale'
-import { notFound } from 'next/navigation'
+import { auth } from '@/auth'
 import { Badge } from '@/components/ui/badge'
-import { buildFilterBy, hasFilters } from '@/lib/estimate-recorte-count'
-import { getFirestoreDb } from '@/lib/firebase-admin'
-import { typesense } from '@/services/typesense/client'
-import type { Recorte } from '@/types/clipping'
+import { createSSRClient } from '@/lib/graphql/client'
+import { getContentService } from '@/services/content'
 
 export const revalidate = 600
 
 type Props = { params: Promise<{ releaseId: string }> }
 
-type Article = {
-  unique_id: string
-  title: string
-  agency: string
-  published_at: number
-  url: string
-  summary?: string
-  theme_1_level_1_label?: string
-}
-
-export async function generateMetadata({ params }: Props) {
-  const { releaseId } = await params
-  const db = getFirestoreDb()
-  const doc = await db.collection('releases').doc(releaseId).get()
-  if (!doc.exists) return { title: 'Artigos da edição' }
-  const name = doc.data()?.clippingName ?? 'Clipping'
-  return { title: `Artigos — ${name} — DestaquesGovBr` }
+export async function generateMetadata() {
+  return { title: 'Artigos da edição — DestaquesGovBr' }
 }
 
 export default async function ReleaseArticlesPage({ params }: Props) {
   const { releaseId } = await params
-  const db = getFirestoreDb()
 
-  const releaseDoc = await db.collection('releases').doc(releaseId).get()
-  if (!releaseDoc.exists) notFound()
+  // Cliente SSR com o token da sessão para que releases privadas
+  // (autor/assinante) resolvam; releases públicas funcionam sem token.
+  const session = await auth()
+  const content = getContentService(
+    createSSRClient(async () => session?.accessToken ?? null),
+  )
 
-  const release = releaseDoc.data()!
-  const refTime = release.refTime?.toDate?.() ?? null
-  const sinceHours: number | null = release.sinceHours ?? null
-
-  // Fetch clipping recortes
-  let recortes: Recorte[] = []
-  if (release.clippingId) {
-    const clippingDoc = await db
-      .collection('clippings')
-      .doc(release.clippingId)
-      .get()
-    if (clippingDoc.exists) {
-      recortes = clippingDoc.data()?.recortes ?? []
-    }
-  }
-
-  // Calculate time window
-  let startDate: Date | null = null
-  let endDate: Date | null = null
-  if (refTime && sinceHours) {
-    endDate = refTime
-    startDate = subHours(refTime, sinceHours)
-  }
-
-  // Fetch articles using the same OR-between-recortes logic as the worker
-  const sinceTimestamp = startDate
-    ? Math.floor(startDate.getTime() / 1000)
-    : Math.floor(Date.now() / 1000) - 24 * 3600
-
-  const seen = new Set<string>()
-  const articles: Article[] = []
-
-  for (const recorte of recortes) {
-    if (!hasFilters(recorte)) continue
-    const filterBy = buildFilterBy(recorte, sinceTimestamp)
-
-    const queryTerms = recorte.keywords.length > 0 ? recorte.keywords : ['*']
-
-    for (const term of queryTerms) {
-      const result = await typesense.collections('news').documents().search({
-        q: term,
-        query_by: 'title,summary',
-        filter_by: filterBy,
-        sort_by: 'published_at:desc',
-        per_page: 250,
-      })
-
-      for (const hit of result.hits ?? []) {
-        const doc = hit.document as Article
-        if (!seen.has(doc.unique_id)) {
-          seen.add(doc.unique_id)
-          articles.push(doc)
-        }
-      }
-    }
-  }
-
-  // Sort by published_at desc
-  articles.sort((a, b) => (b.published_at ?? 0) - (a.published_at ?? 0))
-
-  // Format time window for display
-  const windowText =
-    startDate && endDate
-      ? `${format(startDate, 'dd/MM/yyyy HH:mm')} a ${format(endDate, 'dd/MM/yyyy HH:mm')}`
-      : null
-
-  const refDateText = refTime
-    ? format(refTime, "EEEE, d 'de' MMMM 'de' yyyy", { locale: ptBR })
-    : null
+  // O resolver busca os recortes da release, consulta os artigos por keyword,
+  // deduplica, ordena desc e aplica a janela refTime/sinceHours no servidor.
+  const articles = await content.getReleaseArticles(releaseId)
 
   return (
     <div className="container mx-auto px-4 py-8 max-w-3xl">
-      <h1 className="text-2xl font-bold tracking-tight">
-        Artigos — {release.clippingName}
-      </h1>
-
-      {refDateText && (
-        <p className="mt-1 text-sm text-muted-foreground">
-          Edição de {refDateText}
-        </p>
-      )}
+      <h1 className="text-2xl font-bold tracking-tight">Artigos da edição</h1>
 
       <div className="mt-4 rounded-md border p-4 bg-muted/30 text-sm text-muted-foreground space-y-2">
         <p>
           Estes são os <strong>{articles.length} artigos</strong> que foram
-          considerados para a edição deste clipping
-          {windowText && (
-            <>
-              , publicados no período de <strong>{windowText}</strong>
-            </>
-          )}
-          .
+          considerados para a edição deste clipping.
         </p>
         <p>
           Os artigos são selecionados automaticamente a partir dos recortes
@@ -142,7 +46,7 @@ export default async function ReleaseArticlesPage({ params }: Props) {
         {articles.map((article) => (
           <a
             key={article.unique_id}
-            href={article.url}
+            href={article.url ?? '#'}
             target="_blank"
             rel="noopener noreferrer"
             className="block rounded-md border p-4 hover:shadow-sm transition-shadow"
@@ -151,20 +55,24 @@ export default async function ReleaseArticlesPage({ params }: Props) {
               {article.title}
             </h2>
             <div className="mt-1.5 flex items-center gap-2 flex-wrap">
-              <Badge className="text-xs border-border bg-background">
-                {article.agency}
-              </Badge>
+              {article.agency && (
+                <Badge className="text-xs border-border bg-background">
+                  {article.agency}
+                </Badge>
+              )}
               {article.theme_1_level_1_label && (
                 <Badge className="text-xs">
                   {article.theme_1_level_1_label}
                 </Badge>
               )}
-              <span className="text-xs text-muted-foreground">
-                {new Date(article.published_at * 1000).toLocaleDateString(
-                  'pt-BR',
-                  { day: '2-digit', month: '2-digit', year: 'numeric' },
-                )}
-              </span>
+              {article.published_at && (
+                <span className="text-xs text-muted-foreground">
+                  {new Date(article.published_at * 1000).toLocaleDateString(
+                    'pt-BR',
+                    { day: '2-digit', month: '2-digit', year: 'numeric' },
+                  )}
+                </span>
+              )}
             </div>
           </a>
         ))}

--- a/src/app/clipping/release/[releaseId]/artigos/page.tsx
+++ b/src/app/clipping/release/[releaseId]/artigos/page.tsx
@@ -1,7 +1,7 @@
 import { auth } from '@/auth'
 import { Badge } from '@/components/ui/badge'
 import { createSSRClient } from '@/lib/graphql/client'
-import { getContentService } from '@/services/content'
+import { createGraphQLContentService } from '@/services/content/graphql'
 
 export const revalidate = 600
 
@@ -17,7 +17,7 @@ export default async function ReleaseArticlesPage({ params }: Props) {
   // Cliente SSR com o token da sessão para que releases privadas
   // (autor/assinante) resolvam; releases públicas funcionam sem token.
   const session = await auth()
-  const content = getContentService(
+  const content = createGraphQLContentService(
     createSSRClient(async () => session?.accessToken ?? null),
   )
 

--- a/src/lib/__tests__/estimate-recorte-count.test.ts
+++ b/src/lib/__tests__/estimate-recorte-count.test.ts
@@ -3,8 +3,8 @@ import type { Recorte } from '@/types/clipping'
 
 const mockEstimateRecorteCount = vi.fn()
 
-vi.mock('@/services/content', () => ({
-  getContentService: () => ({
+vi.mock('@/services/content/graphql', () => ({
+  createGraphQLContentService: () => ({
     estimateRecorteCount: mockEstimateRecorteCount,
   }),
 }))

--- a/src/lib/__tests__/estimate-recorte-count.test.ts
+++ b/src/lib/__tests__/estimate-recorte-count.test.ts
@@ -1,125 +1,106 @@
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { Recorte } from '@/types/clipping'
 
-const mockSearch = vi.fn()
-vi.mock('@/services/typesense/client', () => ({
-  typesense: {
-    collections: () => ({
-      documents: () => ({
-        search: mockSearch,
-      }),
-    }),
-  },
+const mockEstimateRecorteCount = vi.fn()
+
+vi.mock('@/services/content', () => ({
+  getContentService: () => ({
+    estimateRecorteCount: mockEstimateRecorteCount,
+  }),
 }))
 
-import { buildFilterBy, estimateRecorteCount } from '../estimate-recorte-count'
+vi.mock('@/lib/graphql/client', () => ({
+  createSSRClient: vi.fn(() => ({})),
+}))
+
+import {
+  estimateRecorteCount,
+  estimateTotalCount,
+  hasFilters,
+} from '../estimate-recorte-count'
 
 function recorte(overrides: Partial<Omit<Recorte, 'id'>> = {}): Recorte {
-  return { id: 'r1', themes: [], agencies: [], keywords: [], ...overrides }
+  return {
+    id: 'r1',
+    title: 'Recorte de teste',
+    themes: [],
+    agencies: [],
+    keywords: [],
+    ...overrides,
+  }
 }
 
-describe('buildFilterBy', () => {
-  it('always includes published_at timestamp', () => {
-    const result = buildFilterBy(recorte(), 1700000000)
-    expect(result).toContain('published_at:>=1700000000')
+beforeEach(() => {
+  mockEstimateRecorteCount.mockReset()
+})
+
+describe('hasFilters', () => {
+  it('is false for an empty recorte', () => {
+    expect(hasFilters(recorte())).toBe(false)
   })
 
-  describe('agency filter', () => {
-    it('uses "agency" field (not "agency_key")', () => {
-      const result = buildFilterBy(recorte({ agencies: ['mec'] }), 0)
-      expect(result).toContain('agency:=mec')
-      expect(result).not.toContain('agency_key')
-    })
-
-    it('joins multiple agencies with OR', () => {
-      const result = buildFilterBy(
-        recorte({ agencies: ['mec', 'ms', 'mf'] }),
-        0,
-      )
-      expect(result).toContain('agency:=mec')
-      expect(result).toContain('agency:=ms')
-      expect(result).toContain('agency:=mf')
-      expect(result).toContain(' || ')
-    })
-
-    it('omits agency filter when agencies is empty', () => {
-      const result = buildFilterBy(recorte({ agencies: [] }), 0)
-      expect(result).not.toContain('agency')
-    })
-  })
-
-  describe('theme filter', () => {
-    it('matches theme code at L1, L2 and L3', () => {
-      const result = buildFilterBy(recorte({ themes: ['08'] }), 0)
-      expect(result).toContain('theme_1_level_1_code:=08')
-      expect(result).toContain('theme_1_level_2_code:=08')
-      expect(result).toContain('theme_1_level_3_code:=08')
-    })
-
-    it('escapes dots in L2/L3 theme codes', () => {
-      const result = buildFilterBy(recorte({ themes: ['08.01'] }), 0)
-      expect(result).toContain('08\\.01')
-      expect(result).not.toMatch(/theme[^:]*:=08\.01[^\\]/)
-    })
-
-    it('joins multiple themes with OR', () => {
-      const result = buildFilterBy(recorte({ themes: ['08', '16'] }), 0)
-      expect(result).toContain(' || ')
-    })
-
-    it('omits theme filter when themes is empty', () => {
-      const result = buildFilterBy(recorte({ themes: [] }), 0)
-      expect(result).not.toContain('theme')
-    })
-  })
-
-  describe('combined filters', () => {
-    it('combines theme and agency with AND', () => {
-      const result = buildFilterBy(
-        recorte({ themes: ['08'], agencies: ['mec'] }),
-        1000,
-      )
-      expect(result).toContain('published_at:>=1000')
-      expect(result).toContain('theme_1_level_1_code:=08')
-      expect(result).toContain('agency:=mec')
-      // All parts joined with &&
-      const parts = result.split(' && ')
-      expect(parts.length).toBeGreaterThanOrEqual(3)
-    })
-
-    it('no optional filters — only timestamp', () => {
-      const result = buildFilterBy(recorte(), 42)
-      expect(result).toBe('published_at:>=42')
-    })
+  it('is true when any of themes/agencies/keywords is set', () => {
+    expect(hasFilters(recorte({ themes: ['08'] }))).toBe(true)
+    expect(hasFilters(recorte({ agencies: ['mec'] }))).toBe(true)
+    expect(hasFilters(recorte({ keywords: ['educação'] }))).toBe(true)
   })
 })
 
 describe('estimateRecorteCount', () => {
-  it('returns 0 for empty recorte without calling Typesense', async () => {
-    mockSearch.mockClear()
+  it('returns 0 for empty recorte without calling the facade', async () => {
     const count = await estimateRecorteCount(recorte())
     expect(count).toBe(0)
-    expect(mockSearch).not.toHaveBeenCalled()
+    expect(mockEstimateRecorteCount).not.toHaveBeenCalled()
   })
 
-  it('calls Typesense when recorte has theme filter', async () => {
-    mockSearch.mockResolvedValue({ found: 42 })
+  it('delegates to the facade when recorte has a theme filter', async () => {
+    mockEstimateRecorteCount.mockResolvedValue(42)
     const count = await estimateRecorteCount(recorte({ themes: ['08'] }))
     expect(count).toBe(42)
-    expect(mockSearch).toHaveBeenCalled()
+    expect(mockEstimateRecorteCount).toHaveBeenCalledWith({
+      themes: ['08'],
+      agencies: [],
+      keywords: [],
+      sinceHours: 24,
+    })
   })
 
-  it('calls Typesense when recorte has agency filter', async () => {
-    mockSearch.mockResolvedValue({ found: 10 })
+  it('delegates to the facade when recorte has an agency filter', async () => {
+    mockEstimateRecorteCount.mockResolvedValue(10)
     const count = await estimateRecorteCount(recorte({ agencies: ['mec'] }))
     expect(count).toBe(10)
   })
 
-  it('calls Typesense when recorte has keyword filter', async () => {
-    mockSearch.mockResolvedValue({ found: 5 })
+  it('delegates to the facade when recorte has a keyword filter', async () => {
+    mockEstimateRecorteCount.mockResolvedValue(5)
     const count = await estimateRecorteCount(
       recorte({ keywords: ['educação'] }),
     )
     expect(count).toBe(5)
+  })
+
+  it('forwards a custom sinceHours window', async () => {
+    mockEstimateRecorteCount.mockResolvedValue(7)
+    await estimateRecorteCount(recorte({ themes: ['08'] }), 48)
+    expect(mockEstimateRecorteCount).toHaveBeenCalledWith(
+      expect.objectContaining({ sinceHours: 48 }),
+    )
+  })
+})
+
+describe('estimateTotalCount', () => {
+  it('sums per-recorte counts and reports each one', async () => {
+    mockEstimateRecorteCount.mockResolvedValueOnce(3).mockResolvedValueOnce(4)
+    const result = await estimateTotalCount([
+      recorte({ themes: ['08'] }),
+      recorte({ agencies: ['mec'] }),
+    ])
+    expect(result).toEqual({ total: 7, perRecorte: [3, 4] })
+  })
+
+  it('skips facade calls for recortes without filters', async () => {
+    const result = await estimateTotalCount([recorte(), recorte()])
+    expect(result).toEqual({ total: 0, perRecorte: [0, 0] })
+    expect(mockEstimateRecorteCount).not.toHaveBeenCalled()
   })
 })

--- a/src/lib/estimate-recorte-count.ts
+++ b/src/lib/estimate-recorte-count.ts
@@ -1,5 +1,5 @@
 import { createSSRClient } from '@/lib/graphql/client'
-import { getContentService } from '@/services/content'
+import { createGraphQLContentService } from '@/services/content/graphql'
 import type { Recorte } from '@/types/clipping'
 
 export const MAX_DAILY_ARTICLES = 100
@@ -21,7 +21,7 @@ export function hasFilters(recorte: Recorte): boolean {
  * Components), por isso usamos o cliente SSR (sem token — resolver público).
  */
 function content() {
-  return getContentService(createSSRClient(async () => null))
+  return createGraphQLContentService(createSSRClient(async () => null))
 }
 
 export async function estimateRecorteCount(

--- a/src/lib/estimate-recorte-count.ts
+++ b/src/lib/estimate-recorte-count.ts
@@ -1,34 +1,8 @@
-import { typesense } from '@/services/typesense/client'
+import { createSSRClient } from '@/lib/graphql/client'
+import { getContentService } from '@/services/content'
 import type { Recorte } from '@/types/clipping'
 
 export const MAX_DAILY_ARTICLES = 100
-
-export function buildFilterBy(
-  recorte: Recorte,
-  sinceTimestamp: number,
-): string {
-  const parts: string[] = [`published_at:>=${sinceTimestamp}`]
-
-  if (recorte.themes.length > 0) {
-    const themeConditions: string[] = []
-    for (const code of recorte.themes) {
-      const escaped = code.replace('.', '\\.')
-      themeConditions.push(`theme_1_level_1_code:=${escaped}`)
-      themeConditions.push(`theme_1_level_2_code:=${escaped}`)
-      themeConditions.push(`theme_1_level_3_code:=${escaped}`)
-    }
-    parts.push(`(${themeConditions.join(' || ')})`)
-  }
-
-  if (recorte.agencies.length > 0) {
-    const agencyConditions = recorte.agencies
-      .map((a) => `agency:=${a}`)
-      .join(' || ')
-    parts.push(`(${agencyConditions})`)
-  }
-
-  return parts.join(' && ')
-}
 
 export function hasFilters(recorte: Recorte): boolean {
   return (
@@ -38,29 +12,30 @@ export function hasFilters(recorte: Recorte): boolean {
   )
 }
 
+/**
+ * Estima a contagem de artigos para um recorte via facade GraphQL.
+ *
+ * O resolver `estimateRecorteCount` é público e calcula a contagem real no
+ * servidor (max entre as keywords, dentro da janela `sinceHours`). Estas
+ * funções rodam server-side (route handlers `/api/clipping/*` e Server
+ * Components), por isso usamos o cliente SSR (sem token — resolver público).
+ */
+function content() {
+  return getContentService(createSSRClient(async () => null))
+}
+
 export async function estimateRecorteCount(
   recorte: Recorte,
   sinceHours = 24,
 ): Promise<number> {
   if (!hasFilters(recorte)) return 0
 
-  const sinceTimestamp = Math.floor(Date.now() / 1000) - sinceHours * 3600
-  const filterBy = buildFilterBy(recorte, sinceTimestamp)
-
-  const queryTerms = recorte.keywords.length > 0 ? recorte.keywords : ['*']
-  let total = 0
-
-  for (const term of queryTerms) {
-    const result = await typesense.collections('news').documents().search({
-      q: term,
-      query_by: 'title,summary',
-      filter_by: filterBy,
-      per_page: 0,
-    })
-    total = Math.max(total, result.found ?? 0)
-  }
-
-  return total
+  return content().estimateRecorteCount({
+    themes: recorte.themes,
+    agencies: recorte.agencies,
+    keywords: recorte.keywords,
+    sinceHours,
+  })
 }
 
 export async function estimateTotalCount(

--- a/src/lib/feed.ts
+++ b/src/lib/feed.ts
@@ -6,7 +6,7 @@ import { createSSRClient } from '@/lib/graphql/client'
 import { markdownToHtml } from '@/lib/markdown-to-html'
 import { getExcerpt } from '@/lib/utils'
 import type { ArticleFilterInput } from '@/services/content'
-import { getContentService } from '@/services/content'
+import { createGraphQLContentService } from '@/services/content/graphql'
 import type { ArticleRow } from '@/types/article'
 
 // --- Types ---
@@ -235,7 +235,7 @@ async function queryArticlesForFeed(
   params: FeedParams,
   limit: number,
 ): Promise<ArticleRow[]> {
-  const content = getContentService(createSSRClient(async () => null))
+  const content = createGraphQLContentService(createSSRClient(async () => null))
 
   const filter: ArticleFilterInput = {}
   if (params.agencias && params.agencias.length > 0) {

--- a/src/lib/feed.ts
+++ b/src/lib/feed.ts
@@ -2,9 +2,11 @@ import { createHash } from 'node:crypto'
 import { Feed } from 'feed'
 import { getAgenciesByName } from '@/data/agencies-utils'
 import { getThemeNameByCode } from '@/data/themes-utils'
+import { createSSRClient } from '@/lib/graphql/client'
 import { markdownToHtml } from '@/lib/markdown-to-html'
 import { getExcerpt } from '@/lib/utils'
-import { typesense } from '@/services/typesense/client'
+import type { ArticleFilterInput } from '@/services/content'
+import { getContentService } from '@/services/content'
 import type { ArticleRow } from '@/types/article'
 
 // --- Types ---
@@ -233,36 +235,33 @@ async function queryArticlesForFeed(
   params: FeedParams,
   limit: number,
 ): Promise<ArticleRow[]> {
-  const filterParts: string[] = []
+  const content = getContentService(createSSRClient(async () => null))
 
+  const filter: ArticleFilterInput = {}
   if (params.agencias && params.agencias.length > 0) {
-    filterParts.push(`agency:[${params.agencias.join(',')}]`)
+    filter.agencies = params.agencias
   }
-
   if (params.temas && params.temas.length > 0) {
-    const themeFilters = params.temas.map(
-      (theme) =>
-        `(theme_1_level_1_code:${theme} || theme_1_level_2_code:${theme} || theme_1_level_3_code:${theme})`,
-    )
-    filterParts.push(`(${themeFilters.join(' || ')})`)
+    filter.themes = params.temas
   }
-
   if (params.tag) {
-    filterParts.push(`tags:=${params.tag}`)
+    filter.tags = [params.tag]
   }
 
-  const result = await typesense
-    .collections<ArticleRow>('news')
-    .documents()
-    .search({
-      q: params.q?.trim().replace(/\s+/g, ' ') || '*',
-      query_by: 'title,content',
-      sort_by: 'published_at:desc,unique_id:desc',
-      filter_by: filterParts.length > 0 ? filterParts.join(' && ') : undefined,
-      limit,
-    })
+  const query = params.q?.trim().replace(/\s+/g, ' ')
 
-  return (result.hits?.map((hit) => hit.document) ?? []) as ArticleRow[]
+  if (query) {
+    const { articles } = await content.searchArticles({
+      query,
+      filter,
+      page: 1,
+    })
+    // O facade pode paginar/capar os resultados; respeitamos o limite do feed.
+    return articles.slice(0, limit)
+  }
+
+  const { articles } = await content.listArticles({ filter, limit })
+  return articles
 }
 
 function buildCategories(article: ArticleRow): Array<{ name: string }> {

--- a/src/lib/graphql/queries/articles.ts
+++ b/src/lib/graphql/queries/articles.ts
@@ -1,0 +1,239 @@
+/**
+ * Operações GraphQL de conteúdo público (artigos, busca, temas, releases).
+ *
+ * Estas operações alimentam o facade `src/services/content/` (Fase 2B), que
+ * por sua vez é consumido pelas ~10 server actions públicas migradas do
+ * Typesense para o GraphQL.
+ *
+ * Todos os campos do `Article` necessários para o mapper
+ * `graphqlArticle → ArticleRow` são selecionados via o fragment
+ * `ArticleFields`. IDs são `String` (scalar do schema).
+ *
+ * Schema de referência: `src/lib/graphql/schema.graphql`.
+ */
+
+import { gql } from '@urql/core'
+
+// ---------- Fragment ----------
+
+/**
+ * Todos os campos de `Article` que o mapper consome. Selecionar tudo aqui
+ * mantém o mapper íntegro independentemente de qual operação trouxe o artigo.
+ */
+export const ARTICLE_FIELDS = gql`
+  fragment ArticleFields on Article {
+    uniqueId
+    title
+    url
+    image
+    videoUrl
+    content
+    summary
+    subtitle
+    editorialLead
+    category
+    tags
+    agency
+    agencyName
+    publishedAt
+    extractedAt
+    theme1Level1Code
+    theme1Level1Label
+    theme1Level2Code
+    theme1Level2Label
+    theme1Level3Code
+    theme1Level3Label
+    mostSpecificThemeCode
+    mostSpecificThemeLabel
+  }
+`
+
+// ---------- Queries ----------
+
+/** Lista paginada de artigos com filtro opcional (agências, temas, datas…). */
+export const ARTICLES_QUERY = gql`
+  ${ARTICLE_FIELDS}
+  query Articles($page: Int!, $limit: Int!, $filter: ArticleFilter) {
+    articles(page: $page, limit: $limit, filter: $filter) {
+      articles {
+        ...ArticleFields
+      }
+      page
+      found
+    }
+  }
+`
+
+/** Busca (keyword/semântica/híbrida) com filtro, paginação e dedup. */
+export const SEARCH_QUERY = gql`
+  ${ARTICLE_FIELDS}
+  query Search(
+    $query: String!
+    $filter: ArticleFilter
+    $page: Int!
+    $semantic: Boolean!
+    $alpha: Float
+    $dedup: Boolean!
+  ) {
+    search(
+      query: $query
+      filter: $filter
+      page: $page
+      semantic: $semantic
+      alpha: $alpha
+      dedup: $dedup
+    ) {
+      articles {
+        ...ArticleFields
+      }
+      page
+      found
+    }
+  }
+`
+
+/** Carrega um único artigo pelo `uniqueId`. */
+export const ARTICLE_QUERY = gql`
+  ${ARTICLE_FIELDS}
+  query Article($uniqueId: String!) {
+    article(uniqueId: $uniqueId) {
+      ...ArticleFields
+    }
+  }
+`
+
+/** Sugestões de autocomplete para a barra de busca. */
+export const SEARCH_SUGGESTIONS_QUERY = gql`
+  query SearchSuggestions($query: String!) {
+    searchSuggestions(query: $query) {
+      uniqueId
+      title
+    }
+  }
+`
+
+/** Artigos relacionados a um dado artigo (similaridade semântica). */
+export const RELATED_ARTICLES_QUERY = gql`
+  ${ARTICLE_FIELDS}
+  query RelatedArticles($uniqueId: String!, $limit: Int!) {
+    relatedArticles(uniqueId: $uniqueId, limit: $limit) {
+      ...ArticleFields
+    }
+  }
+`
+
+/** Contagens de artigos por tema nos últimos N dias (nível da hierarquia). */
+export const THEME_ARTICLE_COUNTS_QUERY = gql`
+  query ThemeArticleCounts($days: Int!, $level: Int!) {
+    themeArticleCounts(days: $days, level: $level) {
+      code
+      label
+      count
+    }
+  }
+`
+
+/** Artigos que compõem uma release de clipping. */
+export const RELEASE_ARTICLES_QUERY = gql`
+  ${ARTICLE_FIELDS}
+  query ReleaseArticles($id: String!) {
+    releaseArticles(id: $id) {
+      ...ArticleFields
+    }
+  }
+`
+
+/** Estima a contagem de artigos para um recorte (themes/agencies/keywords). */
+export const ESTIMATE_RECORTE_COUNT_QUERY = gql`
+  query EstimateRecorteCount(
+    $themes: [String!]!
+    $agencies: [String!]!
+    $keywords: [String!]!
+    $sinceHours: Int!
+  ) {
+    estimateRecorteCount(
+      themes: $themes
+      agencies: $agencies
+      keywords: $keywords
+      sinceHours: $sinceHours
+    )
+  }
+`
+
+// ---------- TypeScript shapes ----------
+
+/** Artigo camelCase como vem do graphql-api (espelha o fragment acima). */
+export interface ArticleGraphQL {
+  uniqueId: string
+  title: string | null
+  url: string | null
+  image: string | null
+  videoUrl: string | null
+  content: string | null
+  summary: string | null
+  subtitle: string | null
+  editorialLead: string | null
+  category: string | null
+  tags: string[] | null
+  agency: string | null
+  agencyName: string | null
+  publishedAt: string | null
+  extractedAt: string | null
+  theme1Level1Code: string | null
+  theme1Level1Label: string | null
+  theme1Level2Code: string | null
+  theme1Level2Label: string | null
+  theme1Level3Code: string | null
+  theme1Level3Label: string | null
+  mostSpecificThemeCode: string | null
+  mostSpecificThemeLabel: string | null
+}
+
+export interface ArticlesResultGraphQL {
+  articles: ArticleGraphQL[]
+  page: number
+  found: number
+}
+
+export interface SearchSuggestionGraphQL {
+  uniqueId: string
+  title: string
+}
+
+export interface ThemeCountGraphQL {
+  code: string
+  label: string | null
+  count: number
+}
+
+export interface ArticlesQueryData {
+  articles: ArticlesResultGraphQL
+}
+
+export interface SearchQueryData {
+  search: ArticlesResultGraphQL
+}
+
+export interface ArticleQueryData {
+  article: ArticleGraphQL | null
+}
+
+export interface SearchSuggestionsQueryData {
+  searchSuggestions: SearchSuggestionGraphQL[]
+}
+
+export interface RelatedArticlesQueryData {
+  relatedArticles: ArticleGraphQL[]
+}
+
+export interface ThemeArticleCountsQueryData {
+  themeArticleCounts: ThemeCountGraphQL[]
+}
+
+export interface ReleaseArticlesQueryData {
+  releaseArticles: ArticleGraphQL[]
+}
+
+export interface EstimateRecorteCountQueryData {
+  estimateRecorteCount: number
+}

--- a/src/lib/graphql/schema.graphql
+++ b/src/lib/graphql/schema.graphql
@@ -81,6 +81,14 @@ type Article {
   agencyName: String
   publishedAt: DateTime
   extractedAt: DateTime
+  theme1Level1Code: String
+  theme1Level1Label: String
+  theme1Level2Code: String
+  theme1Level2Label: String
+  theme1Level3Code: String
+  theme1Level3Label: String
+  mostSpecificThemeCode: String
+  mostSpecificThemeLabel: String
 }
 
 input ArticleFilter {
@@ -89,6 +97,8 @@ input ArticleFilter {
   tags: [String!] = null
   startDate: String = null
   endDate: String = null
+  themeLabel: String = null
+  dedup: Boolean = null
 }
 
 type ArticlesResult {
@@ -229,6 +239,28 @@ type EstimateResult {
 input FeatureUpsertInput {
   uniqueId: String!
   features: JSON!
+}
+
+type FollowedListing {
+  id: String!
+  authorUserId: String!
+  authorDisplayName: String!
+  sourceClippingId: String!
+  name: String!
+  description: String
+  recortes: [MarketplaceRecorte!]!
+  prompt: String
+  schedule: String
+  likeCount: Int!
+  followerCount: Int!
+  cloneCount: Int!
+  publishedAt: DateTime
+  updatedAt: DateTime
+  active: Boolean!
+  deliveryChannels: DeliveryChannels
+  extraEmails: [String!]!
+  webhookUrl: String
+  followedAt: DateTime
 }
 
 type IntegrityCandidateType {
@@ -473,6 +505,8 @@ type Query {
     filter: ArticleFilter = null
     page: Int! = 1
     semantic: Boolean! = false
+    alpha: Float = null
+    dedup: Boolean! = false
   ): ArticlesResult!
 
   """
@@ -526,6 +560,11 @@ type Query {
   clipping(id: String!): Clipping
 
   """
+  Busca um release por ID. Autorizacao espelha `MarketplaceListing.releases`: PUBLICO se o listing fonte do clipping esta ativo; caso contrario somente autor ou subscriber. Substitui o `getReleaseById` do portal. Retorna None se o release nao existe OU o caller nao esta autorizado. Para o caller autorizado, popula `recortes` (filtros do clipping fonte) e `marketplaceListingId` (id do listing ativo, ou null).
+  """
+  release(id: String!): Release
+
+  """
   Estima o numero de artigos para um clipping
   """
   clippingEstimate(
@@ -543,6 +582,11 @@ type Query {
   Busca um listing do marketplace por ID
   """
   marketplaceListing(id: String!): MarketplaceListing
+
+  """
+  Listings que o usuario autenticado segue, com os campos da subscription dele (canais, emails extras, webhook, data). Substitui o `getFollows` do portal. Exclui follows cujo listing esta inativo ou ausente.
+  """
+  myFollowedListings: [FollowedListing!]!
 
   """
   Preferencias de push notification do usuario autenticado
@@ -566,6 +610,11 @@ type Query {
     config: WidgetConfigInput!
     page: Int! = 1
   ): WidgetArticlesResult!
+
+  """
+  True se o usuario autenticado tem o Telegram vinculado (`users/{id}/telegramLink/account` existe). Substitui o `getHasTelegram` do portal. Retorna False se nao logado ou sem doc.
+  """
+  currentUserHasTelegramLinked: Boolean!
 
   """
   Fetch a single news record by unique_id
@@ -605,6 +654,31 @@ type Query {
   Fetch a batch of articles needing integrity checks
   """
   integrityBatch(batchSize: Int! = 50): [IntegrityCandidateType!]!
+
+  """
+  Artigos relacionados a `uniqueId`, baseados no theme-code (Typesense). Replica a logica do portal: usa most_specific_theme_code quando presente, senao theme_1_level_1_code; exclui o proprio artigo; ordena por publishedAt desc; deduplica por content_hash. PUBLICO. (Distinto do `similarArticles` interno, baseado em embedding postgres.)
+  """
+  relatedArticles(uniqueId: String!, limit: Int! = 4): [Article!]!
+
+  """
+  Contagem de artigos por code de tema (nivel `level`) nos ultimos `days` dias. `label` e None (o portal mapeia pela config). PUBLICO.
+  """
+  themeArticleCounts(days: Int! = 30, level: Int! = 1): [ThemeCount!]!
+
+  """
+  Artigos de um release (pagina de artigos do release). Autorizacao espelha `release(id)`: PUBLICO se o listing fonte do clipping esta ativo; caso contrario somente autor ou subscriber. Retorna [] se negado ou inexistente. Janela temporal [refTime - sinceHours, refTime] (default ultimas 24h). Para cada recorte: se tem keywords, uma busca por keyword (q em title,summary) + filtro (themes OR-levels + agencies + janela); senao, uma busca q=* filter-only. Une tudo, deduplica por uniqueId, ordena por publishedAt desc. PUBLICO (sujeito a auth do release).
+  """
+  releaseArticles(id: String!): [Article!]!
+
+  """
+  Estima quantos artigos um recorte capturaria nas ultimas `sinceHours` horas. Replica `lib/estimate-recorte-count.ts`: filtro = themes OR-levels + agencies OR'd + published_at >= now-sinceHours; para keywords, conta por keyword (q em title,summary) e retorna o MAX; sem keywords, uma unica contagem. Substitui o mock `clippingEstimate`. PUBLICO.
+  """
+  estimateRecorteCount(
+    themes: [String!]!
+    agencies: [String!]!
+    keywords: [String!]!
+    sinceHours: Int! = 24
+  ): Int!
 }
 
 type Recorte {
@@ -623,6 +697,9 @@ input RecorteInput {
 }
 
 type Release {
+  digestPreview: String
+  recortes: [Recorte!]!
+  marketplaceListingId: String
   id: String!
   clippingId: String!
   clippingName: String!
@@ -671,6 +748,12 @@ type Tag {
 type Theme {
   code: String!
   label: String!
+}
+
+type ThemeCount {
+  code: String!
+  label: String
+  count: Int!
 }
 
 """

--- a/src/lib/landing-stats.ts
+++ b/src/lib/landing-stats.ts
@@ -1,7 +1,8 @@
 import { unstable_cache } from 'next/cache'
 import { getAgenciesList } from '@/data/agencies-utils'
 import { getFirestoreDb } from '@/lib/firebase-admin'
-import { typesense } from '@/services/typesense/client'
+import { createSSRClient } from '@/lib/graphql/client'
+import { getContentService } from '@/services/content'
 
 export type LandingStats = {
   portalsCount: number
@@ -10,17 +11,12 @@ export type LandingStats = {
 }
 
 async function computeStats(): Promise<LandingStats> {
+  // Conteúdo público não precisa de token de autenticação.
+  const content = getContentService(createSSRClient(async () => null))
+
   const [agencies, newsResult, marketplaceSnap] = await Promise.all([
     getAgenciesList().catch(() => []),
-    typesense
-      .collections('news')
-      .documents()
-      .search({
-        q: '*',
-        query_by: 'title',
-        per_page: 0,
-      })
-      .catch(() => ({ found: 0 })),
+    content.listArticles({ limit: 0 }).catch(() => ({ found: 0 })),
     getFirestoreDb()
       .collection('marketplace')
       .where('active', '==', true)

--- a/src/lib/landing-stats.ts
+++ b/src/lib/landing-stats.ts
@@ -2,7 +2,7 @@ import { unstable_cache } from 'next/cache'
 import { getAgenciesList } from '@/data/agencies-utils'
 import { getFirestoreDb } from '@/lib/firebase-admin'
 import { createSSRClient } from '@/lib/graphql/client'
-import { getContentService } from '@/services/content'
+import { createGraphQLContentService } from '@/services/content/graphql'
 
 export type LandingStats = {
   portalsCount: number
@@ -12,7 +12,7 @@ export type LandingStats = {
 
 async function computeStats(): Promise<LandingStats> {
   // Conteúdo público não precisa de token de autenticação.
-  const content = getContentService(createSSRClient(async () => null))
+  const content = createGraphQLContentService(createSSRClient(async () => null))
 
   const [agencies, newsResult, marketplaceSnap] = await Promise.all([
     getAgenciesList().catch(() => []),

--- a/src/services/content/__tests__/graphql.test.ts
+++ b/src/services/content/__tests__/graphql.test.ts
@@ -1,0 +1,297 @@
+/**
+ * Testes da implementação GraphQL do `ContentService` (Fase 2B).
+ *
+ * Cada método verifica: (a) a operação certa é enviada, (b) as variáveis
+ * corretas, (c) o resultado vem mapeado via o mapper compartilhado.
+ */
+
+import type { Client } from '@urql/core'
+import { describe, expect, it } from 'vitest'
+import type { ArticleGraphQL } from '@/lib/graphql/queries/articles'
+import { createGraphQLContentService } from '../graphql'
+
+// ---------- Helpers ----------
+
+interface Op {
+  query: string
+  vars: unknown
+}
+
+function makeClientStub(handlers: {
+  onQuery?: (query: string, vars: unknown) => unknown
+  queryError?: unknown
+}): { client: Client; queries: Op[] } {
+  const queries: Op[] = []
+  const client = {
+    query: (doc: { loc?: { source?: { body: string } } }, vars: unknown) => ({
+      toPromise: async () => {
+        const body = doc?.loc?.source?.body ?? ''
+        queries.push({ query: body, vars })
+        return {
+          data: handlers.onQuery?.(body, vars) ?? {},
+          error: handlers.queryError,
+        }
+      },
+    }),
+  } as unknown as Client
+  return { client, queries }
+}
+
+function node(overrides: Partial<ArticleGraphQL> = {}): ArticleGraphQL {
+  return {
+    uniqueId: 'a-1',
+    title: 'T',
+    url: 'https://x',
+    image: null,
+    videoUrl: null,
+    content: null,
+    summary: null,
+    subtitle: null,
+    editorialLead: null,
+    category: 'Cat',
+    tags: ['t1'],
+    agency: 'ag-1',
+    agencyName: 'Agência 1',
+    publishedAt: '2026-05-01T10:00:00Z',
+    extractedAt: null,
+    theme1Level1Code: '01',
+    theme1Level1Label: 'Tema 1',
+    theme1Level2Code: null,
+    theme1Level2Label: null,
+    theme1Level3Code: null,
+    theme1Level3Label: null,
+    mostSpecificThemeCode: '01',
+    mostSpecificThemeLabel: 'Tema 1',
+    ...overrides,
+  }
+}
+
+describe('createGraphQLContentService', () => {
+  describe('listArticles', () => {
+    it('envia a query articles com page/limit/filter e mapeia o resultado', async () => {
+      const { client, queries } = makeClientStub({
+        onQuery: () => ({
+          articles: { articles: [node()], page: 2, found: 42 },
+        }),
+      })
+      const svc = createGraphQLContentService(client)
+      const res = await svc.listArticles({
+        page: 2,
+        limit: 5,
+        filter: { agencies: ['ag-1'] },
+        dedup: true,
+      })
+
+      expect(queries).toHaveLength(1)
+      expect(queries[0].query).toContain('query Articles')
+      expect(queries[0].vars).toEqual({
+        page: 2,
+        limit: 5,
+        filter: { agencies: ['ag-1'], dedup: true },
+      })
+      expect(res.found).toBe(42)
+      expect(res.articles).toHaveLength(1)
+      expect(res.articles[0].unique_id).toBe('a-1')
+      expect(res.articles[0].published_at).toBe(1777629600)
+    })
+
+    it('usa defaults page=1/limit=10 e filter null quando ausente', async () => {
+      const { client, queries } = makeClientStub({
+        onQuery: () => ({ articles: { articles: [], page: 1, found: 0 } }),
+      })
+      const svc = createGraphQLContentService(client)
+      await svc.listArticles()
+      expect(queries[0].vars).toEqual({ page: 1, limit: 10, filter: null })
+    })
+
+    it('lança erro útil quando a query falha', async () => {
+      const { client } = makeClientStub({
+        queryError: { graphQLErrors: [{ message: 'boom' }] },
+      })
+      const svc = createGraphQLContentService(client)
+      await expect(svc.listArticles()).rejects.toThrow('boom')
+    })
+  })
+
+  describe('searchArticles', () => {
+    it('envia a query search com todos os argumentos e retorna page', async () => {
+      const { client, queries } = makeClientStub({
+        onQuery: () => ({
+          search: { articles: [node()], page: 3, found: 7 },
+        }),
+      })
+      const svc = createGraphQLContentService(client)
+      const res = await svc.searchArticles({
+        query: 'fgts',
+        page: 3,
+        semantic: true,
+        alpha: 0.5,
+        dedup: true,
+        filter: { themes: ['01'] },
+      })
+
+      expect(queries[0].query).toContain('query Search')
+      expect(queries[0].vars).toEqual({
+        query: 'fgts',
+        page: 3,
+        semantic: true,
+        alpha: 0.5,
+        dedup: true,
+        filter: { themes: ['01'] },
+      })
+      expect(res.page).toBe(3)
+      expect(res.found).toBe(7)
+      expect(res.articles[0].unique_id).toBe('a-1')
+    })
+
+    it('aplica defaults (page=1, semantic=false, alpha=null, dedup=false)', async () => {
+      const { client, queries } = makeClientStub({
+        onQuery: () => ({ search: { articles: [], page: 1, found: 0 } }),
+      })
+      const svc = createGraphQLContentService(client)
+      await svc.searchArticles({ query: 'x' })
+      expect(queries[0].vars).toEqual({
+        query: 'x',
+        page: 1,
+        semantic: false,
+        alpha: null,
+        dedup: false,
+        filter: null,
+      })
+    })
+  })
+
+  describe('getArticle', () => {
+    it('envia a query article com uniqueId e mapeia', async () => {
+      const { client, queries } = makeClientStub({
+        onQuery: () => ({ article: node({ uniqueId: 'art-9' }) }),
+      })
+      const svc = createGraphQLContentService(client)
+      const row = await svc.getArticle('art-9')
+      expect(queries[0].query).toContain('query Article')
+      expect(queries[0].vars).toEqual({ uniqueId: 'art-9' })
+      expect(row?.unique_id).toBe('art-9')
+    })
+
+    it('retorna null quando o artigo não existe', async () => {
+      const { client } = makeClientStub({ onQuery: () => ({ article: null }) })
+      const svc = createGraphQLContentService(client)
+      expect(await svc.getArticle('nope')).toBeNull()
+    })
+  })
+
+  describe('getSearchSuggestions', () => {
+    it('envia a query e retorna {uniqueId,title}[]', async () => {
+      const { client, queries } = makeClientStub({
+        onQuery: () => ({
+          searchSuggestions: [{ uniqueId: 's1', title: 'Sug 1' }],
+        }),
+      })
+      const svc = createGraphQLContentService(client)
+      const res = await svc.getSearchSuggestions('fg')
+      expect(queries[0].query).toContain('query SearchSuggestions')
+      expect(queries[0].vars).toEqual({ query: 'fg' })
+      expect(res).toEqual([{ uniqueId: 's1', title: 'Sug 1' }])
+    })
+  })
+
+  describe('getRelatedArticles', () => {
+    it('envia uniqueId/limit e mapeia a lista', async () => {
+      const { client, queries } = makeClientStub({
+        onQuery: () => ({ relatedArticles: [node()] }),
+      })
+      const svc = createGraphQLContentService(client)
+      const res = await svc.getRelatedArticles('a-1', 6)
+      expect(queries[0].query).toContain('query RelatedArticles')
+      expect(queries[0].vars).toEqual({ uniqueId: 'a-1', limit: 6 })
+      expect(res[0].unique_id).toBe('a-1')
+    })
+
+    it('usa limit default 4', async () => {
+      const { client, queries } = makeClientStub({
+        onQuery: () => ({ relatedArticles: [] }),
+      })
+      const svc = createGraphQLContentService(client)
+      await svc.getRelatedArticles('a-1')
+      expect(queries[0].vars).toEqual({ uniqueId: 'a-1', limit: 4 })
+    })
+  })
+
+  describe('getThemeArticleCounts', () => {
+    it('envia days/level e devolve {code,label,count}[]', async () => {
+      const { client, queries } = makeClientStub({
+        onQuery: () => ({
+          themeArticleCounts: [{ code: '01', label: 'Tema', count: 5 }],
+        }),
+      })
+      const svc = createGraphQLContentService(client)
+      const res = await svc.getThemeArticleCounts(7, 2)
+      expect(queries[0].query).toContain('query ThemeArticleCounts')
+      expect(queries[0].vars).toEqual({ days: 7, level: 2 })
+      expect(res).toEqual([{ code: '01', label: 'Tema', count: 5 }])
+    })
+
+    it('usa defaults days=30/level=1', async () => {
+      const { client, queries } = makeClientStub({
+        onQuery: () => ({ themeArticleCounts: [] }),
+      })
+      const svc = createGraphQLContentService(client)
+      await svc.getThemeArticleCounts()
+      expect(queries[0].vars).toEqual({ days: 30, level: 1 })
+    })
+  })
+
+  describe('getReleaseArticles', () => {
+    it('envia id e mapeia a lista', async () => {
+      const { client, queries } = makeClientStub({
+        onQuery: () => ({ releaseArticles: [node()] }),
+      })
+      const svc = createGraphQLContentService(client)
+      const res = await svc.getReleaseArticles('rel-1')
+      expect(queries[0].query).toContain('query ReleaseArticles')
+      expect(queries[0].vars).toEqual({ id: 'rel-1' })
+      expect(res[0].unique_id).toBe('a-1')
+    })
+  })
+
+  describe('estimateRecorteCount', () => {
+    it('envia themes/agencies/keywords/sinceHours e retorna o número', async () => {
+      const { client, queries } = makeClientStub({
+        onQuery: () => ({ estimateRecorteCount: 123 }),
+      })
+      const svc = createGraphQLContentService(client)
+      const n = await svc.estimateRecorteCount({
+        themes: ['01'],
+        agencies: ['ag'],
+        keywords: ['k'],
+        sinceHours: 48,
+      })
+      expect(queries[0].query).toContain('query EstimateRecorteCount')
+      expect(queries[0].vars).toEqual({
+        themes: ['01'],
+        agencies: ['ag'],
+        keywords: ['k'],
+        sinceHours: 48,
+      })
+      expect(n).toBe(123)
+    })
+
+    it('usa sinceHours default 24', async () => {
+      const { client, queries } = makeClientStub({
+        onQuery: () => ({ estimateRecorteCount: 0 }),
+      })
+      const svc = createGraphQLContentService(client)
+      await svc.estimateRecorteCount({
+        themes: [],
+        agencies: [],
+        keywords: [],
+      })
+      expect(queries[0].vars).toEqual({
+        themes: [],
+        agencies: [],
+        keywords: [],
+        sinceHours: 24,
+      })
+    })
+  })
+})

--- a/src/services/content/__tests__/mapper.test.ts
+++ b/src/services/content/__tests__/mapper.test.ts
@@ -1,0 +1,170 @@
+/**
+ * Testes do mapper compartilhado `mapGraphqlArticleToRow`
+ * (graphql Article camelCase → ArticleRow snake_case).
+ *
+ * Este é o componente de mais alto risco da Fase 2B: ~10 server actions
+ * dependem de que o mapeamento campo-a-campo e, sobretudo, a conversão de
+ * data (ISO → Unix **segundos**) estejam exatos.
+ */
+
+import { describe, expect, it } from 'vitest'
+import type { ArticleGraphQL } from '@/lib/graphql/queries/articles'
+import { mapGraphqlArticleToRow } from '../graphql'
+
+function fullArticle(): ArticleGraphQL {
+  return {
+    uniqueId: 'abc-123',
+    title: 'Título do artigo',
+    url: 'https://gov.br/noticia',
+    image: 'https://gov.br/img.jpg',
+    videoUrl: 'https://gov.br/video.mp4',
+    content: 'Conteúdo completo',
+    summary: 'Resumo',
+    subtitle: 'Subtítulo',
+    editorialLead: 'Linha fina editorial',
+    category: 'Economia',
+    tags: ['fgts', 'inss'],
+    agency: 'ministerio-da-fazenda',
+    agencyName: 'Ministério da Fazenda',
+    publishedAt: '2026-05-01T10:00:00Z',
+    extractedAt: '2026-05-01T12:30:00Z',
+    theme1Level1Code: '01',
+    theme1Level1Label: 'Economia e Finanças',
+    theme1Level2Code: '0101',
+    theme1Level2Label: 'Política Fiscal',
+    theme1Level3Code: '010101',
+    theme1Level3Label: 'Arrecadação',
+    mostSpecificThemeCode: '010101',
+    mostSpecificThemeLabel: 'Arrecadação',
+  }
+}
+
+describe('mapGraphqlArticleToRow', () => {
+  it('mapeia todos os campos camelCase → snake_case', () => {
+    const row = mapGraphqlArticleToRow(fullArticle())
+
+    expect(row.unique_id).toBe('abc-123')
+    expect(row.title).toBe('Título do artigo')
+    expect(row.url).toBe('https://gov.br/noticia')
+    expect(row.image).toBe('https://gov.br/img.jpg')
+    expect(row.video_url).toBe('https://gov.br/video.mp4')
+    expect(row.content).toBe('Conteúdo completo')
+    expect(row.summary).toBe('Resumo')
+    expect(row.subtitle).toBe('Subtítulo')
+    expect(row.editorial_lead).toBe('Linha fina editorial')
+    expect(row.category).toBe('Economia')
+    expect(row.tags).toEqual(['fgts', 'inss'])
+  })
+
+  it('mapeia os campos de tema (níveis 1-3 + mais específico)', () => {
+    const row = mapGraphqlArticleToRow(fullArticle())
+
+    expect(row.theme_1_level_1_code).toBe('01')
+    expect(row.theme_1_level_1_label).toBe('Economia e Finanças')
+    expect(row.theme_1_level_2_code).toBe('0101')
+    expect(row.theme_1_level_2_label).toBe('Política Fiscal')
+    expect(row.theme_1_level_3_code).toBe('010101')
+    expect(row.theme_1_level_3_label).toBe('Arrecadação')
+    expect(row.most_specific_theme_code).toBe('010101')
+    expect(row.most_specific_theme_label).toBe('Arrecadação')
+  })
+
+  it('define theme_1_level_1 como alias de theme1Level1Label', () => {
+    const row = mapGraphqlArticleToRow(fullArticle())
+    expect(row.theme_1_level_1).toBe('Economia e Finanças')
+  })
+
+  it('usa `agency` (a chave) e NÃO sobrescreve com agencyName', () => {
+    const row = mapGraphqlArticleToRow(fullArticle())
+    expect(row.agency).toBe('ministerio-da-fazenda')
+  })
+
+  // --- CONVERSÃO DE DATA: o ponto crítico ---
+  // Evidência no código existente (todos tratam published_at como Unix SEGUNDOS):
+  //  - src/lib/utils.ts formatDateTime: `new Date(timestamp * 1000)`
+  //  - src/lib/feed.ts: `new Date(article.published_at * 1000)`
+  //  - clipping/release/[releaseId]/artigos/page.tsx: `published_at * 1000`
+  //  - embed/actions.ts isoToUnixSeconds: `Math.floor(ms / 1000)`
+  it('converte publishedAt ISO → Unix SEGUNDOS', () => {
+    const row = mapGraphqlArticleToRow(fullArticle())
+    // 2026-05-01T10:00:00Z == 1777629600 s
+    expect(row.published_at).toBe(1777629600)
+  })
+
+  it('converte extractedAt ISO → Unix SEGUNDOS', () => {
+    const row = mapGraphqlArticleToRow(fullArticle())
+    // 2026-05-01T12:30:00Z == 1777638600 s
+    expect(row.extracted_at).toBe(1777638600)
+  })
+
+  it('faz floor de segundos fracionários (ISO com milissegundos)', () => {
+    const row = mapGraphqlArticleToRow({
+      ...fullArticle(),
+      publishedAt: '2026-05-01T10:00:00.750Z',
+    })
+    // 1777629600.750 s → floor → 1777629600
+    expect(row.published_at).toBe(1777629600)
+  })
+
+  it('datas ausentes (null) → null', () => {
+    const row = mapGraphqlArticleToRow({
+      ...fullArticle(),
+      publishedAt: null,
+      extractedAt: null,
+    })
+    expect(row.published_at).toBeNull()
+    expect(row.extracted_at).toBeNull()
+  })
+
+  it('datas inválidas → null', () => {
+    const row = mapGraphqlArticleToRow({
+      ...fullArticle(),
+      publishedAt: 'not-a-date',
+    })
+    expect(row.published_at).toBeNull()
+  })
+
+  it('define published_year/month/week como null (não expostos pelo Article)', () => {
+    const row = mapGraphqlArticleToRow(fullArticle())
+    expect(row.published_year).toBeNull()
+    expect(row.published_month).toBeNull()
+    expect(row.published_week).toBeNull()
+  })
+
+  it('trata campos opcionais ausentes como null (e tags como null)', () => {
+    const row = mapGraphqlArticleToRow({
+      uniqueId: 'min-1',
+      title: null,
+      url: null,
+      image: null,
+      videoUrl: null,
+      content: null,
+      summary: null,
+      subtitle: null,
+      editorialLead: null,
+      category: null,
+      tags: null,
+      agency: null,
+      agencyName: null,
+      publishedAt: null,
+      extractedAt: null,
+      theme1Level1Code: null,
+      theme1Level1Label: null,
+      theme1Level2Code: null,
+      theme1Level2Label: null,
+      theme1Level3Code: null,
+      theme1Level3Label: null,
+      mostSpecificThemeCode: null,
+      mostSpecificThemeLabel: null,
+    })
+
+    expect(row.unique_id).toBe('min-1')
+    expect(row.title).toBeNull()
+    expect(row.video_url).toBeNull()
+    expect(row.editorial_lead).toBeNull()
+    expect(row.agency).toBeNull()
+    expect(row.tags).toBeNull()
+    expect(row.theme_1_level_1).toBeNull()
+    expect(row.most_specific_theme_label).toBeNull()
+  })
+})

--- a/src/services/content/graphql.ts
+++ b/src/services/content/graphql.ts
@@ -1,0 +1,279 @@
+/**
+ * Implementação GraphQL do `ContentService` (Fase 2B).
+ *
+ * Camada de conteúdo público (artigos/busca/temas/releases) consumida pelas
+ * ~10 server actions migradas do Typesense. Server-importável: este módulo
+ * NÃO é `'use client'` — o hook React vive em `index.ts`.
+ *
+ * O mapper `mapGraphqlArticleToRow` é exportado daqui e é a peça central:
+ * converte o `Article` camelCase do graphql-api para o `ArticleRow`
+ * (snake_case) que os componentes do portal já esperam.
+ *
+ * Operations: `src/lib/graphql/queries/articles.ts`.
+ * Schema de referência: `src/lib/graphql/schema.graphql`.
+ */
+
+import type { Client } from '@urql/core'
+import { getClient } from '@/lib/graphql/client'
+import {
+  ARTICLE_QUERY,
+  ARTICLES_QUERY,
+  type ArticleGraphQL,
+  type ArticleQueryData,
+  type ArticlesQueryData,
+  ESTIMATE_RECORTE_COUNT_QUERY,
+  type EstimateRecorteCountQueryData,
+  RELATED_ARTICLES_QUERY,
+  RELEASE_ARTICLES_QUERY,
+  type RelatedArticlesQueryData,
+  type ReleaseArticlesQueryData,
+  SEARCH_QUERY,
+  SEARCH_SUGGESTIONS_QUERY,
+  type SearchQueryData,
+  type SearchSuggestionsQueryData,
+  THEME_ARTICLE_COUNTS_QUERY,
+  type ThemeArticleCountsQueryData,
+} from '@/lib/graphql/queries/articles'
+import type { ArticleRow } from '@/types/article'
+import type {
+  ContentService,
+  EstimateRecorteCountArgs,
+  ListArticlesArgs,
+  SearchArticlesArgs,
+} from './types'
+
+// ---------- Mapper (peça central, compartilhada) ----------
+
+/**
+ * Converte uma data ISO (formato `DateTime` do GraphQL) para timestamp Unix
+ * em **segundos** — a unidade que o `ArticleRow.published_at`/`extracted_at`
+ * usa em todo o portal.
+ *
+ * Evidência (todos os consumidores tratam como segundos):
+ *  - `src/lib/utils.ts` `formatDateTime`: `new Date(timestamp * 1000)`
+ *  - `src/lib/feed.ts`: `new Date(article.published_at * 1000)`
+ *  - `clipping/release/[releaseId]/artigos/page.tsx`: `published_at * 1000`
+ *  - `embed/actions.ts` `isoToUnixSeconds` (mesma conversão).
+ *
+ * Ausente/inválido → `null`.
+ */
+function isoToUnixSeconds(iso?: string | null): number | null {
+  if (!iso) return null
+  const ms = Date.parse(iso)
+  return Number.isNaN(ms) ? null : Math.floor(ms / 1000)
+}
+
+/**
+ * Mapeia um `Article` (camelCase, graphql-api) para o `ArticleRow`
+ * (snake_case) consumido pelos componentes do portal.
+ *
+ * Notas de mapeamento:
+ *  - `agency` ← `agency` (a CHAVE). `agencyName` é separado e NÃO sobrescreve.
+ *  - `theme_1_level_1` é um alias de compatibilidade = `theme1Level1Label`.
+ *  - `published_year/month/week` NÃO são expostos pelo `Article` → `null`.
+ *  - `tags` default `null` quando ausente.
+ */
+export function mapGraphqlArticleToRow(article: ArticleGraphQL): ArticleRow {
+  return {
+    unique_id: article.uniqueId ?? '',
+    agency: article.agency ?? null,
+    published_at: isoToUnixSeconds(article.publishedAt),
+    title: article.title ?? null,
+    url: article.url ?? null,
+    image: article.image ?? null,
+    video_url: article.videoUrl ?? null,
+    category: article.category ?? null,
+    content: article.content ?? null,
+    summary: article.summary ?? null,
+    subtitle: article.subtitle ?? null,
+    editorial_lead: article.editorialLead ?? null,
+    extracted_at: isoToUnixSeconds(article.extractedAt),
+    theme_1_level_1_code: article.theme1Level1Code ?? null,
+    theme_1_level_1_label: article.theme1Level1Label ?? null,
+    theme_1_level_2_code: article.theme1Level2Code ?? null,
+    theme_1_level_2_label: article.theme1Level2Label ?? null,
+    theme_1_level_3_code: article.theme1Level3Code ?? null,
+    theme_1_level_3_label: article.theme1Level3Label ?? null,
+    most_specific_theme_code: article.mostSpecificThemeCode ?? null,
+    most_specific_theme_label: article.mostSpecificThemeLabel ?? null,
+    // Não expostos pelo Article do GraphQL.
+    published_year: null,
+    published_month: null,
+    published_week: null,
+    tags: article.tags ?? null,
+    // Alias de compatibilidade (espelha o label de nível 1).
+    theme_1_level_1: article.theme1Level1Label ?? null,
+  }
+}
+
+// ---------- Helpers ----------
+
+/** Lê o erro mais útil de um `OperationResult` do urql. */
+function unwrapError(error: unknown, fallback: string): Error {
+  if (error && typeof error === 'object') {
+    const e = error as {
+      message?: string
+      graphQLErrors?: Array<{ message: string }>
+    }
+    if (e.graphQLErrors?.[0]?.message) {
+      return new Error(e.graphQLErrors[0].message)
+    }
+    if (e.message) {
+      return new Error(e.message)
+    }
+  }
+  return new Error(fallback)
+}
+
+/**
+ * Constrói o `ArticleFilter` do schema a partir do filtro do facade + a flag
+ * `dedup` (que no schema vive dentro do filtro). Retorna `null` quando não há
+ * nada a filtrar — coerente com o default do schema.
+ */
+function buildFilter(
+  filter: ListArticlesArgs['filter'] | SearchArticlesArgs['filter'],
+  dedup?: boolean,
+): Record<string, unknown> | null {
+  const base = filter ?? null
+  if (base == null && dedup == null) return null
+  return {
+    ...(base ?? {}),
+    ...(dedup != null ? { dedup } : {}),
+  }
+}
+
+// ---------- Service ----------
+
+/**
+ * Cria a implementação GraphQL com injeção de cliente (facilita testes).
+ *
+ * @param client Cliente urql. Default: `getClient()` (singleton browser).
+ */
+export function createGraphQLContentService(
+  client: Client = getClient(),
+): ContentService {
+  return {
+    async listArticles(args: ListArticlesArgs = {}) {
+      const page = args.page ?? 1
+      const limit = args.limit ?? 10
+      const filter = buildFilter(args.filter, args.dedup)
+      const result = await client
+        .query<ArticlesQueryData>(ARTICLES_QUERY, { page, limit, filter })
+        .toPromise()
+      if (result.error) {
+        throw unwrapError(result.error, 'Erro ao carregar artigos')
+      }
+      const data = result.data?.articles
+      return {
+        articles: (data?.articles ?? []).map(mapGraphqlArticleToRow),
+        found: data?.found ?? 0,
+      }
+    },
+
+    async searchArticles(args: SearchArticlesArgs) {
+      const vars = {
+        query: args.query,
+        page: args.page ?? 1,
+        semantic: args.semantic ?? false,
+        alpha: args.alpha ?? null,
+        dedup: args.dedup ?? false,
+        filter: args.filter ?? null,
+      }
+      const result = await client
+        .query<SearchQueryData>(SEARCH_QUERY, vars)
+        .toPromise()
+      if (result.error) {
+        throw unwrapError(result.error, 'Erro na busca')
+      }
+      const data = result.data?.search
+      return {
+        articles: (data?.articles ?? []).map(mapGraphqlArticleToRow),
+        found: data?.found ?? 0,
+        page: data?.page ?? vars.page,
+      }
+    },
+
+    async getArticle(uniqueId: string): Promise<ArticleRow | null> {
+      const result = await client
+        .query<ArticleQueryData>(ARTICLE_QUERY, { uniqueId })
+        .toPromise()
+      if (result.error) {
+        throw unwrapError(result.error, 'Erro ao carregar artigo')
+      }
+      const node: ArticleGraphQL | null = result.data?.article ?? null
+      return node ? mapGraphqlArticleToRow(node) : null
+    },
+
+    async getSearchSuggestions(query: string) {
+      const result = await client
+        .query<SearchSuggestionsQueryData>(SEARCH_SUGGESTIONS_QUERY, { query })
+        .toPromise()
+      if (result.error) {
+        throw unwrapError(result.error, 'Erro ao buscar sugestões')
+      }
+      return (result.data?.searchSuggestions ?? []).map((s) => ({
+        uniqueId: s.uniqueId,
+        title: s.title,
+      }))
+    },
+
+    async getRelatedArticles(uniqueId: string, limit = 4) {
+      const result = await client
+        .query<RelatedArticlesQueryData>(RELATED_ARTICLES_QUERY, {
+          uniqueId,
+          limit,
+        })
+        .toPromise()
+      if (result.error) {
+        throw unwrapError(result.error, 'Erro ao carregar relacionados')
+      }
+      return (result.data?.relatedArticles ?? []).map(mapGraphqlArticleToRow)
+    },
+
+    async getThemeArticleCounts(days = 30, level = 1) {
+      const result = await client
+        .query<ThemeArticleCountsQueryData>(THEME_ARTICLE_COUNTS_QUERY, {
+          days,
+          level,
+        })
+        .toPromise()
+      if (result.error) {
+        throw unwrapError(result.error, 'Erro ao carregar contagens por tema')
+      }
+      return (result.data?.themeArticleCounts ?? []).map((t) => ({
+        code: t.code,
+        label: t.label ?? null,
+        count: t.count,
+      }))
+    },
+
+    async getReleaseArticles(id: string) {
+      const result = await client
+        .query<ReleaseArticlesQueryData>(RELEASE_ARTICLES_QUERY, { id })
+        .toPromise()
+      if (result.error) {
+        throw unwrapError(result.error, 'Erro ao carregar artigos da release')
+      }
+      return (result.data?.releaseArticles ?? []).map(mapGraphqlArticleToRow)
+    },
+
+    async estimateRecorteCount(args: EstimateRecorteCountArgs) {
+      const result = await client
+        .query<EstimateRecorteCountQueryData>(ESTIMATE_RECORTE_COUNT_QUERY, {
+          themes: args.themes,
+          agencies: args.agencies,
+          keywords: args.keywords,
+          sinceHours: args.sinceHours ?? 24,
+        })
+        .toPromise()
+      if (result.error) {
+        throw unwrapError(result.error, 'Erro ao estimar contagem')
+      }
+      return result.data?.estimateRecorteCount ?? 0
+    },
+  }
+}
+
+/** Instância pronta para uso client-side. */
+export const graphqlContentService: ContentService =
+  createGraphQLContentService()

--- a/src/services/content/index.ts
+++ b/src/services/content/index.ts
@@ -1,0 +1,52 @@
+/**
+ * Facade do serviço de conteúdo público (artigos/busca/temas/releases).
+ *
+ * GraphQL é o único caminho. Há duas formas de consumir:
+ *
+ *   1. `getContentService(client?)`: factory pura, aceita um urql Client
+ *      opcional. Indicada para server actions (SSR — passe `createSSRClient()`)
+ *      e para testes.
+ *
+ *   2. Hook React `useContentService()`: devolve a implementação GraphQL com o
+ *      cliente singleton do browser. Indicado para client components.
+ *
+ * O mapper compartilhado `mapGraphqlArticleToRow` também é reexportado aqui.
+ */
+
+'use client'
+
+import type { Client } from '@urql/core'
+import { useMemo } from 'react'
+import { getClient } from '@/lib/graphql/client'
+import { createGraphQLContentService, mapGraphqlArticleToRow } from './graphql'
+import type { ContentService } from './types'
+
+export { mapGraphqlArticleToRow }
+
+export type {
+  ArticleFilterInput,
+  ArticlesPage,
+  ContentService,
+  EstimateRecorteCountArgs,
+  ListArticlesArgs,
+  SearchArticlesArgs,
+  SearchArticlesResult,
+  SearchSuggestion,
+  ThemeCount,
+} from './types'
+
+/**
+ * Factory pura — usada em server actions (SSR) e em testes. Aceita um urql
+ * Client opcional (override para SSR/testes).
+ */
+export function getContentService(client?: Client): ContentService {
+  return createGraphQLContentService(client)
+}
+
+/**
+ * Hook React: devolve a implementação GraphQL do serviço de conteúdo.
+ * Memoizado para evitar recriação a cada render.
+ */
+export function useContentService(): ContentService {
+  return useMemo(() => createGraphQLContentService(getClient()), [])
+}

--- a/src/services/content/types.ts
+++ b/src/services/content/types.ts
@@ -1,0 +1,92 @@
+/**
+ * Tipos do `ContentService` — camada GraphQL de conteúdo público (Fase 2B).
+ *
+ * As ~10 server actions públicas (notícias, busca, temas, órgãos, artigo,
+ * releases, widget…) consomem este facade em vez de falar com o Typesense
+ * diretamente. As respostas já vêm mapeadas para `ArticleRow` (snake_case),
+ * o contrato que os componentes do portal (`NewsCard`, etc.) já esperam.
+ */
+
+import type { ArticleRow } from '@/types/article'
+
+/** Filtro de artigos/busca (espelha `ArticleFilter` do schema). */
+export interface ArticleFilterInput {
+  agencies?: string[] | null
+  themes?: string[] | null
+  tags?: string[] | null
+  startDate?: string | null
+  endDate?: string | null
+  themeLabel?: string | null
+  dedup?: boolean | null
+}
+
+export interface ListArticlesArgs {
+  page?: number
+  limit?: number
+  filter?: ArticleFilterInput | null
+  dedup?: boolean
+}
+
+export interface SearchArticlesArgs {
+  query: string
+  filter?: ArticleFilterInput | null
+  page?: number
+  semantic?: boolean
+  alpha?: number | null
+  dedup?: boolean
+}
+
+export interface ArticlesPage {
+  articles: ArticleRow[]
+  found: number
+}
+
+export interface SearchArticlesResult {
+  articles: ArticleRow[]
+  found: number
+  page: number
+}
+
+export interface SearchSuggestion {
+  uniqueId: string
+  title: string
+}
+
+export interface ThemeCount {
+  code: string
+  label: string | null
+  count: number
+}
+
+export interface EstimateRecorteCountArgs {
+  themes: string[]
+  agencies: string[]
+  keywords: string[]
+  sinceHours?: number
+}
+
+export interface ContentService {
+  /** Lista paginada de artigos com filtro opcional. */
+  listArticles(args?: ListArticlesArgs): Promise<ArticlesPage>
+
+  /** Busca (keyword/semântica/híbrida) de artigos. */
+  searchArticles(args: SearchArticlesArgs): Promise<SearchArticlesResult>
+
+  /** Carrega um único artigo pelo `uniqueId` (null se não existir). */
+  getArticle(uniqueId: string): Promise<ArticleRow | null>
+
+  /** Sugestões de autocomplete para a barra de busca. */
+  getSearchSuggestions(query: string): Promise<SearchSuggestion[]>
+
+  /** Artigos relacionados (similaridade semântica). */
+  getRelatedArticles(uniqueId: string, limit?: number): Promise<ArticleRow[]>
+
+  /** Contagens de artigos por tema nos últimos N dias. */
+  getThemeArticleCounts(days?: number, level?: number): Promise<ThemeCount[]>
+
+  /** Artigos que compõem uma release de clipping. */
+  getReleaseArticles(id: string): Promise<ArticleRow[]>
+
+  /** Estima a contagem de artigos para um recorte. */
+  estimateRecorteCount(args: EstimateRecorteCountArgs): Promise<number>
+}


### PR DESCRIPTION
## Contexto

Fase 2B do desacoplamento BD→GraphQL (`_plan/desacoplamento-bd-graphql.md`). As **server actions públicas** do portal deixam de falar direto com Typesense/embeddings e passam a consumir o graphql-api (resolvers da Fase 2A, já deployados em prod).

> Depende dos resolvers da Fase 2A (PR graphql-api #12, já em produção). Branchada de `development` — quando a 1B (#248) mergear, o `git` resolve o snapshot/arquivos (conjuntos majoritariamente disjuntos).

## Fundação

- **Fachada `src/services/content`** (`getContentService`) + **mapper compartilhado** `graphqlArticle → ArticleRow` (camelCase→snake_case; `publishedAt` ISO → **Unix segundos**, unidade confirmada em todo o codebase). Operations em `queries/articles.ts`. **26 testes** (mapper + fachada).

## Server actions migradas (sem `@/services/typesense`)

| Arquivo | Resolver |
|---|---|
| `(public)/actions.ts` (landing) + `lib/landing-stats.ts` | `listArticles`, `themeArticleCounts` (getThemes mantém scoring sobre artigos crus) |
| `busca/actions.ts` | `search(semantic, alpha:0.8, dedup)` — embeddings agora server-side; suggestions + autocomplete inline derivado |
| `artigos/[articleId]/actions.ts` | `getArticle` + `getRelatedArticles` |
| `temas/actions.ts` + `temas/[themeLabel]` + `orgaos/[agencyKey]` | `themeArticleCounts` (3 níveis) / `listArticles` (filtro label/code, dedup) |
| `lib/feed.ts` | `listArticles`/`searchArticles` (feeds REST mantidos por design) |
| `lib/estimate-recorte-count.ts` | `estimateRecorteCount` real (remove `buildFilterBy`) |
| `clipping/release/[releaseId]/artigos` | `getReleaseArticles` (1 query, auth no servidor) |

## Notas / riscos (para o gate 2C)

- **Paridade semântica:** geração de embeddings migrou cliente→servidor; ordenação depende do `search` do graphql-api casar com o vector_query antigo (`alpha:0.8`). Validar no E2E.
- **Limites de data:** actions enviam `startDate`/`endDate` ISO; assume `startDate` inclusivo / `endDate` exclusivo (`+1 dia`) como antes. Confirmar no E2E.
- **feed (branch com query):** `searchArticles` não expõe `limit` (só `page`) → `slice(limit)`; branch sem query usa `listArticles({limit})` exato.
- **Página release/artigos:** `getReleaseArticles` retorna só `ArticleRow[]` — heading/metadata viraram estáticos (perdeu o nome do clipping). Reexpor exigiria metadata do release junto; fora do escopo "1 query".
- `published_year/month/week` → null no mapper (nenhum consumidor lê).

## Validação

- `biome` ✓ · `pnpm lint` ✓ · `pnpm exec vitest run` → **557 passed** · `pnpm exec tsc --noEmit` (33 erros **pré-existentes**; 0 nos arquivos desta PR) · `pnpm graphql:codegen` ✓ (sem drift) · `pnpm build` ✓.

Gate real = **E2E `e2e/graphql` + specs públicos (2C)** contra staging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
