### PR TITLE
test(e2e): auth.setup compartilha cache de token do bot (evita lockout Keycloak)

### DIFF
--- a/e2e/auth.setup.ts
+++ b/e2e/auth.setup.ts
@@ -2,7 +2,7 @@ import crypto from 'node:crypto'
 import path from 'node:path'
 import { encode } from '@auth/core/jwt'
 import { expect, test as setup } from '@playwright/test'
-import { writeTokenCache } from './fixtures/keycloak'
+import { getCachedBotTokens } from './fixtures/keycloak'
 
 /**
  * Setup project para autenticação contra portal staging — bypassa o browser
@@ -38,9 +38,6 @@ import { writeTokenCache } from './fixtures/keycloak'
 
 const STAGING_PORTAL_URL =
   'https://destaquesgovbr-portal-staging-klvx64dufq-rj.a.run.app'
-const STAGING_KC_URL = 'https://destaquesgovbr-keycloak-klvx64dufq-rj.a.run.app'
-const KC_REALM = 'destaquesgovbr'
-const KC_CLIENT_ID = 'portal-e2e'
 const DEFAULT_BOT_USERNAME = 'e2e-bot@destaquesgovbr.gov.br'
 const SESSION_MAX_AGE_SECONDS = 30 * 24 * 60 * 60 // 30 dias
 
@@ -49,14 +46,6 @@ const authFile = path.join(
   '.auth',
   process.env.E2E_AUTH_STATE_FILENAME ?? 'staging.json',
 )
-
-interface KeycloakTokenResponse {
-  access_token: string
-  refresh_token: string
-  id_token?: string
-  expires_in: number
-  token_type: string
-}
 
 interface AccessTokenClaims {
   sub: string
@@ -77,33 +66,6 @@ function decodeJwtPayload<T = Record<string, unknown>>(token: string): T {
   return JSON.parse(payload) as T
 }
 
-async function fetchKeycloakToken(opts: {
-  kcUrl: string
-  username: string
-  password: string
-}): Promise<KeycloakTokenResponse> {
-  const tokenEndpoint = `${opts.kcUrl}/realms/${KC_REALM}/protocol/openid-connect/token`
-  const body = new URLSearchParams({
-    grant_type: 'password',
-    client_id: KC_CLIENT_ID,
-    username: opts.username,
-    password: opts.password,
-    scope: 'openid email profile',
-  })
-  const res = await fetch(tokenEndpoint, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-    body,
-  })
-  if (!res.ok) {
-    const text = await res.text()
-    throw new Error(
-      `Keycloak token endpoint retornou ${res.status}: ${text.slice(0, 500)}`,
-    )
-  }
-  return (await res.json()) as KeycloakTokenResponse
-}
-
 setup(
   'forge NextAuth session via Keycloak Direct Access Grant',
   async ({ context, request }) => {
@@ -121,24 +83,19 @@ setup(
     }
 
     const portalUrl = process.env.PLAYWRIGHT_BASE_URL ?? STAGING_PORTAL_URL
-    const kcUrl = process.env.KC_URL ?? STAGING_KC_URL
     const botUsername = process.env.E2E_BOT_USERNAME ?? DEFAULT_BOT_USERNAME
     const isHttps = portalUrl.startsWith('https://')
     const cookieName = isHttps
       ? '__Secure-authjs.session-token'
       : 'authjs.session-token'
 
-    // 1. Fetch JWT via Direct Access Grant.
-    const tokens = await fetchKeycloakToken({
-      kcUrl,
-      username: botUsername,
-      password: botPassword,
-    })
-
-    // 1b. Pré-popula o cache de token compartilhado para que as fixtures
-    //     reusem este grant (evita rajada de Direct Access Grants em paralelo,
-    //     que dispara o brute-force/quick-login lockout do Keycloak).
-    writeTokenCache(tokens)
+    // 1. Obtém o JWT do bot reusando o cache compartilhado (memória → arquivo →
+    //    refresh_token → password grant). Assim um rerun com cache válido NÃO
+    //    faz password grant — evita a rajada de Direct Access Grants que dispara
+    //    o brute-force/quick-login lockout do Keycloak. `getCachedBotTokens` já
+    //    persiste o cache (memória + arquivo) ao renovar ou fazer grant, então
+    //    não há `writeTokenCache` redundante aqui. (KC_URL é lido internamente.)
+    const tokens = await getCachedBotTokens()
 
     // 2. Decode access_token claims (sem validar — só para extrair metadados).
     const claims = decodeJwtPayload<AccessTokenClaims>(tokens.access_token)

--- a/e2e/fixtures/keycloak.ts
+++ b/e2e/fixtures/keycloak.ts
@@ -68,8 +68,31 @@ interface CachedToken {
   expires_in: number
 }
 
+/** Conjunto completo de tokens do bot, derivado do cache ou de um grant. */
+export interface BotTokens {
+  access_token: string
+  refresh_token?: string
+  /** validade em segundos — restante real quando vindo do cache */
+  expires_in: number
+}
+
 let memoryToken: CachedToken | null = null
-let inflight: Promise<string> | null = null
+let inflight: Promise<BotTokens> | null = null
+
+/** Segundos de validade restantes de um token cacheado (nunca negativo). */
+function remainingExpiresIn(t: CachedToken): number {
+  const ageSec = (Date.now() - t.obtained_at) / 1000
+  return Math.max(0, Math.floor(t.expires_in - ageSec))
+}
+
+/** Converte um `CachedToken` para o conjunto completo, corrigindo `expires_in`. */
+function cachedToBotTokens(t: CachedToken): BotTokens {
+  return {
+    access_token: t.access_token,
+    refresh_token: t.refresh_token,
+    expires_in: remainingExpiresIn(t),
+  }
+}
 
 function tokenIsFresh(t: CachedToken | null): boolean {
   if (!t?.access_token) return false
@@ -169,26 +192,34 @@ async function refreshGrant(
 }
 
 /**
- * Obtém um `access_token` do bot E2E, reusando o cache compartilhado.
+ * Obtém o conjunto COMPLETO de tokens do bot E2E (access + refresh + expires_in),
+ * reusando o cache compartilhado. Fonte única de verdade da ordem de obtenção.
  *
  * Ordem: memória do worker → arquivo de cache → `refresh_token` → password grant.
- * Coalesce chamadas concorrentes no mesmo worker (uma única ida em voo).
+ * Coalesce chamadas concorrentes no mesmo worker (uma única ida em voo). Escreve
+ * o cache (memória + arquivo) sempre que renova ou faz password grant.
+ *
+ * Quando o token vem do cache (memória ou arquivo), `expires_in` é corrigido para
+ * os segundos de validade RESTANTES — não o valor original do grant. Assim quem
+ * usa `expires_in` para calcular `expiresAt` (ex.: `auth.setup.ts`) não
+ * super-estima a expiração de um token já parcialmente consumido.
  *
  * Requer `E2E_BOT_PASSWORD` no ambiente (via `scripts/e2e/load-creds.sh`)
  * apenas quando precisar do password grant — com cache/refresh válidos, não.
  */
-export async function fetchBotAccessToken(): Promise<string> {
-  if (memoryToken && tokenIsFresh(memoryToken)) return memoryToken.access_token
+export async function getCachedBotTokens(): Promise<BotTokens> {
+  if (memoryToken && tokenIsFresh(memoryToken))
+    return cachedToBotTokens(memoryToken)
   if (inflight) return inflight
 
   inflight = (async () => {
     if (memoryToken && tokenIsFresh(memoryToken))
-      return memoryToken.access_token
+      return cachedToBotTokens(memoryToken)
 
     const cached = readTokenCacheFile()
     if (cached && tokenIsFresh(cached)) {
       memoryToken = cached
-      return cached.access_token
+      return cachedToBotTokens(cached)
     }
 
     // Token expirado mas com refresh_token: renova (não dispara brute-force).
@@ -196,19 +227,38 @@ export async function fetchBotAccessToken(): Promise<string> {
       const refreshed = await refreshGrant(cached.refresh_token)
       if (refreshed) {
         writeTokenCache(refreshed)
-        return refreshed.access_token
+        return {
+          access_token: refreshed.access_token,
+          refresh_token: refreshed.refresh_token,
+          expires_in: refreshed.expires_in,
+        }
       }
     }
 
     // Fallback: novo password grant (raro — só sem cache/refresh válidos).
     const tokens = await passwordGrant()
     writeTokenCache(tokens)
-    return tokens.access_token
+    return {
+      access_token: tokens.access_token,
+      refresh_token: tokens.refresh_token,
+      expires_in: tokens.expires_in,
+    }
   })().finally(() => {
     inflight = null
   })
 
   return inflight
+}
+
+/**
+ * Obtém apenas o `access_token` do bot E2E, reusando o cache compartilhado.
+ *
+ * Delega a `getCachedBotTokens()` (mesma ordem memória → arquivo → refresh →
+ * password) e devolve só o `access_token` — assinatura preservada para as
+ * fixtures que dependem de `Promise<string>`.
+ */
+export async function fetchBotAccessToken(): Promise<string> {
+  return (await getCachedBotTokens()).access_token
 }
 
 /** Decodifica o payload de um JWT (sem validar — só para extrair claims). */


### PR DESCRIPTION
## Problema
`e2e/auth.setup.ts` fazia sempre um `grant_type=password` próprio (`fetchKeycloakToken`), então **cada rodada** de `playwright test` disparava um password grant. Rodadas repetidas em janela curta acionam o brute-force/quick-login do Keycloak → bot `e2e-bot` lockado (`invalid_grant`/401 mesmo com senha certa). Já havia cache compartilhado em `fixtures/keycloak.ts` (`fetchBotAccessToken`), mas o setup não o usava.

## Fix
- Extrai `getCachedBotTokens()` em `fixtures/keycloak.ts` como **fonte única**: memória → arquivo (`bot-token.local.json`) → `refresh_token` grant → password grant (com coalescing in-flight). Escreve o cache em todo refresh/password.
- `fetchBotAccessToken()` delega a ele (assinatura `Promise<string>` inalterada).
- `auth.setup.ts` passa a usar `getCachedBotTokens()` (precisa do token completo p/ forjar a sessão NextAuth) e remove o `fetchKeycloakToken` próprio.

**Resultado:** rodada normal faz ≤1 password grant; reruns dentro da janela de cache/refresh fazem **0** (só refresh, que não conta como login). Nenhum caminho faz password grant incondicional.

## Validação
`tsc --noEmit` (e2e) ✓ · `biome` ✓. E2E ao vivo não rodável agora (bot em cooldown de lockout); validado por typecheck + revisão de lógica.

🤖 Generated with [Claude Code](https://claude.com/claude-code)