### PR TITLE
chore: workflow de dependency submission do pnpm (destrava alertas Dependabot)

### DIFF
--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -1,0 +1,42 @@
+name: Dependency Submission
+
+# Mantém o dependency graph do GitHub em sincronia com o pnpm-lock.yaml.
+#
+# Contexto: após a migração npm→pnpm (dez/2025) o package-lock.json foi removido,
+# mas o dependency graph do GitHub congelou no estado pré-migração — um manifesto
+# "fantasma" (package-lock.json) que não existe mais continuava gerando alertas
+# Dependabot que nunca fechavam, mesmo com as deps já corrigidas no pnpm-lock.yaml.
+#
+# A action component-detection (do time GitHub Advanced Security) parseia o
+# pnpm-lock.yaml e submete a árvore REAL de dependências via Dependency Submission
+# API, substituindo o manifesto fantasma e destravando o fechamento dos alertas.
+#
+# Roda no push para main (quando o lockfile muda), semanalmente como rede de
+# segurança, e sob demanda via workflow_dispatch.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - pnpm-lock.yaml
+      - package.json
+      - .github/workflows/dependency-submission.yml
+  schedule:
+    - cron: "0 6 * * 1" # segunda-feira 06:00 UTC
+  workflow_dispatch:
+
+permissions:
+  id-token: write
+  contents: write
+
+jobs:
+  dependency-submission:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Submit pnpm dependency graph
+        uses: advanced-security/component-detection-dependency-submission-action@v0.1.1
+        with:
+          filePath: "."


### PR DESCRIPTION
## Problema

O dependency graph do GitHub deste repo está **congelado no estado pré-migração npm→pnpm** (commit `894c9a5`, dez/2025). Sintomas diagnosticados:

- 48 alertas Dependabot apontam para `package-lock.json` — manifesto **removido há ~6 meses** que nunca foi purgado do grafo.
- 18 alertas de `next` em `package.json` também não fecham, mesmo com `next` já em 15.5.19.
- `GET /dependency-graph/sbom` retorna 404 → o grafo não reflete o `pnpm-lock.yaml` real.

Resultado: as correções de vulnerabilidade (PR #254/#255, já em `main`) **não fecham os alertas**, porque o GitHub não está lendo o lockfile real. É bookkeeping do grafo, não as deps (essas estão corrigidas e verificadas por build + E2E).

## Correção

Workflow `dependency-submission.yml` que roda a action [`advanced-security/component-detection-dependency-submission-action`](https://github.com/advanced-security/component-detection-dependency-submission-action) (GitHub Advanced Security). Ela parseia o `pnpm-lock.yaml` e submete a árvore real de dependências via **Dependency Submission API**, substituindo o manifesto fantasma.

**Triggers:** push em `main` (mudança em `pnpm-lock.yaml`/`package.json`/o próprio workflow), schedule semanal (rede de segurança) e `workflow_dispatch` (sob demanda).

**Permissões:** `id-token: write` + `contents: write` (exigidas pela API de submission).

## Efeito esperado

Assim que chegar em `main`, o push dispara o workflow (o próprio arquivo está no filtro de `paths`); o grafo passa a refletir as deps reais já corrigidas e os 66 alertas resolvidos fecham automaticamente. O schedule semanal mantém o grafo fresco daqui pra frente.

🤖 Generated with [Claude Code](https://claude.com/claude-code)