### PR TITLE
chore: atualiza GitHub Actions para runtime Node 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Fetch Typesense Config
         id: typesense
@@ -23,10 +23,10 @@ jobs:
           service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: "20"
           cache: "pnpm"

--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -34,9 +34,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Submit pnpm dependency graph
-        uses: advanced-security/component-detection-dependency-submission-action@v0.1.1
+        uses: advanced-security/component-detection-dependency-submission-action@v0.1.3
         with:
           filePath: "."

--- a/.github/workflows/deploy-preview-update.yml
+++ b/.github/workflows/deploy-preview-update.yml
@@ -45,13 +45,13 @@ jobs:
           echo "tag=preview-$SLUG-$(echo '${{ github.sha }}' | cut -c1-7)" >> "$GITHUB_OUTPUT"
 
       - name: Authenticate to GCP
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@v3
         with:
           workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
 
       - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
+        uses: google-github-actions/setup-gcloud@v3
 
       - name: Check if preview exists
         id: check
@@ -67,7 +67,7 @@ jobs:
 
       - name: Checkout code
         if: steps.check.outputs.exists == 'true'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Fetch Typesense Config
         if: steps.check.outputs.exists == 'true'
@@ -88,7 +88,7 @@ jobs:
 
       - name: Set up Docker Buildx
         if: steps.check.outputs.exists == 'true'
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Configure Docker for Artifact Registry
         if: steps.check.outputs.exists == 'true'

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -64,7 +64,7 @@ jobs:
           echo "### Preview slug: \`$SLUG\`" >> "$GITHUB_STEP_SUMMARY"
 
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ inputs.branch }}
 
@@ -76,7 +76,7 @@ jobs:
           service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Configure Docker for Artifact Registry
         run: gcloud auth configure-docker ${{ env.REGISTRY }}
@@ -170,13 +170,13 @@ jobs:
           echo "service=portal-preview-$SLUG" >> "$GITHUB_OUTPUT"
 
       - name: Authenticate to GCP
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@v3
         with:
           workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
 
       - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
+        uses: google-github-actions/setup-gcloud@v3
 
       - name: Delete Cloud Run service
         run: |
@@ -232,13 +232,13 @@ jobs:
 
     steps:
       - name: Authenticate to GCP
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@v3
         with:
           workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
 
       - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
+        uses: google-github-actions/setup-gcloud@v3
 
       - name: List preview services
         run: |

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -35,7 +35,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Fetch Typesense Config
         id: typesense
@@ -45,7 +45,7 @@ jobs:
           service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Configure Docker for Artifact Registry
         run: gcloud auth configure-docker ${{ env.REGISTRY }}

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Fetch Typesense Config
         id: typesense
@@ -31,7 +31,7 @@ jobs:
           service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Configure Docker for Artifact Registry
         run: gcloud auth configure-docker ${{ env.REGISTRY }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,13 +11,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '20'
           cache: 'pnpm'
@@ -33,7 +33,7 @@ jobs:
           NEXT_PUBLIC_TYPESENSE_SEARCH_ONLY_API_KEY: test_key
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v5
         with:
           files: ./coverage/lcov.info
           fail_ci_if_error: false


### PR DESCRIPTION
## Por quê

O GitHub vai **forçar Node 24** nas actions JS a partir de **16/06/2026** (Node 20 deprecado — aviso surgiu no deploy da v6.0.1). Este PR bumpa todas as actions para o **menor major que roda em node24**, minimizando mudança de comportamento.

## Mudanças (verificadas via `runs.using` de cada action)

| Action | De → Para | Runtime |
|--------|-----------|---------|
| `actions/checkout` | v4 → **v5** | node24 |
| `actions/setup-node` | v4 → **v5** | node24 |
| `pnpm/action-setup` | v4 → **v5** | node24 (lê `packageManager` do package.json) |
| `docker/setup-buildx-action` | v3 → **v4** | node24 |
| `google-github-actions/auth` | v2 → **v3** | node24 |
| `google-github-actions/setup-gcloud` | v2 → **v3** | node24 |
| `codecov/codecov-action` | v4 → **v5** | composite (`fail_ci_if_error: false` de-risca) |
| `component-detection-...` | v0.1.1 → **v0.1.3** | ⚠️ ainda node20 (sem release node24 upstream) |

## Notas
- **component-detection** não tem versão node24; ficará sob o node24 forçado pelo runner (actions node20 rodam nesse modo na prática). Sem alternativa upstream melhor para submission de pnpm.
- **Fora deste repo:** a reusable action interna `destaquesgovbr/reusable-workflows/.../fetch-typesense-config@v1` também deve ser auditada (repo `infra`/`reusable-workflows`).

## Validação
- ✅ Todos os YAMLs parseiam; diff é puro bump de versão (23/23)
- CI do PR exercita checkout/setup-node/pnpm v5 + codecov v5
- deploy-staging (no merge) exercita buildx v4; deploy-production usa as mesmas (checkout/buildx)

🤖 Generated with [Claude Code](https://claude.com/claude-code)