### PR TITLE
feature: tela da notícia enriquecida + filtros/ordenação na busca + páginas de entidade

### DIFF
--- a/_plan/enriquecer-noticia-features-e-navegacao-cruzada.md
+++ b/_plan/enriquecer-noticia-features-e-navegacao-cruzada.md
@@ -1,0 +1,130 @@
+# Enriquecer a tela da notícia com features do feature_worker + navegação cruzada
+
+> **Diretrizes de implementação (desta execução):**
+> - **Workflow orchestration** (ultracode) para as fases.
+> - **TDD** sempre que possível: teste primeiro → implementação → verde.
+> - **Local-first**: subir graphql-api (`make dev` :8000) + portal (`pnpm dev` :3000) localmente para debug rápido antes de qualquer CI/deploy. graphql-api dev fala com Postgres/Typesense **reais** do GCP.
+> - **Frontend** via skill `/frontend-design:frontend-design` para UI nova (chips de entidade, páginas de entidade, controles de filtro).
+> - **Branches**: portal → `development` (NUNCA `main` durante R1); graphql-api → `feat/*` → `main`; data-platform → fluxo próprio.
+
+## Context
+
+Hoje a página de uma notícia (`/artigos/[articleId]`) mostra "notícias relacionadas", mas a seleção **não usa** as features calculadas pelo `data-platform`. O resolver público `relatedArticles` (graphql-api, `public_content.py:93-125`) escolhe por **theme-code no Typesense** (`most_specific_theme_code` → senão `theme_1_level_1_code`, dedup por `content_hash`, top 4 por data). A similaridade semântica real (`similar_articles`, pgvector cosine) e a extração de entidades (`entities`, NER via Bedrock) **existem** em `news_features` (JSONB), mas o tipo público `Article` não expõe **nenhuma** feature — ele é populado só do Typesense.
+
+Objetivo: (1) trocar relacionadas para similaridade semântica; (2) enriquecer a tela da notícia com **entidades** (instituições/pessoas/locais), **popularidade & trending** e **leitura & legibilidade**; (3) habilitar **navegação cruzada** por entidade — tanto via filtro na `/busca` quanto via **páginas dedicadas de entidade** (`/entidades/[slug]`); (4) adicionar filtros novos à `/busca`: **entidades**, **sentimento** e **ordenação por trending/views**.
+
+Decisões tomadas com o usuário:
+- Relacionadas → **semântica (embedding)**.
+- Exibir na notícia → **entidades, popularidade & trending, leitura & legibilidade** (sem sentimento na tela).
+- Navegação cruzada → **ambos**: filtro na busca **e** páginas de entidade.
+- Novos filtros → **entidades, sentimento, ordenar por trending/views**.
+
+## Arquitetura-alvo (dois caminhos de dados)
+
+| Capacidade | Caminho | Custo |
+|---|---|---|
+| **Exibir** features numa notícia (entidades, views, trending, word_count, flesch) | **Postgres** — `news_features.features` JSONB, lookup por `unique_id` (lazy, batched) | Baixo. Nenhum reindex. |
+| **Relacionadas** semânticas | **Postgres** — `get_similar_articles()` (pgvector) → hidrata via Typesense | Baixo. Resolver já existe. |
+| **Filtrar / facetar / ordenar** por entidade, sentimento, trending, views | **Typesense** — campos facetáveis/sortáveis | Médio. Exige schema-update + reindex no data-platform. |
+
+Princípio: o que é só **leitura de uma notícia** sai do Postgres (rápido, sem mexer no Typesense). O que precisa de **busca/agregação em escala** vai pro Typesense.
+
+## Pré-requisito / Gate de dados (verificar ANTES de construir)
+
+O `enrichment-worker` (entities/sentiment) foi reportado como "em desenvolvimento". **Confirmar cobertura real** de `entities` em produção antes de investir na trilha de entidades:
+
+```sql
+SELECT count(*) FILTER (WHERE features ? 'entities') AS com_entities,
+       count(*) AS total
+FROM news_features;
+SELECT features->'entities' FROM news_features WHERE features ? 'entities' LIMIT 5;
+```
+- Se cobertura baixa → rodar/agendar backfill do enrichment (`data-science/src/news_enrichment/`) antes das fases que dependem de entidades.
+- `trending_score`, `view_count`, `word_count`, `readability_flesch` já têm pipeline (DAGs + feature-worker) e parcialmente já vão pro Typesense.
+
+---
+
+## Fase 0 — data-platform: indexar entidades + view_count no Typesense
+
+Necessária só para **filtro/facet/ordenação** (Fases 2/4). A exibição na notícia (Fases 1/3) não depende disto.
+
+**Arquivos:**
+- `data-platform/src/data_platform/typesense/collection.py` (`COLLECTION_SCHEMA`): adicionar
+  - `entity_org`, `entity_per`, `entity_loc`, `entity_misc` → `type: "string[]", facet: true, optional: true`
+  - opcional: `entities` (string[] facet) achatado para filtro "qualquer tipo"
+  - `view_count` → `type: "int32", facet: false, optional: true, sort: true`
+  - (`trending_score` já `sort:true`; `sentiment_label` já `facet:true`.)
+- `data-platform/src/data_platform/workers/typesense_sync/handler.py` (+ `typesense/indexer.py`): mapear `features.entities` → arrays por tipo e `features.view_count` → `view_count`.
+
+**Deploy/backfill (workflows manuais, NÃO terraform local):**
+- `gh workflow run typesense-schema-update.yaml` (PATCH aditivo idempotente).
+- `gh workflow run typesense-maintenance-sync.yaml` para popular nos docs existentes.
+
+## Fase 1 — graphql-api: expor features no `Article` + relacionadas semânticas
+
+**Branch:** `feat/*` → `main`. Rodar `e2e/graphql` antes de mergear.
+
+**1a. Novos tipos** (`schema/types/`):
+- `EntityType { text: String!, type: String!, count: Int! }`
+- `ArticleFeatures { entities: [EntityType!]!, viewCount: Int, uniqueSessions: Int, trendingScore: Float, wordCount: Int, readabilityFlesch: Float }`
+
+**1b. Campo `features` lazy no `Article`** (`schema/types/article.py`):
+- `@strawberry.field async def features(self, info) -> Optional[ArticleFeatures]` usando `self.unique_id` + **DataLoader** novo. Só resolve quando a operação seleciona `features { ... }` — listas/busca que pedem só `...ArticleFields` não pagam custo.
+- DataLoader em `dataloaders.py` (`create_features_loader(postgres_ds)`): batch por `unique_id` lendo `news_features.features` (reusar `PostgresDatasource.get_news_batch()`). Registrar no `context.py`.
+- `entities` ausente → `[]`.
+
+**1c. `relatedArticles` → semântico** (`schema/resolvers/public_content.py:93-125`):
+- Trocar theme-code por `postgres_ds.get_similar_articles(unique_id, threshold≈0.7, limit)` → hidratar para `Article` via **novo** `TypesenseDatasource.get_articles_by_ids(ids)`, **preservando ordem de similaridade**.
+- Assinatura GraphQL **inalterada** → zero drift; portal já chama e já rotula como "similaridade semântica".
+- Resolver passa a `async`. Fallback: sem embedding/sem vizinhos → `[]`.
+
+**1d.** `make docs-schema` + testes (`tests/test_schema.py`).
+
+## Fase 2 — graphql-api: filtros + ordenação na busca
+
+**2a. `ArticleFilter`** (`schema/types/article.py:43`): `entities: Optional[list[str]]`, `sentiment: Optional[list[str]]`.
+**2b. `sort`** nos resolvers `search`/`articles`: enum `RELEVANCE | DATE | TRENDING | VIEWS` → `sort_by` Typesense.
+**2c. `search_articles`** (`datasources/typesense.py:159`): tratar `entities` (`entity_*:=[...]` OR), `sentiment` (`sentiment_label:[...]`), `sort_by`.
+**2d. `entitySuggestions(query, type, limit): [EntityFacet!]`** via Typesense `facet_query`/`facet_by` sobre `entity_*`. ⚠️ Loaders em `dataloaders.py:12,31` usam `collections["articles"]`, mas a coleção é `"news"` — usar `"news"` no código novo.
+**2e.** `make docs-schema` + testes.
+
+## Fase 3 — portal: tela da notícia enriquecida
+
+**Branch:** `development`. Skills: `portal-implementation`, `frontend-design`, `use-button-component`, `reuse-components`, `no-index-key`.
+
+**3a. Query** (`src/lib/graphql/queries/articles.ts`): estender **só** `ARTICLE_QUERY` (não o fragment) com `features { entities { text type count } viewCount uniqueSessions trendingScore wordCount readabilityFlesch }`. Atualizar interfaces + mapper (`services/content/graphql.ts`, `types/article.ts`).
+
+**3b. UI `components/articles/ClientArticle.tsx`:**
+- **Entidades**: chips agrupados (Instituições/Pessoas/Locais via `type`), clicáveis → `/entidades/[slug]`. Componente `Button` + chips existentes.
+- **Popularidade & trending**: views + selo "Em alta" por `trendingScore`.
+- **Leitura & legibilidade**: tempo ≈ `wordCount/200` min + faixa de `readabilityFlesch`.
+- `features == null` → esconder seções. Manter ISR.
+
+**3c.** Relacionadas já vêm semânticas (Fase 1, sem mudança de operação). Ajustar título se desejado.
+
+## Fase 4 — portal: filtros na busca + páginas de entidade
+
+**4a. Filtros `/busca`** (`components/articles/ArticleFilters.tsx` + `app/(public)/busca/QueryPageClient.tsx` + `actions.ts`): multiselect de entidades (typeahead via `entitySuggestions`), select de sentimento, dropdown de ordenação. Params `entidades`, `sentimento`, `ordenar`. Passar `filter.entities`, `filter.sentiment`, `sort` ao `SEARCH_QUERY`.
+
+**4b. Páginas de entidade** — `app/(public)/entidades/[slug]/page.tsx` (+ client): helpers slug; header resolve label/tipo/contagem via `entitySuggestions`; lista paginada via `search` com `filter.entities=[label]` (reusar `NewsCard` + `useInfiniteQuery`). `generateMetadata` p/ SEO. Frontend via `frontend-design`.
+
+## Reuso (não recriar)
+
+- `PostgresDatasource.get_similar_articles()` (`datasources/postgres.py:381`).
+- `_NEWS_BASE_SQL` / `get_news_batch()` (já faz `LEFT JOIN news_features`, devolve `.features`).
+- Padrão DataLoader (`dataloaders.py`).
+- `update_schema()` (`typesense/collection.py:267`) — PATCH aditivo.
+- Portal: `NewsCard`, `Button`, `useInfiniteQuery`, facade `services/content/graphql.ts`, sync filtro↔URL de `/busca`.
+
+## Riscos & gates
+
+- **Cobertura de `entities`** (gate Fase 0) — sem dados, a trilha de entidades não renderiza. Verificar/backfill primeiro.
+- **Canonicalização de entidades** — texto livre do LLM; v1 = match exato; normalização (cruzar com `agencies`) é fast-follow.
+- **Drift gate (R1-01)** — `relatedArticles` não muda assinatura; `features`/`ArticleFilter.entities,sentiment`/`sort` são aditivos/nullable. `make docs-schema` + `e2e/graphql` antes de mergear o graphql-api.
+- **Ordem**: Fase 0 → 1/2 → 3/4. Exibição de entidades (1/3) é independente do Typesense (0) — pode sair antes do filtro/facet.
+
+## Verificação (E2E)
+
+1. **graphql-api** (`make dev` :8000): `pytest` + `make docs-schema` sem diff; smoke `article{features{...}}`, `relatedArticles`, `search(filter:{entities})`, `sort:TRENDING`.
+2. **portal** (gate real = Playwright no browser): estender `e2e/graphql/public-content.spec.ts` (chips + stats + clique→`/entidades`); novo spec `/busca` (filtro entidade/sentimento + ordenação). Suíte `e2e/graphql` **serial** (`--workers=1`). Rodar portal + graphql-api locais.
+3. **data-platform**: após `typesense-maintenance-sync`, conferir doc com `entity_org`/`view_count`; validar facet via `entitySuggestions`.

--- a/src/app/(public)/busca/QueryPageClient.tsx
+++ b/src/app/(public)/busca/QueryPageClient.tsx
@@ -33,11 +33,15 @@ const SORT_OPTIONS: Array<{
   value: string
   sort: ArticleSort
   label: string
+  /** Mantida no mapeamento URL→enum, mas oculta do dropdown. */
+  hidden?: boolean
 }> = [
   { value: 'relevance', sort: 'RELEVANCE', label: 'Relevância' },
   { value: 'date', sort: 'DATE', label: 'Mais recentes' },
   { value: 'trending', sort: 'TRENDING', label: 'Em alta' },
-  { value: 'views', sort: 'VIEWS', label: 'Mais vistas' },
+  // "Mais vistas" (VIEWS) oculto até a DAG de engagement popular view_count (cobertura ~0,3%).
+  // O valor segue mapeado para não quebrar links antigos com ?ordenar=views.
+  { value: 'views', sort: 'VIEWS', label: 'Mais vistas', hidden: true },
 ]
 
 const DEFAULT_SORT_VALUE = 'relevance'
@@ -82,7 +86,8 @@ export default function QueryPageClient({
 
   const [sortValue, setSortValue] = useState<string>(() => {
     const ordenar = searchParams.get('ordenar')
-    return SORT_OPTIONS.some((o) => o.value === ordenar)
+    // Opções ocultas (ex.: ?ordenar=views de links antigos) caem no default.
+    return SORT_OPTIONS.some((o) => o.value === ordenar && !o.hidden)
       ? (ordenar as string)
       : DEFAULT_SORT_VALUE
   })
@@ -432,11 +437,13 @@ export default function QueryPageClient({
                       <SelectValue />
                     </SelectTrigger>
                     <SelectContent>
-                      {SORT_OPTIONS.map((option) => (
-                        <SelectItem key={option.value} value={option.value}>
-                          {option.label}
-                        </SelectItem>
-                      ))}
+                      {SORT_OPTIONS.filter((option) => !option.hidden).map(
+                        (option) => (
+                          <SelectItem key={option.value} value={option.value}>
+                            {option.label}
+                          </SelectItem>
+                        ),
+                      )}
                     </SelectContent>
                   </Select>
                 </div>

--- a/src/app/(public)/busca/QueryPageClient.tsx
+++ b/src/app/(public)/busca/QueryPageClient.tsx
@@ -11,13 +11,39 @@ import { ArticleFilters } from '@/components/articles/ArticleFilters'
 import NewsCard from '@/components/articles/NewsCard'
 import { FeedLink } from '@/components/common/FeedLink'
 import { Button } from '@/components/ui/button'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
 import type { AgencyOption } from '@/data/agencies-utils'
 import type { ThemeOption } from '@/data/themes-utils'
+import type { ArticleSort } from '@/services/content/types'
 import { queryArticles } from './actions'
 
 type QueryPageClientProps = {
   agencies: AgencyOption[]
   themes: ThemeOption[]
+}
+
+/** Opções de ordenação: valor URL (`ordenar`) ↔ enum ArticleSort. */
+const SORT_OPTIONS: Array<{
+  value: string
+  sort: ArticleSort
+  label: string
+}> = [
+  { value: 'relevance', sort: 'RELEVANCE', label: 'Relevância' },
+  { value: 'date', sort: 'DATE', label: 'Mais recentes' },
+  { value: 'trending', sort: 'TRENDING', label: 'Em alta' },
+  { value: 'views', sort: 'VIEWS', label: 'Mais vistas' },
+]
+
+const DEFAULT_SORT_VALUE = 'relevance'
+
+function sortValueToEnum(value: string): ArticleSort {
+  return SORT_OPTIONS.find((o) => o.value === value)?.sort ?? 'RELEVANCE'
 }
 
 export default function QueryPageClient({
@@ -54,6 +80,23 @@ export default function QueryPageClient({
     () => searchParams.get('semantica') !== '0',
   )
 
+  const [sortValue, setSortValue] = useState<string>(() => {
+    const ordenar = searchParams.get('ordenar')
+    return SORT_OPTIONS.some((o) => o.value === ordenar)
+      ? (ordenar as string)
+      : DEFAULT_SORT_VALUE
+  })
+
+  const [selectedSentiments, setSelectedSentiments] = useState<string[]>(() => {
+    const sentimento = searchParams.get('sentimento')
+    return sentimento ? sentimento.split(',') : []
+  })
+
+  const [selectedEntities, setSelectedEntities] = useState<string[]>(() => {
+    const entidades = searchParams.get('entidades')
+    return entidades ? entidades.split(',') : []
+  })
+
   // Analytics tracking
   const { track } = useUmamiTrack()
   const hasTrackedSearch = useRef(false)
@@ -65,6 +108,9 @@ export default function QueryPageClient({
       dataFim?: string | null
       agencias?: string | null
       temas?: string | null
+      ordenar?: string | null
+      sentimento?: string | null
+      entidades?: string | null
     }) => {
       const params = new URLSearchParams(searchParams.toString())
 
@@ -148,6 +194,51 @@ export default function QueryPageClient({
     [updateUrlParams, track],
   )
 
+  const handleSortChange = useCallback(
+    (value: string) => {
+      setSortValue(value)
+      updateUrlParams({
+        ordenar: value === DEFAULT_SORT_VALUE ? null : value,
+      })
+      track('filter_changed', {
+        filter_type: 'sort',
+        action: 'set',
+        value,
+      })
+    },
+    [updateUrlParams, track],
+  )
+
+  const handleSentimentsChange = useCallback(
+    (sentimentsList: string[]) => {
+      setSelectedSentiments(sentimentsList)
+      updateUrlParams({
+        sentimento: sentimentsList.length > 0 ? sentimentsList.join(',') : null,
+      })
+      track('filter_changed', {
+        filter_type: 'sentiment',
+        action: sentimentsList.length > 0 ? 'set' : 'clear',
+        value: sentimentsList.length > 0 ? sentimentsList.join(',') : null,
+      })
+    },
+    [updateUrlParams, track],
+  )
+
+  const handleEntitiesChange = useCallback(
+    (entitiesList: string[]) => {
+      setSelectedEntities(entitiesList)
+      updateUrlParams({
+        entidades: entitiesList.length > 0 ? entitiesList.join(',') : null,
+      })
+      track('filter_changed', {
+        filter_type: 'entities',
+        action: entitiesList.length > 0 ? 'set' : 'clear',
+        value: entitiesList.length > 0 ? entitiesList.join(',') : null,
+      })
+    },
+    [updateUrlParams, track],
+  )
+
   const handleSemanticToggle = useCallback(() => {
     const next = !semantic
     setSemantic(next)
@@ -173,6 +264,9 @@ export default function QueryPageClient({
       selectedAgencies,
       selectedThemes,
       semantic,
+      sortValue,
+      selectedSentiments,
+      selectedEntities,
     ],
     queryFn: ({ pageParam }: { pageParam: number | null }) =>
       queryArticles({
@@ -183,6 +277,10 @@ export default function QueryPageClient({
         agencies: selectedAgencies.length > 0 ? selectedAgencies : undefined,
         themes: selectedThemes.length > 0 ? selectedThemes : undefined,
         semantic,
+        sort: sortValueToEnum(sortValue),
+        sentiment:
+          selectedSentiments.length > 0 ? selectedSentiments : undefined,
+        entities: selectedEntities.length > 0 ? selectedEntities : undefined,
       }),
     getNextPageParam: (lastPage) => lastPage.page ?? undefined,
     initialPageParam: 1,
@@ -291,20 +389,26 @@ export default function QueryPageClient({
             endDate={endDate}
             selectedAgencies={selectedAgencies}
             selectedThemes={selectedThemes}
+            selectedSentiments={selectedSentiments}
+            selectedEntities={selectedEntities}
             onStartDateChange={handleStartDateChange}
             onEndDateChange={handleEndDateChange}
             onAgenciesChange={handleAgenciesChange}
             onThemesChange={handleThemesChange}
+            onSentimentsChange={handleSentimentsChange}
+            onEntitiesChange={handleEntitiesChange}
             getAgencyName={getAgencyName}
             getThemeName={getThemeName}
             getThemeHierarchyPath={getThemeHierarchyPath}
+            showSentimentFilter
+            showEntityFilter
           />
 
           {/* Right Content - Results Grid */}
           <main className="flex-1 min-w-0">
-            {/* Semantic search toggle */}
+            {/* Toolbar: busca inteligente + ordenação */}
             {query && (
-              <div className="mb-4 flex items-center gap-2">
+              <div className="mb-4 flex flex-wrap items-center justify-between gap-3">
                 <Button
                   type="button"
                   variant={semantic ? 'default' : 'secondary'}
@@ -317,6 +421,25 @@ export default function QueryPageClient({
                   <Sparkles className="h-3.5 w-3.5" />
                   Busca inteligente
                 </Button>
+
+                <div className="flex items-center gap-2">
+                  <span className="text-sm text-primary/70">Ordenar por</span>
+                  <Select value={sortValue} onValueChange={handleSortChange}>
+                    <SelectTrigger
+                      className="w-44 bg-white"
+                      aria-label="Ordenar resultados"
+                    >
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {SORT_OPTIONS.map((option) => (
+                        <SelectItem key={option.value} value={option.value}>
+                          {option.label}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
               </div>
             )}
             <motion.div

--- a/src/app/(public)/busca/__tests__/actions.test.ts
+++ b/src/app/(public)/busca/__tests__/actions.test.ts
@@ -110,6 +110,40 @@ describe('queryArticles', () => {
     await queryArticles({ page: 1, query: 'x', semantic: false })
     expect(searchArticles.mock.calls[0][0].semantic).toBe(false)
   })
+
+  it('usa wildcard "*" quando não há texto mas há filtro (entidade)', async () => {
+    searchArticles.mockResolvedValue({ articles: [], found: 0, page: 1 })
+    await queryArticles({ page: 1, entities: ['Geraldo Alckmin'] })
+    const arg = searchArticles.mock.calls[0][0]
+    expect(arg.query).toBe('*')
+    expect(arg.filter.entities).toEqual(['Geraldo Alckmin'])
+  })
+
+  it('usa wildcard "*" quando não há texto mas há filtro (agência/sentimento)', async () => {
+    searchArticles.mockResolvedValue({ articles: [], found: 0, page: 1 })
+    await queryArticles({
+      page: 1,
+      agencies: ['min-a'],
+      sentiment: ['positive'],
+    })
+    expect(searchArticles.mock.calls[0][0].query).toBe('*')
+  })
+
+  it('mantém query vazia quando não há texto NEM filtro algum', async () => {
+    searchArticles.mockResolvedValue({ articles: [], found: 0, page: 1 })
+    await queryArticles({ page: 1 })
+    expect(searchArticles.mock.calls[0][0].query).toBe('')
+  })
+
+  it('prioriza o texto sobre o wildcard quando há texto E filtro', async () => {
+    searchArticles.mockResolvedValue({ articles: [], found: 0, page: 1 })
+    await queryArticles({
+      page: 1,
+      query: 'governo',
+      entities: ['Geraldo Alckmin'],
+    })
+    expect(searchArticles.mock.calls[0][0].query).toBe('governo')
+  })
 })
 
 describe('getSearchSuggestions', () => {

--- a/src/app/(public)/busca/actions.ts
+++ b/src/app/(public)/busca/actions.ts
@@ -3,6 +3,7 @@
 import { createSSRClient } from '@/lib/graphql/client'
 import { removeDiacritics } from '@/lib/utils'
 import { createGraphQLContentService } from '@/services/content/graphql'
+import type { EntityFacet } from '@/services/content/types'
 import type {
   CombinedSearchResults,
   InlineAutocompleteSuggestion,
@@ -186,6 +187,9 @@ export async function queryArticles(
     agencies,
     themes,
     semantic = true,
+    sort,
+    sentiment,
+    entities,
   } = args
 
   const normalizedQuery = query ? query.trim().replace(/\s+/g, ' ') : null
@@ -203,9 +207,12 @@ export async function queryArticles(
     semantic,
     alpha: 0.8,
     dedup: true,
+    sort: sort ?? null,
     filter: {
       agencies: agencies && agencies.length > 0 ? agencies : null,
       themes: themes && themes.length > 0 ? themes : null,
+      sentiment: sentiment && sentiment.length > 0 ? sentiment : null,
+      entities: entities && entities.length > 0 ? entities : null,
       startDate: startIso,
       endDate: endIso,
     },
@@ -218,5 +225,27 @@ export async function queryArticles(
     articles: result.articles,
     page: page + 1,
     found: result.found,
+  }
+}
+
+/**
+ * Busca sugestões de entidades (facets) para o typeahead do filtro de busca e
+ * para as páginas `/entidades/[slug]`. `type` (ORG/PER/LOC) restringe ao campo
+ * tipado. Degrada para `[]` enquanto a Fase 0 (reindex Typesense) não rodar.
+ */
+export async function getEntitySuggestions(
+  query: string,
+  type?: string | null,
+  limit = 10,
+): Promise<EntityFacet[]> {
+  const normalizedQuery = query.trim().replace(/\s+/g, ' ')
+  try {
+    return await content().getEntitySuggestions(
+      normalizedQuery,
+      type ?? null,
+      limit,
+    )
+  } catch {
+    return []
   }
 }

--- a/src/app/(public)/busca/actions.ts
+++ b/src/app/(public)/busca/actions.ts
@@ -200,8 +200,21 @@ export async function queryArticles(
   const startIso = startDate ? new Date(startDate).toISOString() : null
   const endIso = endDate ? new Date(endDate + 86400000).toISOString() : null
 
+  // O resolver `search` do graphql-api rejeita query vazia. Quando NÃO há
+  // texto mas HÁ ao menos um filtro (entidade/sentimento/agência/tema/data),
+  // usamos `'*'` — o wildcard filter-only aceito. Sem texto E sem filtro
+  // algum, mantemos `''` (não disparamos uma busca "tudo").
+  const hasAnyFilter =
+    (agencies?.length ?? 0) > 0 ||
+    (themes?.length ?? 0) > 0 ||
+    (sentiment?.length ?? 0) > 0 ||
+    (entities?.length ?? 0) > 0 ||
+    startIso != null ||
+    endIso != null
+  const effectiveQuery = normalizedQuery ?? (hasAnyFilter ? '*' : '')
+
   const result = await content().searchArticles({
-    query: normalizedQuery ?? '',
+    query: effectiveQuery,
     page,
     // graphql-api faz embeddings + híbrido server-side (alpha:0.8, group_by content_hash).
     semantic,

--- a/src/app/(public)/entidades/[slug]/EntityPageClient.tsx
+++ b/src/app/(public)/entidades/[slug]/EntityPageClient.tsx
@@ -1,0 +1,121 @@
+'use client'
+
+import { useInfiniteQuery } from '@tanstack/react-query'
+import { motion } from 'framer-motion'
+import { Tag as TagIcon } from 'lucide-react'
+import { useInView } from 'react-intersection-observer'
+import NewsCard from '@/components/articles/NewsCard'
+import { getEntityArticles } from './actions'
+
+type EntityPageClientProps = {
+  /** Texto canônico exato da entidade (vazio quando não resolvida). */
+  entityText: string
+  /** Slug original da URL (usado no header quando a entidade não resolve). */
+  slugLabel: string
+  /** Contagem inicial (do facet), se disponível. */
+  initialCount: number | null
+}
+
+export default function EntityPageClient({
+  entityText,
+  slugLabel,
+  initialCount,
+}: EntityPageClientProps) {
+  // Quando a entidade não resolve (Fase 0 pendente), não dispara a query —
+  // a página renderiza o estado vazio amigável.
+  const resolved = entityText.length > 0
+  const displayName = resolved ? entityText : slugLabel
+
+  const articlesQ = useInfiniteQuery({
+    queryKey: ['entity-articles', entityText],
+    queryFn: ({ pageParam }: { pageParam: number | null }) =>
+      getEntityArticles({
+        entity: entityText,
+        page: pageParam ?? 1,
+      }),
+    getNextPageParam: (lastPage) => lastPage.page ?? undefined,
+    initialPageParam: 1,
+    enabled: resolved,
+  })
+
+  const { ref } = useInView({
+    onChange: (inView) => {
+      if (inView && articlesQ.hasNextPage && !articlesQ.isFetchingNextPage) {
+        articlesQ.fetchNextPage()
+      }
+    },
+  })
+
+  const articles = articlesQ.data?.pages.flatMap((page) => page.articles) ?? []
+  const found = articlesQ.data?.pages[0]?.found ?? initialCount ?? 0
+
+  return (
+    <section className="py-16">
+      {/* Cabeçalho institucional da entidade */}
+      <div className="container mx-auto px-4 text-center mb-12">
+        <div className="mx-auto mb-3 inline-flex items-center gap-2 rounded-full bg-primary/5 px-4 py-1.5 text-sm font-medium text-primary/70">
+          <TagIcon className="h-4 w-4" aria-hidden />
+          Entidade
+        </div>
+
+        <h1 className="text-3xl font-bold text-primary">{displayName}</h1>
+
+        {/* Linha divisória SVG */}
+        <div className="mx-auto mt-3 w-40">
+          <img src="/underscore.svg" alt="" />
+        </div>
+
+        {resolved && found > 0 && (
+          <p className="mt-4 text-base text-primary/80">
+            {new Intl.NumberFormat('pt-BR').format(found)} notícia
+            {found === 1 ? '' : 's'} mencionam esta entidade.
+          </p>
+        )}
+      </div>
+
+      {/* Conteúdo */}
+      <div className="container mx-auto px-4">
+        {articlesQ.isError ? (
+          <p className="text-center text-red-500">
+            Ocorreu um erro ao carregar as notícias.
+          </p>
+        ) : (
+          <main className="min-w-0">
+            <motion.div
+              className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-6"
+              initial={{ opacity: 0, y: 40 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ duration: 0.6, ease: 'easeOut' }}
+            >
+              {articles.map((article, index) => (
+                <NewsCard
+                  key={article.unique_id}
+                  internalUrl={`/artigos/${article.unique_id}`}
+                  theme={article.theme_1_level_3_label || ''}
+                  date={article.published_at}
+                  ref={index === articles.length - 1 ? ref : undefined}
+                  summary={article.summary || ''}
+                  title={article.title || ''}
+                  imageUrl={article.image || ''}
+                  trackingOrigin="search"
+                />
+              ))}
+            </motion.div>
+
+            {!articlesQ.isLoading && articles.length === 0 && (
+              <div className="mx-auto mt-8 max-w-xl text-center">
+                <p className="text-primary/70">
+                  Ainda não há notícias indexadas para esta entidade.
+                </p>
+                <p className="mt-2 text-sm text-primary/50">
+                  As menções a entidades estão sendo processadas e ficarão
+                  disponíveis em breve.
+                </p>
+              </div>
+            )}
+          </main>
+        )}
+      </div>
+    </section>
+  )
+}

--- a/src/app/(public)/entidades/[slug]/actions.ts
+++ b/src/app/(public)/entidades/[slug]/actions.ts
@@ -69,7 +69,10 @@ export async function getEntityArticles(
   const { entity, page } = args
 
   const result = await content().searchArticles({
-    query: '',
+    // Busca filter-only por entidade: o resolver `search` do graphql-api
+    // rejeita query vazia ("Query must not be empty"). `'*'` é o wildcard
+    // filter-only aceito (convenção já usada em outros call-sites).
+    query: '*',
     page,
     semantic: false,
     dedup: true,

--- a/src/app/(public)/entidades/[slug]/actions.ts
+++ b/src/app/(public)/entidades/[slug]/actions.ts
@@ -1,0 +1,87 @@
+'use server'
+
+import { deslugifyEntity, matchEntityBySlug } from '@/lib/entity-slug'
+import { createSSRClient } from '@/lib/graphql/client'
+import { createGraphQLContentService } from '@/services/content/graphql'
+import type { ArticleRow } from '@/types/article'
+
+/** Cliente GraphQL público (sem token) para as server actions de entidade. */
+function content() {
+  return createGraphQLContentService(createSSRClient(async () => null))
+}
+
+export type ResolvedEntity = {
+  /** Texto canônico exato da entidade (usado em `filter.entities`). */
+  text: string
+  /** Contagem de artigos associada ao facet (best-effort). */
+  count: number | null
+}
+
+/**
+ * Resolve o texto canônico de uma entidade a partir do slug da URL.
+ *
+ * Estratégia: consulta `entitySuggestions(query=<deslug>)` e escolhe o facet
+ * cujo slug bate com o slug-alvo. Retorna `null` quando nada casa — o que é o
+ * caso enquanto a Fase 0 (reindex Typesense) não tiver rodado (o resolver
+ * retorna vazio). A página trata `null` com um estado vazio amigável.
+ */
+export async function resolveEntity(
+  slug: string,
+): Promise<ResolvedEntity | null> {
+  const approxQuery = deslugifyEntity(slug)
+  const suggestions = await content().getEntitySuggestions(
+    approxQuery,
+    null,
+    20,
+  )
+  if (suggestions.length === 0) return null
+
+  const match = matchEntityBySlug(
+    slug,
+    suggestions.map((s) => s.value),
+  )
+  if (!match) return null
+
+  const facet = suggestions.find((s) => s.value === match)
+  return { text: match, count: facet?.count ?? null }
+}
+
+export type GetEntityArticlesArgs = {
+  /** Texto canônico exato da entidade. */
+  entity: string
+  page: number
+}
+
+export type GetEntityArticlesResult = {
+  articles: ArticleRow[]
+  page: number
+  found: number
+}
+
+/**
+ * Lista paginada de artigos que mencionam a entidade. Reutiliza a busca
+ * (`search`) com `filter.entities=[texto]`, espelhando o comportamento da
+ * página /busca (dedup por content_hash, sem busca semântica).
+ */
+export async function getEntityArticles(
+  args: GetEntityArticlesArgs,
+): Promise<GetEntityArticlesResult> {
+  const { entity, page } = args
+
+  const result = await content().searchArticles({
+    query: '',
+    page,
+    semantic: false,
+    dedup: true,
+    sort: 'DATE',
+    filter: {
+      entities: [entity],
+    },
+  })
+
+  return {
+    articles: result.articles,
+    page: page + 1,
+    found: result.found,
+  }
+}

--- a/src/app/(public)/entidades/[slug]/page.tsx
+++ b/src/app/(public)/entidades/[slug]/page.tsx
@@ -1,0 +1,52 @@
+import { deslugifyEntity } from '@/lib/entity-slug'
+import { resolveEntity } from './actions'
+import EntityPageClient from './EntityPageClient'
+
+type EntityPageProps = {
+  params: Promise<{
+    slug: string
+  }>
+}
+
+export async function generateMetadata({ params }: EntityPageProps) {
+  const { slug } = await params
+  const resolved = await resolveEntity(slug)
+  const name = resolved?.text ?? deslugifyEntity(slug)
+
+  const siteUrl = process.env.NEXT_PUBLIC_SITE_URL ?? ''
+  const pageUrl = `${siteUrl}/entidades/${slug}`
+  const title = `${name} — Notícias do Governo Federal | DestaquesGovBr`
+  const description = `Acompanhe as notícias e publicações oficiais do Governo Federal que mencionam ${name}.`
+
+  return {
+    title,
+    description,
+    alternates: { canonical: pageUrl },
+    openGraph: {
+      title,
+      description,
+      url: pageUrl,
+      type: 'website',
+      locale: 'pt_BR',
+      siteName: 'DestaquesGovBr',
+    },
+    twitter: {
+      card: 'summary',
+      title,
+      description,
+    },
+  }
+}
+
+export default async function EntityPage({ params }: EntityPageProps) {
+  const { slug } = await params
+  const resolved = await resolveEntity(slug)
+
+  return (
+    <EntityPageClient
+      entityText={resolved?.text ?? ''}
+      slugLabel={deslugifyEntity(slug)}
+      initialCount={resolved?.count ?? null}
+    />
+  )
+}

--- a/src/components/articles/ArticleFeatures.tsx
+++ b/src/components/articles/ArticleFeatures.tsx
@@ -1,0 +1,216 @@
+/**
+ * Seções de features computadas (news_features) da tela de detalhe da notícia:
+ *   - `ArticleFichaBar`: faixa-resumo de leitura (tempo, legibilidade), selo
+ *     "Em alta" (trending) e visualizações (best-effort).
+ *   - `ArticleEntities`: entidades nomeadas agrupadas (Instituições/Pessoas/
+ *     Locais/Outros), cada chip linkando para a busca.
+ *
+ * Harmoniza com o design institucional do artigo: paleta government-*,
+ * componente Badge, ícones lucide, larguras max-w-3xl. Cada bloco se esconde
+ * quando não há dado (o pipeline de features é parcial).
+ */
+
+import {
+  Building2,
+  Clock,
+  Eye,
+  Flame,
+  Gauge,
+  type LucideIcon,
+  MapPin,
+  Tag as TagIcon,
+  User,
+} from 'lucide-react'
+import Link from 'next/link'
+import type { ReactNode } from 'react'
+import { Badge } from '@/components/ui/badge'
+import { slugifyEntity } from '@/lib/entity-slug'
+import type { ArticleEntity, ArticleFeatures } from '@/types/article'
+
+// trending_score = volume 24h / média 7d por tema (nível 1). >= 1.5 indica
+// volume claramente acima da média recente → digno do selo "Em alta".
+const TRENDING_THRESHOLD = 1.5
+const WORDS_PER_MINUTE = 200
+
+function readingMinutes(wordCount: number | null): number | null {
+  if (!wordCount || wordCount <= 0) return null
+  return Math.max(1, Math.round(wordCount / WORDS_PER_MINUTE))
+}
+
+function readabilityBand(flesch: number | null): string | null {
+  if (flesch == null) return null
+  if (flesch >= 70) return 'Leitura fácil'
+  if (flesch >= 50) return 'Leitura média'
+  return 'Leitura densa'
+}
+
+function Stat({
+  icon: Icon,
+  children,
+}: {
+  icon: LucideIcon
+  children: ReactNode
+}) {
+  return (
+    <span className="inline-flex items-center gap-1.5 text-sm text-primary/70">
+      <Icon className="w-4 h-4 text-primary/50" aria-hidden />
+      {children}
+    </span>
+  )
+}
+
+export function ArticleFichaBar({
+  features,
+}: {
+  features?: ArticleFeatures | null
+}) {
+  if (!features) return null
+
+  const minutes = readingMinutes(features.word_count)
+  const band = readabilityBand(features.readability_flesch)
+  const trending =
+    features.trending_score != null &&
+    features.trending_score >= TRENDING_THRESHOLD
+  const views =
+    features.view_count && features.view_count > 0 ? features.view_count : null
+
+  if (!minutes && !band && !trending && !views) return null
+
+  return (
+    <div className="mx-auto mb-12 flex max-w-3xl flex-wrap items-center justify-center gap-x-5 gap-y-2 rounded-lg border border-primary/10 bg-primary/[0.03] px-5 py-3">
+      {trending && (
+        <span className="inline-flex items-center gap-1.5 rounded-full bg-government-red/10 px-2.5 py-0.5 text-sm font-semibold text-government-red">
+          <Flame className="w-4 h-4" aria-hidden />
+          Em alta
+        </span>
+      )}
+      {minutes && <Stat icon={Clock}>{minutes} min de leitura</Stat>}
+      {band && <Stat icon={Gauge}>{band}</Stat>}
+      {views && (
+        <Stat icon={Eye}>
+          {new Intl.NumberFormat('pt-BR').format(views)} visualizações
+        </Stat>
+      )}
+    </div>
+  )
+}
+
+type EntityGroup = {
+  key: string
+  label: string
+  types: string[]
+  icon: LucideIcon
+  dot: string
+}
+
+const GROUPS: EntityGroup[] = [
+  {
+    key: 'org',
+    label: 'Instituições',
+    types: ['ORG'],
+    icon: Building2,
+    dot: 'bg-government-blue',
+  },
+  {
+    key: 'per',
+    label: 'Pessoas',
+    types: ['PER'],
+    icon: User,
+    dot: 'bg-government-green',
+  },
+  {
+    key: 'loc',
+    label: 'Locais',
+    types: ['LOC'],
+    icon: MapPin,
+    dot: 'bg-government-yellow',
+  },
+]
+
+const KNOWN_TYPES = new Set(GROUPS.flatMap((g) => g.types))
+
+function EntityChips({ items }: { items: ArticleEntity[] }) {
+  return (
+    <div className="flex flex-wrap gap-2">
+      {items.map((entity) => (
+        <Link
+          key={entity.text}
+          href={`/entidades/${slugifyEntity(entity.text)}`}
+          aria-label={`Ver notícias sobre ${entity.text}`}
+        >
+          <Badge className="bg-white text-primary font-medium hover:bg-primary/5 transition-colors cursor-pointer">
+            {entity.text}
+            {entity.count > 1 && (
+              <span className="ml-1.5 text-primary/40">{entity.count}</span>
+            )}
+          </Badge>
+        </Link>
+      ))}
+    </div>
+  )
+}
+
+export function ArticleEntities({
+  entities,
+}: {
+  entities?: ArticleEntity[] | null
+}) {
+  if (!entities || entities.length === 0) return null
+
+  const byCountDesc = (a: ArticleEntity, b: ArticleEntity) => b.count - a.count
+
+  const named = GROUPS.map((group) => ({
+    ...group,
+    items: entities
+      .filter((e) => group.types.includes(e.type))
+      .sort(byCountDesc),
+  })).filter((group) => group.items.length > 0)
+
+  const others = entities
+    .filter((e) => !KNOWN_TYPES.has(e.type))
+    .sort(byCountDesc)
+
+  const groups: Array<EntityGroup & { items: ArticleEntity[] }> = [
+    ...named,
+    ...(others.length > 0
+      ? [
+          {
+            key: 'outros',
+            label: 'Outros',
+            types: [],
+            icon: TagIcon,
+            dot: 'bg-primary/40',
+            items: others,
+          },
+        ]
+      : []),
+  ]
+
+  if (groups.length === 0) return null
+
+  return (
+    <section className="mt-12 mb-8 max-w-3xl mx-auto">
+      <h2 className="text-sm font-semibold text-primary/70 uppercase tracking-wide mb-4">
+        Entidades mencionadas
+      </h2>
+      <div className="space-y-4">
+        {groups.map((group) => {
+          const Icon = group.icon
+          return (
+            <div key={group.key}>
+              <div className="mb-2 flex items-center gap-1.5 text-xs font-medium uppercase tracking-wide text-primary/50">
+                <span
+                  className={`inline-block w-1.5 h-1.5 rounded-full ${group.dot}`}
+                  aria-hidden
+                />
+                <Icon className="w-3.5 h-3.5" aria-hidden />
+                {group.label}
+              </div>
+              <EntityChips items={group.items} />
+            </div>
+          )
+        })}
+      </div>
+    </section>
+  )
+}

--- a/src/components/articles/ArticleFilters.tsx
+++ b/src/components/articles/ArticleFilters.tsx
@@ -4,6 +4,7 @@ import { X } from 'lucide-react'
 import { useEffect, useRef, useState } from 'react'
 import { TagFilter } from '@/components/articles/TagFilter'
 import { AgencyMultiSelect } from '@/components/filters/AgencyMultiSelect'
+import { EntityMultiSelect } from '@/components/filters/EntityMultiSelect'
 import { ThemeMultiSelect } from '@/components/filters/ThemeMultiSelect'
 import { Portal } from '@/components/layout/Portal'
 import { Button } from '@/components/ui/button'
@@ -11,6 +12,13 @@ import { Input } from '@/components/ui/input'
 import type { AgencyOption } from '@/data/agencies-utils'
 import type { ThemeOption } from '@/data/themes-utils'
 import type { TagFacet } from '@/types/article'
+
+/** Opções de sentimento expostas no filtro (valor enviado ao filter.sentiment). */
+const SENTIMENT_OPTIONS: Array<{ value: string; label: string }> = [
+  { value: 'positive', label: 'Positivo' },
+  { value: 'neutral', label: 'Neutro' },
+  { value: 'negative', label: 'Negativo' },
+]
 
 type DateFilterProps = {
   label: string
@@ -112,17 +120,23 @@ type ArticleFiltersProps = {
   selectedAgencies?: string[]
   selectedThemes?: string[]
   selectedTags?: string[]
+  selectedSentiments?: string[]
+  selectedEntities?: string[]
   onStartDateChange: (date: Date | undefined) => void
   onEndDateChange: (date: Date | undefined) => void
   onAgenciesChange?: (agencies: string[]) => void
   onThemesChange?: (themes: string[]) => void
   onTagsChange?: (tags: string[]) => void
+  onSentimentsChange?: (sentiments: string[]) => void
+  onEntitiesChange?: (entities: string[]) => void
   getAgencyName?: (key: string) => string
   getThemeName?: (key: string) => string
   getThemeHierarchyPath?: (key: string) => string
   showAgencyFilter?: boolean
   showThemeFilter?: boolean
   showTagFilter?: boolean
+  showSentimentFilter?: boolean
+  showEntityFilter?: boolean
 }
 
 export function ArticleFilters({
@@ -134,18 +148,32 @@ export function ArticleFilters({
   selectedAgencies = [],
   selectedThemes = [],
   selectedTags = [],
+  selectedSentiments = [],
+  selectedEntities = [],
   onStartDateChange,
   onEndDateChange,
   onAgenciesChange,
   onThemesChange,
   onTagsChange,
+  onSentimentsChange,
+  onEntitiesChange,
   getAgencyName,
   getThemeName,
   getThemeHierarchyPath,
   showAgencyFilter = true,
   showThemeFilter = true,
   showTagFilter = true,
+  showSentimentFilter = false,
+  showEntityFilter = false,
 }: ArticleFiltersProps) {
+  const toggleSentiment = (value: string) => {
+    if (!onSentimentsChange) return
+    onSentimentsChange(
+      selectedSentiments.includes(value)
+        ? selectedSentiments.filter((s) => s !== value)
+        : [...selectedSentiments, value],
+    )
+  }
   return (
     <aside className="lg:w-80 flex-shrink-0 lg:border-r lg:border-border lg:pr-8 relative z-[98]">
       <div>
@@ -310,6 +338,93 @@ export function ArticleFilters({
                 onSelectedTagsChange={onTagsChange}
               />
             </div>
+          )}
+
+          {/* Sentiment Filter */}
+          {showSentimentFilter && onSentimentsChange && (
+            <div className="flex flex-col gap-2">
+              <span className="text-sm font-semibold text-primary">
+                Sentimento
+              </span>
+              <div className="flex flex-wrap gap-2">
+                {SENTIMENT_OPTIONS.map((option) => {
+                  const active = selectedSentiments.includes(option.value)
+                  return (
+                    <Button
+                      key={option.value}
+                      type="button"
+                      variant={active ? 'default' : 'outline'}
+                      size="sm"
+                      onClick={() => toggleSentiment(option.value)}
+                      className="rounded-full"
+                      aria-pressed={active}
+                    >
+                      {option.label}
+                    </Button>
+                  )
+                })}
+              </div>
+            </div>
+          )}
+
+          {/* Entity Filter (typeahead — depende da Fase 0 para retornar dados) */}
+          {showEntityFilter && onEntitiesChange && (
+            <>
+              <div className="flex flex-col gap-2">
+                <span className="text-sm font-semibold text-primary">
+                  Entidades
+                </span>
+                <EntityMultiSelect
+                  selectedEntities={selectedEntities}
+                  onSelectedEntitiesChange={onEntitiesChange}
+                />
+              </div>
+
+              {/* Selected Entities List */}
+              {selectedEntities.length > 0 && (
+                <div className="pt-4 border-t border-border">
+                  <div className="flex items-center justify-between mb-3">
+                    <span className="text-sm font-semibold text-primary">
+                      Entidades selecionadas ({selectedEntities.length})
+                    </span>
+                    <Button
+                      type="button"
+                      variant="link"
+                      onClick={() => onEntitiesChange([])}
+                      className="h-auto p-0 text-xs text-muted-foreground hover:text-primary"
+                    >
+                      Limpar todas
+                    </Button>
+                  </div>
+                  <div className="space-y-2 max-h-60 overflow-y-auto">
+                    {selectedEntities.map((value) => (
+                      <div
+                        key={value}
+                        className="flex items-center justify-between gap-2 px-3 py-2 bg-primary/5 border border-primary/10 rounded-md text-sm hover:bg-primary/10 transition-colors group"
+                      >
+                        <span className="truncate text-primary/90 flex-1 min-w-0">
+                          {value}
+                        </span>
+                        <Button
+                          type="button"
+                          variant="ghost"
+                          size="icon"
+                          onClick={() =>
+                            onEntitiesChange(
+                              selectedEntities.filter((v) => v !== value),
+                            )
+                          }
+                          className="h-6 w-6 p-0 text-primary/50 hover:text-primary opacity-0 group-hover:opacity-100 transition-opacity flex-shrink-0"
+                          aria-label={`Remover ${value}`}
+                        >
+                          <X className="h-4 w-4" />
+                        </Button>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              )}
+            </>
           )}
         </div>
       </div>

--- a/src/components/articles/ClientArticle.tsx
+++ b/src/components/articles/ClientArticle.tsx
@@ -10,6 +10,10 @@ import {
 } from 'lucide-react'
 import Link from 'next/link'
 import { useMemo, useState } from 'react'
+import {
+  ArticleEntities,
+  ArticleFichaBar,
+} from '@/components/articles/ArticleFeatures'
 import NewsCard from '@/components/articles/NewsCard'
 import { VideoPlayer } from '@/components/articles/VideoPlayer'
 import { MarkdownRenderer } from '@/components/common/MarkdownRenderer'
@@ -147,6 +151,9 @@ export default function ClientArticle({
           </div>
         </header>
 
+        {/* Faixa de leitura/trending (features computadas) */}
+        <ArticleFichaBar features={article.features} />
+
         {/* Video takes priority over cover image */}
         {article.video_url ? (
           <VideoPlayer videoUrl={article.video_url} title={article.title} />
@@ -206,6 +213,9 @@ export default function ClientArticle({
             </div>
           </section>
         )}
+
+        {/* Entidades mencionadas (features computadas) */}
+        <ArticleEntities entities={article.features?.entities} />
 
         {/* Notícias similares */}
         {similarArticles.length > 0 && (

--- a/src/components/filters/EntityMultiSelect.tsx
+++ b/src/components/filters/EntityMultiSelect.tsx
@@ -1,0 +1,118 @@
+'use client'
+
+import { useQuery } from '@tanstack/react-query'
+import { Check, Loader2 } from 'lucide-react'
+import * as React from 'react'
+import { getEntitySuggestions } from '@/app/(public)/busca/actions'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+
+type EntityMultiSelectProps = {
+  /** Textos canônicos de entidades já selecionados. */
+  selectedEntities: string[]
+  onSelectedEntitiesChange: (entities: string[]) => void
+  /** Restringe as sugestões a um tipo (ORG/PER/LOC). Ausente = campo combinado. */
+  type?: string | null
+}
+
+const DEBOUNCE_MS = 300
+const MIN_QUERY_LENGTH = 2
+
+export function EntityMultiSelect({
+  selectedEntities,
+  onSelectedEntitiesChange,
+  type = null,
+}: EntityMultiSelectProps) {
+  const [searchTerm, setSearchTerm] = React.useState('')
+  const [debouncedTerm, setDebouncedTerm] = React.useState('')
+  const debounceRef = React.useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  // Debounce do termo digitado antes de consultar as sugestões.
+  React.useEffect(() => {
+    if (debounceRef.current) clearTimeout(debounceRef.current)
+    debounceRef.current = setTimeout(() => {
+      setDebouncedTerm(searchTerm.trim())
+    }, DEBOUNCE_MS)
+    return () => {
+      if (debounceRef.current) clearTimeout(debounceRef.current)
+    }
+  }, [searchTerm])
+
+  const suggestionsQ = useQuery({
+    queryKey: ['entitySuggestions', debouncedTerm, type],
+    queryFn: () => getEntitySuggestions(debouncedTerm, type, 10),
+    enabled: debouncedTerm.length >= MIN_QUERY_LENGTH,
+    staleTime: 60_000,
+  })
+
+  const suggestions = suggestionsQ.data ?? []
+  const isLoading =
+    debouncedTerm.length >= MIN_QUERY_LENGTH &&
+    (suggestionsQ.isLoading || suggestionsQ.isFetching)
+
+  const toggleEntity = React.useCallback(
+    (value: string) => {
+      onSelectedEntitiesChange(
+        selectedEntities.includes(value)
+          ? selectedEntities.filter((v) => v !== value)
+          : [...selectedEntities, value],
+      )
+    },
+    [selectedEntities, onSelectedEntitiesChange],
+  )
+
+  return (
+    <div className="relative w-full">
+      <Input
+        type="text"
+        placeholder="Buscar entidades..."
+        value={searchTerm}
+        onChange={(e) => setSearchTerm(e.target.value)}
+        className="bg-white"
+        aria-label="Buscar entidades"
+      />
+
+      {debouncedTerm.length >= MIN_QUERY_LENGTH && (
+        <div className="mt-2 max-h-60 overflow-y-auto rounded-md border border-border bg-white">
+          {isLoading ? (
+            <div className="flex items-center justify-center gap-2 py-4 text-sm text-muted-foreground">
+              <Loader2 className="h-4 w-4 animate-spin" />
+              Buscando...
+            </div>
+          ) : suggestions.length === 0 ? (
+            <div className="py-4 text-center text-sm text-muted-foreground">
+              Nenhuma entidade encontrada
+            </div>
+          ) : (
+            <div className="p-1">
+              {suggestions.map((s) => {
+                const isSelected = selectedEntities.includes(s.value)
+                return (
+                  <Button
+                    key={s.value}
+                    type="button"
+                    variant="ghost"
+                    onClick={() => toggleEntity(s.value)}
+                    className="h-auto w-full justify-between gap-2 px-3 py-2 text-left font-normal"
+                    aria-pressed={isSelected}
+                  >
+                    <span className="flex min-w-0 items-center gap-2">
+                      <Check
+                        className={`h-4 w-4 flex-shrink-0 ${isSelected ? 'opacity-100 text-primary' : 'opacity-0'}`}
+                        aria-hidden
+                      />
+                      <span className="truncate">{s.value}</span>
+                    </span>
+                    <span className="flex-shrink-0 text-xs text-muted-foreground">
+                      {s.count}
+                    </span>
+                  </Button>
+                )
+              })}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/lib/entity-slug.ts
+++ b/src/lib/entity-slug.ts
@@ -1,0 +1,55 @@
+/**
+ * Helpers de slug para páginas de entidade (`/entidades/[slug]`).
+ *
+ * O slug é uma forma kebab-case sem acentos do texto canônico da entidade
+ * (ex.: "Ministério da Saúde" → "ministerio-da-saude"). Como o filtro de busca
+ * (`filter.entities`) precisa do TEXTO canônico exato (não do slug), a página
+ * resolve o texto via `entitySuggestions(query=<deslug aproximado>)` e escolhe
+ * o melhor match. `deslugifyEntity` produz uma string legível só para alimentar
+ * essa busca por prefixo — não é o texto canônico.
+ */
+
+import { removeDiacritics } from '@/lib/utils'
+
+/**
+ * Converte o texto canônico de uma entidade em um slug URL-safe.
+ *
+ * @example
+ * slugifyEntity('Ministério da Saúde') // 'ministerio-da-saude'
+ * slugifyEntity('Lula') // 'lula'
+ */
+export function slugifyEntity(text: string): string {
+  return removeDiacritics(text)
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9]+/g, '-') // não-alfanuméricos → hífen
+    .replace(/^-+|-+$/g, '') // remove hífens nas pontas
+}
+
+/**
+ * Converte um slug de volta para uma string de busca aproximada (legível),
+ * usada como `query` em `entitySuggestions` para reencontrar o texto canônico.
+ * NÃO produz o texto canônico exato (acentos/caixa se perdem no slug).
+ *
+ * @example
+ * deslugifyEntity('ministerio-da-saude') // 'ministerio da saude'
+ */
+export function deslugifyEntity(slug: string): string {
+  return slug.replace(/-+/g, ' ').trim()
+}
+
+/**
+ * Dado um slug e uma lista de candidatos (textos canônicos), escolhe o que
+ * melhor casa: primeiro um match exato de slug; senão, o primeiro candidato
+ * cujo slug começa com o slug-alvo; senão `null`.
+ */
+export function matchEntityBySlug(
+  slug: string,
+  candidates: string[],
+): string | null {
+  const target = slugifyEntity(deslugifyEntity(slug))
+  const exact = candidates.find((c) => slugifyEntity(c) === target)
+  if (exact) return exact
+  const prefix = candidates.find((c) => slugifyEntity(c).startsWith(target))
+  return prefix ?? null
+}

--- a/src/lib/graphql/queries/articles.ts
+++ b/src/lib/graphql/queries/articles.ts
@@ -64,7 +64,7 @@ export const ARTICLES_QUERY = gql`
   }
 `
 
-/** Busca (keyword/semântica/híbrida) com filtro, paginação e dedup. */
+/** Busca (keyword/semântica/híbrida) com filtro, paginação, dedup e ordenação. */
 export const SEARCH_QUERY = gql`
   ${ARTICLE_FIELDS}
   query Search(
@@ -74,6 +74,7 @@ export const SEARCH_QUERY = gql`
     $semantic: Boolean!
     $alpha: Float
     $dedup: Boolean!
+    $sort: ArticleSort
   ) {
     search(
       query: $query
@@ -82,6 +83,7 @@ export const SEARCH_QUERY = gql`
       semantic: $semantic
       alpha: $alpha
       dedup: $dedup
+      sort: $sort
     ) {
       articles {
         ...ArticleFields
@@ -92,12 +94,46 @@ export const SEARCH_QUERY = gql`
   }
 `
 
-/** Carrega um único artigo pelo `uniqueId`. */
+/**
+ * Sugestões de entidades (facets) para o typeahead do filtro de busca e para
+ * resolver o texto canônico de uma entidade nas páginas `/entidades/[slug]`.
+ *
+ * ⚠️ Depende de campos Typesense (`entities`/`entity_org`/…) que só existem
+ * após a Fase 0 (reindex de produção). Até lá, retorna vazio/erro graciosamente
+ * — o facade `getEntitySuggestions` engole o erro e devolve `[]`.
+ */
+export const ENTITY_SUGGESTIONS_QUERY = gql`
+  query EntitySuggestions($query: String!, $type: String, $limit: Int!) {
+    entitySuggestions(query: $query, type: $type, limit: $limit) {
+      value
+      count
+    }
+  }
+`
+
+/**
+ * Carrega um único artigo pelo `uniqueId`, incluindo as features computadas
+ * (entidades, leitura/legibilidade, popularidade/trending). O bloco `features`
+ * fica SÓ aqui — não no fragment `ArticleFields` — para não onerar
+ * listas/busca/relacionadas, que não selecionam features.
+ */
 export const ARTICLE_QUERY = gql`
   ${ARTICLE_FIELDS}
   query Article($uniqueId: String!) {
     article(uniqueId: $uniqueId) {
       ...ArticleFields
+      features {
+        entities {
+          text
+          type
+          count
+        }
+        viewCount
+        uniqueSessions
+        trendingScore
+        wordCount
+        readabilityFlesch
+      }
     }
   }
 `
@@ -162,6 +198,29 @@ export const ESTIMATE_RECORTE_COUNT_QUERY = gql`
 
 // ---------- TypeScript shapes ----------
 
+/** Valores do enum `ArticleSort` do schema, usados na ordenação de busca. */
+export type ArticleSort = 'RELEVANCE' | 'DATE' | 'TRENDING' | 'VIEWS'
+
+/** Facet de entidade (texto canônico + contagem) do `entitySuggestions`. */
+export interface EntityFacetGraphQL {
+  value: string
+  count: number
+}
+
+export interface EntitySuggestionsQueryData {
+  entitySuggestions: EntityFacetGraphQL[]
+}
+
+/** Features computadas, como vêm do graphql-api (camelCase). Só no detalhe. */
+export interface ArticleFeaturesGraphQL {
+  entities: Array<{ text: string; type: string; count: number }>
+  viewCount: number | null
+  uniqueSessions: number | null
+  trendingScore: number | null
+  wordCount: number | null
+  readabilityFlesch: number | null
+}
+
 /** Artigo camelCase como vem do graphql-api (espelha o fragment acima). */
 export interface ArticleGraphQL {
   uniqueId: string
@@ -187,6 +246,8 @@ export interface ArticleGraphQL {
   theme1Level3Label: string | null
   mostSpecificThemeCode: string | null
   mostSpecificThemeLabel: string | null
+  // Presente apenas em ARTICLE_QUERY (detalhe do artigo).
+  features?: ArticleFeaturesGraphQL | null
 }
 
 export interface ArticlesResultGraphQL {

--- a/src/lib/graphql/schema.graphql
+++ b/src/lib/graphql/schema.graphql
@@ -89,6 +89,34 @@ type Article {
   theme1Level3Label: String
   mostSpecificThemeCode: String
   mostSpecificThemeLabel: String
+  features: ArticleFeatures
+}
+
+type ArticleFeatures {
+  entities: [EntityType!]!
+  viewCount: Int
+  uniqueSessions: Int
+  trendingScore: Float
+  wordCount: Int
+  readabilityFlesch: Float
+}
+
+type EntityType {
+  text: String!
+  type: String!
+  count: Int!
+}
+
+type EntityFacet {
+  value: String!
+  count: Int!
+}
+
+enum ArticleSort {
+  RELEVANCE
+  DATE
+  TRENDING
+  VIEWS
 }
 
 input ArticleFilter {
@@ -99,6 +127,8 @@ input ArticleFilter {
   endDate: String = null
   themeLabel: String = null
   dedup: Boolean = null
+  entities: [String!] = null
+  sentiment: [String!] = null
 }
 
 type ArticlesResult {
@@ -490,6 +520,7 @@ type Query {
     page: Int! = 1
     limit: Int! = 10
     filter: ArticleFilter = null
+    sort: ArticleSort = null
   ): ArticlesResult!
 
   """
@@ -507,6 +538,7 @@ type Query {
     semantic: Boolean! = false
     alpha: Float = null
     dedup: Boolean! = false
+    sort: ArticleSort = null
   ): ArticlesResult!
 
   """
@@ -659,6 +691,15 @@ type Query {
   Artigos relacionados a `uniqueId`, baseados no theme-code (Typesense). Replica a logica do portal: usa most_specific_theme_code quando presente, senao theme_1_level_1_code; exclui o proprio artigo; ordena por publishedAt desc; deduplica por content_hash. PUBLICO. (Distinto do `similarArticles` interno, baseado em embedding postgres.)
   """
   relatedArticles(uniqueId: String!, limit: Int! = 4): [Article!]!
+
+  """
+  Sugestoes de entidades (facet) para o filtro de busca e as paginas de entidade. `type` (ORG/PER/LOC) restringe ao campo tipado; ausente usa o campo combinado. `query` filtra por prefixo. PUBLICO.
+  """
+  entitySuggestions(
+    query: String! = ""
+    type: String = null
+    limit: Int! = 10
+  ): [EntityFacet!]!
 
   """
   Contagem de artigos por code de tema (nivel `level`) nos ultimos `days` dias. `label` e None (o portal mapeia pela config). PUBLICO.

--- a/src/services/content/__tests__/graphql.test.ts
+++ b/src/services/content/__tests__/graphql.test.ts
@@ -138,6 +138,7 @@ describe('createGraphQLContentService', () => {
         alpha: 0.5,
         dedup: true,
         filter: { themes: ['01'] },
+        sort: null,
       })
       expect(res.page).toBe(3)
       expect(res.found).toBe(7)
@@ -157,6 +158,7 @@ describe('createGraphQLContentService', () => {
         alpha: null,
         dedup: false,
         filter: null,
+        sort: null,
       })
     })
   })

--- a/src/services/content/graphql.ts
+++ b/src/services/content/graphql.ts
@@ -21,6 +21,8 @@ import {
   type ArticleGraphQL,
   type ArticleQueryData,
   type ArticlesQueryData,
+  ENTITY_SUGGESTIONS_QUERY,
+  type EntitySuggestionsQueryData,
   ESTIMATE_RECORTE_COUNT_QUERY,
   type EstimateRecorteCountQueryData,
   RELATED_ARTICLES_QUERY,
@@ -103,6 +105,21 @@ export function mapGraphqlArticleToRow(article: ArticleGraphQL): ArticleRow {
     tags: article.tags ?? null,
     // Alias de compatibilidade (espelha o label de nível 1).
     theme_1_level_1: article.theme1Level1Label ?? null,
+    // Features só vêm no detalhe (ARTICLE_QUERY); ausentes nas demais ops → null.
+    features: article.features
+      ? {
+          entities: (article.features.entities ?? []).map((e) => ({
+            text: e.text,
+            type: e.type,
+            count: e.count,
+          })),
+          view_count: article.features.viewCount ?? null,
+          unique_sessions: article.features.uniqueSessions ?? null,
+          trending_score: article.features.trendingScore ?? null,
+          word_count: article.features.wordCount ?? null,
+          readability_flesch: article.features.readabilityFlesch ?? null,
+        }
+      : null,
   }
 }
 
@@ -178,6 +195,7 @@ export function createGraphQLContentService(
         alpha: args.alpha ?? null,
         dedup: args.dedup ?? false,
         filter: args.filter ?? null,
+        sort: args.sort ?? null,
       }
       const result = await client
         .query<SearchQueryData>(SEARCH_QUERY, vars)
@@ -244,6 +262,26 @@ export function createGraphQLContentService(
         code: t.code,
         label: t.label ?? null,
         count: t.count,
+      }))
+    },
+
+    async getEntitySuggestions(query: string, type = null, limit = 10) {
+      // Degrada para [] enquanto a Fase 0 (reindex Typesense) não rodar: os
+      // campos `entities`/`entity_org`/… ainda não existem, então o resolver
+      // retorna erro. Não propagamos — o typeahead/página fica vazio, não quebra.
+      const result = await client
+        .query<EntitySuggestionsQueryData>(ENTITY_SUGGESTIONS_QUERY, {
+          query,
+          type,
+          limit,
+        })
+        .toPromise()
+      if (result.error) {
+        return []
+      }
+      return (result.data?.entitySuggestions ?? []).map((e) => ({
+        value: e.value,
+        count: e.count,
       }))
     },
 

--- a/src/services/content/types.ts
+++ b/src/services/content/types.ts
@@ -9,6 +9,9 @@
 
 import type { ArticleRow } from '@/types/article'
 
+/** Valores do enum `ArticleSort` do schema, usados na ordenação de busca. */
+export type ArticleSort = 'RELEVANCE' | 'DATE' | 'TRENDING' | 'VIEWS'
+
 /** Filtro de artigos/busca (espelha `ArticleFilter` do schema). */
 export interface ArticleFilterInput {
   agencies?: string[] | null
@@ -18,6 +21,10 @@ export interface ArticleFilterInput {
   endDate?: string | null
   themeLabel?: string | null
   dedup?: boolean | null
+  /** Textos canônicos de entidades (NER). Depende da Fase 0 (reindex). */
+  entities?: string[] | null
+  /** Sentimentos: `positive` / `neutral` / `negative`. */
+  sentiment?: string[] | null
 }
 
 export interface ListArticlesArgs {
@@ -34,6 +41,8 @@ export interface SearchArticlesArgs {
   semantic?: boolean
   alpha?: number | null
   dedup?: boolean
+  /** Ordenação dos resultados. Ausente → RELEVANCE (default do schema). */
+  sort?: ArticleSort | null
 }
 
 export interface ArticlesPage {
@@ -55,6 +64,12 @@ export interface SearchSuggestion {
 export interface ThemeCount {
   code: string
   label: string | null
+  count: number
+}
+
+/** Facet de entidade: texto canônico + contagem de artigos. */
+export interface EntityFacet {
+  value: string
   count: number
 }
 
@@ -83,6 +98,17 @@ export interface ContentService {
 
   /** Contagens de artigos por tema nos últimos N dias. */
   getThemeArticleCounts(days?: number, level?: number): Promise<ThemeCount[]>
+
+  /**
+   * Sugestões de entidades (facets) por prefixo, para o typeahead do filtro e
+   * para resolver o texto canônico nas páginas de entidade. `type` (ORG/PER/LOC)
+   * restringe ao campo tipado. Degrada para `[]` enquanto a Fase 0 não rodar.
+   */
+  getEntitySuggestions(
+    query: string,
+    type?: string | null,
+    limit?: number,
+  ): Promise<EntityFacet[]>
 
   /** Artigos que compõem uma release de clipping. */
   getReleaseArticles(id: string): Promise<ArticleRow[]>

--- a/src/types/article.ts
+++ b/src/types/article.ts
@@ -1,3 +1,20 @@
+/** Entidade nomeada extraída do conteúdo (NER). type: ORG/PER/LOC/MISC/EVENT/… */
+export type ArticleEntity = {
+  text: string
+  type: string
+  count: number
+}
+
+/** Features computadas (news_features), expostas no detalhe do artigo. */
+export type ArticleFeatures = {
+  entities: ArticleEntity[]
+  view_count: number | null
+  unique_sessions: number | null
+  trending_score: number | null
+  word_count: number | null
+  readability_flesch: number | null
+}
+
 export type ArticleRow = {
   unique_id: string
   agency: string | null
@@ -26,6 +43,8 @@ export type ArticleRow = {
   tags: string[] | null
   // Manter theme_1_level_1 como alias para compatibilidade
   theme_1_level_1?: string | null
+  // Features computadas — presentes apenas no detalhe do artigo (ARTICLE_QUERY).
+  features?: ArticleFeatures | null
 }
 
 export type TagFacet = {

--- a/src/types/search.ts
+++ b/src/types/search.ts
@@ -1,3 +1,4 @@
+import type { ArticleSort } from '@/services/content/types'
 import type { ArticleRow } from './article'
 
 export type QueryArticlesArgs = {
@@ -8,6 +9,12 @@ export type QueryArticlesArgs = {
   agencies?: string[]
   themes?: string[]
   semantic?: boolean
+  /** Ordenação: RELEVANCE (default) / DATE / TRENDING / VIEWS. */
+  sort?: ArticleSort
+  /** Sentimentos: `positive` / `neutral` / `negative`. */
+  sentiment?: string[]
+  /** Textos canônicos de entidades (depende da Fase 0). */
+  entities?: string[]
 }
 
 export type QueryArticlesResult = {


### PR DESCRIPTION
## O que muda

### Fase 3 — Tela da notícia enriquecida
- Adiciona o campo `features` ao `Article` (proveniente do graphql-api): entidades mencionadas, tempo de leitura e sinais de trending.
- Novo componente `ArticleFeatures` (composto por `ArticleFichaBar` + `ArticleEntities`), integrado ao `ClientArticle`.
- Atualiza os tipos (`Article` / `ArticleFeatures`) e a operação de artigo para trazer `features`.

### Fase 4 — Busca e navegação cruzada
- Filtros por **sentimento** e por **entidades** + **ordenação** (`sort`) na `/busca` (`ArticleFilters` + `QueryPageClient` + `actions`).
- `EntityMultiSelect` com typeahead alimentado por `entitySuggestions`.
- Páginas `/entidades/[slug]` (`page` + `actions` + `EntityPageClient`), com helper de slug em `src/lib/entity-slug.ts`.
- Estende `ArticleFilter` (`entities` / `sentiment`) e adiciona `sort` na operação `Search`.
- Ajusta as expectativas do teste de `services/content/graphql` para a nova variável `sort`.

## Dependências de deploy (IMPORTANTE)

- **Requer o graphql-api PR #17 (`destaquesgovbr/graphql-api`) DEPLOYADO antes do merge em staging.** As operações usam campos novos do schema: `Article.features`, `ArticleFilter.entities`/`sentiment`, `sort` (na `Search`) e `entitySuggestions`. Sem esse deploy, as queries quebram por drift de schema.
- O **filtro/typeahead de entidade** e o `sort: VIEWS` dependem **adicionalmente** do data-platform PR #174 + **reindex do Typesense de produção**.

## Observação

- A opção **"Mais vistas"** (`sort: VIEWS`) só funciona após o reindex; `view_count` tem **baixa cobertura** por ora.

## Gates locais
- `pnpm graphql:codegen` (drift gate): OK, sem drift.
- `pnpm exec biome check` nos arquivos tocados: limpo (apenas 1 warning pré-existente de `isNaN` em código não alterado de `ArticleFilters.tsx`).
- `npx tsc --noEmit`: sem erros nos arquivos tocados (erros remanescentes são pré-existentes em `__tests__`/`config/__tests__`, não relacionados).
- `pnpm test` (vitest): 484 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)