### PR TITLE
Entidades canônicas, grupos Eventos/Políticas e lente semântica (data-platform#178)

### DIFF
--- a/src/app/(public)/busca/actions.ts
+++ b/src/app/(public)/busca/actions.ts
@@ -190,6 +190,7 @@ export async function queryArticles(
     sort,
     sentiment,
     entities,
+    entityCanonical,
   } = args
 
   const normalizedQuery = query ? query.trim().replace(/\s+/g, ' ') : null
@@ -209,6 +210,7 @@ export async function queryArticles(
     (themes?.length ?? 0) > 0 ||
     (sentiment?.length ?? 0) > 0 ||
     (entities?.length ?? 0) > 0 ||
+    (entityCanonical?.length ?? 0) > 0 ||
     startIso != null ||
     endIso != null
   const effectiveQuery = normalizedQuery ?? (hasAnyFilter ? '*' : '')
@@ -226,6 +228,8 @@ export async function queryArticles(
       themes: themes && themes.length > 0 ? themes : null,
       sentiment: sentiment && sentiment.length > 0 ? sentiment : null,
       entities: entities && entities.length > 0 ? entities : null,
+      entityCanonical:
+        entityCanonical && entityCanonical.length > 0 ? entityCanonical : null,
       startDate: startIso,
       endDate: endIso,
     },

--- a/src/app/(public)/entidades/[slug]/EntityPageClient.tsx
+++ b/src/app/(public)/entidades/[slug]/EntityPageClient.tsx
@@ -2,35 +2,47 @@
 
 import { useInfiniteQuery } from '@tanstack/react-query'
 import { motion } from 'framer-motion'
-import { Tag as TagIcon } from 'lucide-react'
+import { ExternalLink, Tag as TagIcon } from 'lucide-react'
 import { useInView } from 'react-intersection-observer'
 import NewsCard from '@/components/articles/NewsCard'
+import { Badge } from '@/components/ui/badge'
+import { entityTypeStyle } from '@/lib/entity-types'
+import type { EntityNode } from '@/services/content/types'
 import { getEntityArticles } from './actions'
 
 type EntityPageClientProps = {
-  /** Texto canônico exato da entidade (vazio quando não resolvida). */
+  /** Id canônico (`Q…`/`dgb_…`) quando a página é canônica; senão `null`. */
+  canonicalId: string | null
+  /** Texto canônico exato da entidade (caminho legado; vazio quando canônico). */
   entityText: string
-  /** Slug original da URL (usado no header quando a entidade não resolve). */
+  /** Rótulo do cabeçalho (nome canônico, ou o deslug do texto legado). */
   slugLabel: string
-  /** Contagem inicial (do facet), se disponível. */
+  /** Nó do registry (só no caminho canônico, pode ser `null` se não resolveu). */
+  entityNode: EntityNode | null
+  /** Contagem inicial (do facet, só no caminho legado), se disponível. */
   initialCount: number | null
 }
 
 export default function EntityPageClient({
+  canonicalId,
   entityText,
   slugLabel,
+  entityNode,
   initialCount,
 }: EntityPageClientProps) {
-  // Quando a entidade não resolve (Fase 0 pendente), não dispara a query —
-  // a página renderiza o estado vazio amigável.
-  const resolved = entityText.length > 0
-  const displayName = resolved ? entityText : slugLabel
+  // Dispara a query quando temos um id canônico OU um texto legado resolvido.
+  // Caso contrário (texto não resolvido, Fase 0 pendente), mostra o estado vazio.
+  const resolved = canonicalId != null || entityText.length > 0
+  const displayName = entityNode?.canonicalName ?? slugLabel
+  const typeStyle = entityNode?.type ? entityTypeStyle(entityNode.type) : null
+  const TypeIcon = typeStyle?.icon ?? TagIcon
 
   const articlesQ = useInfiniteQuery({
-    queryKey: ['entity-articles', entityText],
+    queryKey: ['entity-articles', canonicalId ?? entityText],
     queryFn: ({ pageParam }: { pageParam: number | null }) =>
       getEntityArticles({
         entity: entityText,
+        canonicalId,
         page: pageParam ?? 1,
       }),
     getNextPageParam: (lastPage) => lastPage.page ?? undefined,
@@ -54,8 +66,8 @@ export default function EntityPageClient({
       {/* Cabeçalho institucional da entidade */}
       <div className="container mx-auto px-4 text-center mb-12">
         <div className="mx-auto mb-3 inline-flex items-center gap-2 rounded-full bg-primary/5 px-4 py-1.5 text-sm font-medium text-primary/70">
-          <TagIcon className="h-4 w-4" aria-hidden />
-          Entidade
+          <TypeIcon className="h-4 w-4" aria-hidden />
+          {typeStyle?.label ?? 'Entidade'}
         </div>
 
         <h1 className="text-3xl font-bold text-primary">{displayName}</h1>
@@ -65,11 +77,47 @@ export default function EntityPageClient({
           <img src="/underscore.svg" alt="" />
         </div>
 
-        {resolved && found > 0 && (
+        {/* Descrição canônica (Wikidata/registry), quando disponível */}
+        {entityNode?.description && (
+          <p className="mx-auto mt-4 max-w-2xl text-base text-primary/70">
+            {entityNode.description}
+          </p>
+        )}
+
+        {found > 0 && (
           <p className="mt-4 text-base text-primary/80">
             {new Intl.NumberFormat('pt-BR').format(found)} notícia
             {found === 1 ? '' : 's'} mencionam esta entidade.
           </p>
+        )}
+
+        {/* Link para o verbete Wikidata da entidade canônica */}
+        {entityNode?.wikidataUrl && (
+          <div className="mt-4 flex justify-center">
+            <a
+              href={entityNode.wikidataUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-1.5 text-sm text-primary/70 hover:text-primary hover:underline"
+            >
+              <ExternalLink className="h-3.5 w-3.5" aria-hidden />
+              {entityNode.wikidataId ?? 'Wikidata'}
+            </a>
+          </div>
+        )}
+
+        {/* Aliases conhecidos da entidade canônica */}
+        {entityNode?.aliases && entityNode.aliases.length > 0 && (
+          <div className="mt-4 flex flex-wrap justify-center gap-2">
+            {entityNode.aliases.map((alias) => (
+              <Badge
+                key={alias}
+                className="bg-white text-primary/80 font-normal"
+              >
+                {alias}
+              </Badge>
+            ))}
+          </div>
         )}
       </div>
 

--- a/src/app/(public)/entidades/[slug]/actions.ts
+++ b/src/app/(public)/entidades/[slug]/actions.ts
@@ -1,8 +1,13 @@
 'use server'
 
-import { deslugifyEntity, matchEntityBySlug } from '@/lib/entity-slug'
+import {
+  deslugifyEntity,
+  isCanonicalEntityId,
+  matchEntityBySlug,
+} from '@/lib/entity-slug'
 import { createSSRClient } from '@/lib/graphql/client'
 import { createGraphQLContentService } from '@/services/content/graphql'
+import type { EntityNode } from '@/services/content/types'
 import type { ArticleRow } from '@/types/article'
 
 /** Cliente GraphQL público (sem token) para as server actions de entidade. */
@@ -15,6 +20,18 @@ export type ResolvedEntity = {
   text: string
   /** Contagem de artigos associada ao facet (best-effort). */
   count: number | null
+}
+
+/**
+ * Cabeçalho de uma entidade canônica, resolvido por `entity(id)`. `null` quando
+ * o id não existe (ou o `entity(id)` ainda não está disponível) — a página
+ * então cai num cabeçalho mínimo a partir do próprio id.
+ */
+export async function resolveCanonicalEntity(
+  id: string,
+): Promise<EntityNode | null> {
+  if (!isCanonicalEntityId(id)) return null
+  return content().getEntity(id)
 }
 
 /**
@@ -47,8 +64,13 @@ export async function resolveEntity(
 }
 
 export type GetEntityArticlesArgs = {
-  /** Texto canônico exato da entidade. */
+  /**
+   * Texto canônico exato da entidade (caminho legado fuzzy-text). Ignorado
+   * quando `canonicalId` está presente.
+   */
   entity: string
+  /** Id canônico (`Q…`/`dgb_…`); quando presente, filtra por `entityCanonical`. */
+  canonicalId?: string | null
   page: number
 }
 
@@ -60,13 +82,16 @@ export type GetEntityArticlesResult = {
 
 /**
  * Lista paginada de artigos que mencionam a entidade. Reutiliza a busca
- * (`search`) com `filter.entities=[texto]`, espelhando o comportamento da
- * página /busca (dedup por content_hash, sem busca semântica).
+ * (`search`) filter-only (dedup por content_hash, sem busca semântica).
+ *
+ * - **Canônico** (`canonicalId`): filtra por `filter.entityCanonical=[id]` —
+ *   dedup'd por `entity_id`, robusto a variantes de texto.
+ * - **Legado** (texto): filtra por `filter.entities=[texto]` (migração graciosa).
  */
 export async function getEntityArticles(
   args: GetEntityArticlesArgs,
 ): Promise<GetEntityArticlesResult> {
-  const { entity, page } = args
+  const { entity, canonicalId, page } = args
 
   const result = await content().searchArticles({
     // Busca filter-only por entidade: o resolver `search` do graphql-api
@@ -77,9 +102,9 @@ export async function getEntityArticles(
     semantic: false,
     dedup: true,
     sort: 'DATE',
-    filter: {
-      entities: [entity],
-    },
+    filter: canonicalId
+      ? { entityCanonical: [canonicalId] }
+      : { entities: [entity] },
   })
 
   return {

--- a/src/app/(public)/entidades/[slug]/page.tsx
+++ b/src/app/(public)/entidades/[slug]/page.tsx
@@ -1,5 +1,5 @@
-import { deslugifyEntity } from '@/lib/entity-slug'
-import { resolveEntity } from './actions'
+import { deslugifyEntity, isCanonicalEntityId } from '@/lib/entity-slug'
+import { resolveCanonicalEntity, resolveEntity } from './actions'
 import EntityPageClient from './EntityPageClient'
 
 type EntityPageProps = {
@@ -10,8 +10,17 @@ type EntityPageProps = {
 
 export async function generateMetadata({ params }: EntityPageProps) {
   const { slug } = await params
-  const resolved = await resolveEntity(slug)
-  const name = resolved?.text ?? deslugifyEntity(slug)
+
+  // Caminho canônico (id `Q…`/`dgb_…`): resolve o nome via entity(id).
+  // Caminho legado (texto): resolve o texto canônico via fuzzy-match.
+  let name: string
+  if (isCanonicalEntityId(slug)) {
+    const node = await resolveCanonicalEntity(slug)
+    name = node?.canonicalName ?? slug
+  } else {
+    const resolved = await resolveEntity(slug)
+    name = resolved?.text ?? deslugifyEntity(slug)
+  }
 
   const siteUrl = process.env.NEXT_PUBLIC_SITE_URL ?? ''
   const pageUrl = `${siteUrl}/entidades/${slug}`
@@ -40,12 +49,29 @@ export async function generateMetadata({ params }: EntityPageProps) {
 
 export default async function EntityPage({ params }: EntityPageProps) {
   const { slug } = await params
-  const resolved = await resolveEntity(slug)
 
+  // Slug canônico → resolve o nó do registry e filtra por id canônico.
+  if (isCanonicalEntityId(slug)) {
+    const node = await resolveCanonicalEntity(slug)
+    return (
+      <EntityPageClient
+        canonicalId={slug}
+        entityText=""
+        slugLabel={node?.canonicalName ?? slug}
+        entityNode={node}
+        initialCount={null}
+      />
+    )
+  }
+
+  // Slug legado (texto) → comportamento fuzzy-text preservado.
+  const resolved = await resolveEntity(slug)
   return (
     <EntityPageClient
+      canonicalId={null}
       entityText={resolved?.text ?? ''}
       slugLabel={deslugifyEntity(slug)}
+      entityNode={null}
       initialCount={resolved?.count ?? null}
     />
   )

--- a/src/components/articles/ArticleFeatures.tsx
+++ b/src/components/articles/ArticleFeatures.tsx
@@ -10,21 +10,18 @@
  * quando não há dado (o pipeline de features é parcial).
  */
 
-import {
-  Building2,
-  Clock,
-  Eye,
-  Flame,
-  Gauge,
-  type LucideIcon,
-  MapPin,
-  Tag as TagIcon,
-  User,
-} from 'lucide-react'
+import { Clock, Eye, Flame, Gauge, type LucideIcon } from 'lucide-react'
 import Link from 'next/link'
 import type { ReactNode } from 'react'
 import { Badge } from '@/components/ui/badge'
 import { slugifyEntity } from '@/lib/entity-slug'
+import {
+  ENTITY_TYPE_ORDER,
+  ENTITY_TYPE_STYLES,
+  type EntityTypeKey,
+  entityTypeStyle,
+  KNOWN_ENTITY_TYPES,
+} from '@/lib/entity-types'
 import type { ArticleEntity, ArticleFeatures } from '@/types/article'
 
 // trending_score = volume 24h / média 7d por tema (nível 1). >= 1.5 indica
@@ -95,47 +92,24 @@ export function ArticleFichaBar({
   )
 }
 
-type EntityGroup = {
-  key: string
-  label: string
-  types: string[]
-  icon: LucideIcon
-  dot: string
+/**
+ * Destino de navegação de um chip de entidade: a página canônica
+ * `/entidades/{canonicalId}` quando a menção já tem id canônico; senão o
+ * fallback de texto `/entidades/{slug}` (migração graciosa).
+ */
+function entityHref(entity: ArticleEntity): string {
+  return entity.canonical_id
+    ? `/entidades/${entity.canonical_id}`
+    : `/entidades/${slugifyEntity(entity.text)}`
 }
-
-const GROUPS: EntityGroup[] = [
-  {
-    key: 'org',
-    label: 'Instituições',
-    types: ['ORG'],
-    icon: Building2,
-    dot: 'bg-government-blue',
-  },
-  {
-    key: 'per',
-    label: 'Pessoas',
-    types: ['PER'],
-    icon: User,
-    dot: 'bg-government-green',
-  },
-  {
-    key: 'loc',
-    label: 'Locais',
-    types: ['LOC'],
-    icon: MapPin,
-    dot: 'bg-government-yellow',
-  },
-]
-
-const KNOWN_TYPES = new Set(GROUPS.flatMap((g) => g.types))
 
 function EntityChips({ items }: { items: ArticleEntity[] }) {
   return (
     <div className="flex flex-wrap gap-2">
       {items.map((entity) => (
         <Link
-          key={entity.text}
-          href={`/entidades/${slugifyEntity(entity.text)}`}
+          key={`${entity.type}:${entity.text}`}
+          href={entityHref(entity)}
           aria-label={`Ver notícias sobre ${entity.text}`}
         >
           <Badge className="bg-white text-primary font-medium hover:bg-primary/5 transition-colors cursor-pointer">
@@ -150,6 +124,52 @@ function EntityChips({ items }: { items: ArticleEntity[] }) {
   )
 }
 
+type ResolvedGroup = {
+  key: string
+  label: string
+  icon: LucideIcon
+  dot: string
+  items: ArticleEntity[]
+}
+
+/**
+ * Agrupa as menções por tipo na ordem canônica (ORG/PER/LOC/EVENT/POLICY),
+ * drenando o resíduo para o balde "Outros". Grupos vazios são omitidos.
+ */
+export function groupEntities(entities: ArticleEntity[]): ResolvedGroup[] {
+  const byCountDesc = (a: ArticleEntity, b: ArticleEntity) => b.count - a.count
+
+  const named: ResolvedGroup[] = ENTITY_TYPE_ORDER.map(
+    (type: EntityTypeKey) => {
+      const style = ENTITY_TYPE_STYLES[type]
+      return {
+        key: type.toLowerCase(),
+        label: style.label,
+        icon: style.icon,
+        dot: style.dot,
+        items: entities.filter((e) => e.type === type).sort(byCountDesc),
+      }
+    },
+  ).filter((group) => group.items.length > 0)
+
+  const others = entities
+    .filter((e) => !KNOWN_ENTITY_TYPES.has(e.type))
+    .sort(byCountDesc)
+
+  if (others.length > 0) {
+    const style = entityTypeStyle('OTHER')
+    named.push({
+      key: 'outros',
+      label: style.label,
+      icon: style.icon,
+      dot: style.dot,
+      items: others,
+    })
+  }
+
+  return named
+}
+
 export function ArticleEntities({
   entities,
 }: {
@@ -157,35 +177,7 @@ export function ArticleEntities({
 }) {
   if (!entities || entities.length === 0) return null
 
-  const byCountDesc = (a: ArticleEntity, b: ArticleEntity) => b.count - a.count
-
-  const named = GROUPS.map((group) => ({
-    ...group,
-    items: entities
-      .filter((e) => group.types.includes(e.type))
-      .sort(byCountDesc),
-  })).filter((group) => group.items.length > 0)
-
-  const others = entities
-    .filter((e) => !KNOWN_TYPES.has(e.type))
-    .sort(byCountDesc)
-
-  const groups: Array<EntityGroup & { items: ArticleEntity[] }> = [
-    ...named,
-    ...(others.length > 0
-      ? [
-          {
-            key: 'outros',
-            label: 'Outros',
-            types: [],
-            icon: TagIcon,
-            dot: 'bg-primary/40',
-            items: others,
-          },
-        ]
-      : []),
-  ]
-
+  const groups = groupEntities(entities)
   if (groups.length === 0) return null
 
   return (

--- a/src/components/articles/ClientArticle.tsx
+++ b/src/components/articles/ClientArticle.tsx
@@ -5,22 +5,27 @@ import {
   Calendar,
   Check,
   ExternalLink,
+  Highlighter,
   Share2,
   Tag,
 } from 'lucide-react'
 import Link from 'next/link'
-import { useMemo, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import {
   ArticleEntities,
   ArticleFichaBar,
 } from '@/components/articles/ArticleFeatures'
 import NewsCard from '@/components/articles/NewsCard'
+import { SemanticLens } from '@/components/articles/SemanticLens'
 import { VideoPlayer } from '@/components/articles/VideoPlayer'
 import { MarkdownRenderer } from '@/components/common/MarkdownRenderer'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { formatDateTime } from '@/lib/utils'
 import type { ArticleRow } from '@/types/article'
+
+/** Chave de persistência da preferência de exibir a lente semântica. */
+const LENS_STORAGE_KEY = 'dgb:semantic-lens'
 
 export default function ClientArticle({
   article,
@@ -35,6 +40,24 @@ export default function ClientArticle({
 }) {
   const [copied, setCopied] = useState(false)
   const [coverImageBroken, setCoverImageBroken] = useState(false)
+
+  // Lente semântica: default OFF, escolha persistida em localStorage.
+  const [lensOn, setLensOn] = useState(false)
+  useEffect(() => {
+    setLensOn(localStorage.getItem(LENS_STORAGE_KEY) === '1')
+  }, [])
+
+  function toggleLens() {
+    setLensOn((prev) => {
+      const next = !prev
+      localStorage.setItem(LENS_STORAGE_KEY, next ? '1' : '0')
+      return next
+    })
+  }
+
+  // A lente só faz sentido quando há anotações de span derivadas para o corpo.
+  const annotations = article.features?.content_annotations ?? []
+  const lensAvailable = annotations.length > 0 && !!article.content
 
   // Check if the cover image appears in the article body
   const isImageInBody = useMemo(() => {
@@ -111,6 +134,24 @@ export default function ClientArticle({
                 </>
               )}
             </Button>
+
+            {/* Lente semântica: liga/desliga o destaque de entidades no corpo */}
+            {lensAvailable && (
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={toggleLens}
+                aria-pressed={lensOn}
+                className={
+                  lensOn
+                    ? 'text-government-blue hover:text-government-blue transition-colors'
+                    : 'text-primary/70 hover:text-primary transition-colors'
+                }
+              >
+                <Highlighter className="w-4 h-4 mr-1" />
+                {lensOn ? 'Lente ativa' : 'Lente semântica'}
+              </Button>
+            )}
           </div>
 
           {/* Editorial Lead - aparece como tag acima do título */}
@@ -175,9 +216,17 @@ export default function ClientArticle({
           )
         )}
 
-        {/* Corpo do artigo */}
+        {/* Corpo do artigo — lente ON destaca entidades sobre o texto plano;
+            lente OFF mantém o Markdown renderizado normalmente. */}
         <article className="prose prose-lg mx-auto max-w-3xl text-primary/90 leading-relaxed article-content">
-          <MarkdownRenderer content={article.content ?? ''} />
+          {lensOn && lensAvailable ? (
+            <SemanticLens
+              content={article.content ?? ''}
+              annotations={annotations}
+            />
+          ) : (
+            <MarkdownRenderer content={article.content ?? ''} />
+          )}
         </article>
 
         {/* Botão CTA para notícia original */}

--- a/src/components/articles/SemanticLens.tsx
+++ b/src/components/articles/SemanticLens.tsx
@@ -1,0 +1,151 @@
+'use client'
+
+/**
+ * Lente semântica — renderiza o corpo da notícia (texto plano) com as entidades
+ * destacadas inline e ligáveis às respectivas páginas de entidade.
+ *
+ * Contrato de robustez (validate-then-split): o NER rodou sobre o texto plano,
+ * enquanto o corpo servido pode divergir (Markdown ↔ plain-text, drift
+ * Typesense ↔ Postgres). Portanto cada span é **validado** antes de destacar:
+ * descartamos qualquer anotação cujo `content.slice(start,end)` foldado (NFC +
+ * casefold + sem acento) não bata com `annotation.text` foldado. Span inválido
+ * simplesmente não é destacado (cobertura parcial aceitável; nunca destaca
+ * errado).
+ *
+ * O destaque é um tint de fundo sutil + borda inferior (não um chip cheio) para
+ * preservar o fluxo de leitura. Cada destaque é um `next/link` inline.
+ */
+
+import Link from 'next/link'
+import { slugifyEntity } from '@/lib/entity-slug'
+import { entityTypeStyle } from '@/lib/entity-types'
+import type { ContentAnnotation } from '@/types/article'
+
+/**
+ * Dobra (fold) uma string para comparação tolerante: NFC, casefold
+ * (lowercase) e remoção de acentos. Espelha a derivação determinística de
+ * offsets do feature-worker, defendendo contra drift de conteúdo no render.
+ */
+export function foldForMatch(s: string): string {
+  return s
+    .normalize('NFC')
+    .toLowerCase()
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+}
+
+/** Um segmento plano do texto: texto puro, ou uma entidade destacável. */
+export type LensSegment =
+  | { kind: 'text'; text: string; start: number }
+  | {
+      kind: 'entity'
+      text: string
+      start: number
+      end: number
+      type: string
+      canonicalId: string | null
+    }
+
+/**
+ * Constrói os segmentos planos do texto a partir das anotações.
+ *
+ * Passos:
+ *  1. **validate**: mantém só spans cujo `content.slice` foldado == `text` foldado.
+ *  2. **sort + dedupe overlap**: ordena por `start asc`; descarta qualquer span
+ *     que comece antes do fim do anterior aceito (overlaps já são resolvidos
+ *     upstream por longest-match-wins, mas defendemos aqui por garantia).
+ *  3. **split**: caminha o cursor emitindo texto puro entre spans + os spans.
+ */
+export function buildSegments(
+  content: string,
+  annotations: ContentAnnotation[],
+): LensSegment[] {
+  const valid = annotations
+    .filter((a) => {
+      if (
+        !Number.isInteger(a.start) ||
+        !Number.isInteger(a.end) ||
+        a.start < 0 ||
+        a.end > content.length ||
+        a.start >= a.end
+      ) {
+        return false
+      }
+      return (
+        foldForMatch(content.slice(a.start, a.end)) === foldForMatch(a.text)
+      )
+    })
+    .sort((a, b) => a.start - b.start || b.end - a.end)
+
+  const segments: LensSegment[] = []
+  let cursor = 0
+
+  for (const a of valid) {
+    // Pula spans que se sobrepõem a um já emitido (non-overlapping).
+    if (a.start < cursor) continue
+
+    if (a.start > cursor) {
+      segments.push({
+        kind: 'text',
+        text: content.slice(cursor, a.start),
+        start: cursor,
+      })
+    }
+
+    segments.push({
+      kind: 'entity',
+      text: content.slice(a.start, a.end),
+      start: a.start,
+      end: a.end,
+      type: a.type,
+      canonicalId: a.canonical_id ?? null,
+    })
+    cursor = a.end
+  }
+
+  if (cursor < content.length) {
+    segments.push({ kind: 'text', text: content.slice(cursor), start: cursor })
+  }
+
+  return segments
+}
+
+/** Destino da entidade: página canônica quando há id; senão fallback de texto. */
+function entityHref(text: string, canonicalId: string | null): string {
+  return canonicalId
+    ? `/entidades/${canonicalId}`
+    : `/entidades/${slugifyEntity(text)}`
+}
+
+export function SemanticLens({
+  content,
+  annotations,
+}: {
+  content: string
+  annotations: ContentAnnotation[]
+}) {
+  const segments = buildSegments(content, annotations)
+
+  return (
+    <p className="whitespace-pre-wrap">
+      {segments.map((segment) => {
+        if (segment.kind === 'text') {
+          // Key estável pelo offset de início (único e nunca o índice do array).
+          return <span key={`t-${segment.start}`}>{segment.text}</span>
+        }
+        const style = entityTypeStyle(segment.type)
+        return (
+          <Link
+            key={`${segment.start}-${segment.end}`}
+            href={entityHref(segment.text, segment.canonicalId)}
+            title={`Ver notícias sobre ${segment.text}`}
+            aria-label={`Ver notícias sobre ${segment.text}`}
+            className={`rounded-sm px-0.5 transition-colors ${style.lens}`}
+          >
+            {segment.text}
+          </Link>
+        )
+      })}
+    </p>
+  )
+}

--- a/src/components/articles/__tests__/ArticleFeatures.test.tsx
+++ b/src/components/articles/__tests__/ArticleFeatures.test.tsx
@@ -1,0 +1,107 @@
+import { screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import { render } from '@/__tests__/test-utils'
+import type { ArticleEntity } from '@/types/article'
+import { ArticleEntities, groupEntities } from '../ArticleFeatures'
+
+function ent(
+  text: string,
+  type: string,
+  count = 1,
+  canonical_id: string | null = null,
+): ArticleEntity {
+  return { text, type, count, canonical_id }
+}
+
+describe('groupEntities', () => {
+  it('agrupa por tipo na ordem ORG/PER/LOC/EVENT/POLICY', () => {
+    const groups = groupEntities([
+      ent('Bolsa Família', 'POLICY'),
+      ent('Copa do Mundo', 'EVENT'),
+      ent('Brasília', 'LOC'),
+      ent('Lula', 'PER'),
+      ent('MEC', 'ORG'),
+    ])
+    expect(groups.map((g) => g.label)).toEqual([
+      'Instituições',
+      'Pessoas',
+      'Locais',
+      'Eventos',
+      'Políticas Públicas',
+    ])
+  })
+
+  it('inclui grupos EVENT e POLICY (antes escondidos no balde MISC)', () => {
+    const groups = groupEntities([
+      ent('Enem 2026', 'EVENT'),
+      ent('Pé-de-Meia', 'POLICY'),
+    ])
+    expect(groups.map((g) => g.label)).toEqual([
+      'Eventos',
+      'Políticas Públicas',
+    ])
+  })
+
+  it('omite grupos vazios', () => {
+    const groups = groupEntities([ent('MEC', 'ORG')])
+    expect(groups).toHaveLength(1)
+    expect(groups[0].label).toBe('Instituições')
+  })
+
+  it('drena tipos desconhecidos para o balde "Outros"', () => {
+    const groups = groupEntities([ent('algo', 'LAW'), ent('MEC', 'ORG')])
+    const labels = groups.map((g) => g.label)
+    expect(labels).toContain('Instituições')
+    expect(labels).toContain('Outros')
+    // "Outros" sempre por último.
+    expect(labels[labels.length - 1]).toBe('Outros')
+  })
+
+  it('ordena os itens de cada grupo por contagem desc', () => {
+    const groups = groupEntities([
+      ent('Pouco', 'ORG', 2),
+      ent('Muito', 'ORG', 9),
+    ])
+    expect(groups[0].items.map((e) => e.text)).toEqual(['Muito', 'Pouco'])
+  })
+})
+
+describe('ArticleEntities render', () => {
+  it('não renderiza nada quando não há entidades', () => {
+    const { container } = render(<ArticleEntities entities={[]} />)
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('linka chip canônico para /entidades/{canonicalId}', () => {
+    render(
+      <ArticleEntities
+        entities={[ent('Ministério da Saúde', 'ORG', 3, 'Q216330')]}
+      />,
+    )
+    const link = screen.getByRole('link', {
+      name: /Ver notícias sobre Ministério da Saúde/i,
+    })
+    expect(link).toHaveAttribute('href', '/entidades/Q216330')
+  })
+
+  it('faz fallback para slug de texto quando a menção não tem id canônico', () => {
+    render(<ArticleEntities entities={[ent('Lula', 'PER', 5, null)]} />)
+    const link = screen.getByRole('link', {
+      name: /Ver notícias sobre Lula/i,
+    })
+    expect(link).toHaveAttribute('href', '/entidades/lula')
+  })
+
+  it('renderiza as seções Eventos e Políticas Públicas', () => {
+    render(
+      <ArticleEntities
+        entities={[
+          ent('Copa do Mundo', 'EVENT'),
+          ent('Bolsa Família', 'POLICY'),
+        ]}
+      />,
+    )
+    expect(screen.getByText('Eventos')).toBeInTheDocument()
+    expect(screen.getByText('Políticas Públicas')).toBeInTheDocument()
+  })
+})

--- a/src/components/articles/__tests__/SemanticLens.test.tsx
+++ b/src/components/articles/__tests__/SemanticLens.test.tsx
@@ -1,0 +1,143 @@
+import { screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import { render } from '@/__tests__/test-utils'
+import type { ContentAnnotation } from '@/types/article'
+import { buildSegments, foldForMatch, SemanticLens } from '../SemanticLens'
+
+function ann(
+  start: number,
+  end: number,
+  text: string,
+  type = 'ORG',
+  canonical_id: string | null = null,
+): ContentAnnotation {
+  return { start, end, type, text, canonical_id }
+}
+
+describe('foldForMatch', () => {
+  it('dobra caixa e acentos (NFC + casefold + sem acento)', () => {
+    expect(foldForMatch('Ministério')).toBe('ministerio')
+    expect(foldForMatch('SAÚDE')).toBe(foldForMatch('saúde'))
+  })
+})
+
+describe('buildSegments — validate-then-split', () => {
+  it('destaca um span válido e mantém o texto ao redor', () => {
+    const content = 'Visita ao Ministério da Saúde hoje.'
+    const start = content.indexOf('Ministério da Saúde')
+    const end = start + 'Ministério da Saúde'.length
+    const segments = buildSegments(content, [
+      ann(start, end, 'Ministério da Saúde', 'ORG', 'Q216330'),
+    ])
+
+    const entity = segments.filter((s) => s.kind === 'entity')
+    expect(entity).toHaveLength(1)
+    expect(entity[0]).toMatchObject({
+      text: 'Ministério da Saúde',
+      type: 'ORG',
+      canonicalId: 'Q216330',
+    })
+    // Texto: prefixo + sufixo (dois segmentos de texto envolvendo o destaque).
+    const text = segments.filter((s) => s.kind === 'text')
+    expect(text.map((s) => s.text).join('')).toContain('Visita ao ')
+  })
+
+  it('valida insensível a acento/caixa (drift Markdown↔plain tolerado)', () => {
+    const content = 'O ministério da saude agiu.'
+    const start = content.indexOf('ministério da saude')
+    const end = start + 'ministério da saude'.length
+    const segments = buildSegments(content, [
+      // surface da anotação difere em caixa/acento do slice, mas folda igual.
+      ann(start, end, 'Ministério da Saúde', 'ORG'),
+    ])
+    expect(segments.some((s) => s.kind === 'entity')).toBe(true)
+  })
+
+  it('descarta span "driftado" (slice foldado ≠ text foldado)', () => {
+    const content = 'Texto totalmente diferente aqui.'
+    const segments = buildSegments(content, [
+      // offsets apontam para "Texto tota" que não folda para "Bolsa Família".
+      ann(0, 10, 'Bolsa Família', 'POLICY'),
+    ])
+    expect(segments.every((s) => s.kind === 'text')).toBe(true)
+    expect(segments.map((s) => s.text).join('')).toBe(content)
+  })
+
+  it('descarta offsets fora dos limites ou degenerados', () => {
+    const content = 'curto'
+    expect(
+      buildSegments(content, [ann(0, 999, 'curto')]).every(
+        (s) => s.kind === 'text',
+      ),
+    ).toBe(true)
+    expect(
+      buildSegments(content, [ann(3, 3, '')]).every((s) => s.kind === 'text'),
+    ).toBe(true)
+  })
+
+  it('não destaca nada quando não há anotações (texto puro)', () => {
+    const content = 'Sem entidades.'
+    const segments = buildSegments(content, [])
+    expect(segments).toEqual([{ kind: 'text', text: content, start: 0 }])
+  })
+
+  it('resolve overlap mantendo o primeiro/maior e pulando o aninhado', () => {
+    // "Ministério da Educação (MEC)" engloba "MEC" — varredura start asc, len
+    // desc: o maior vence, o aninhado é pulado (non-overlapping).
+    const content = 'Ministério da Educação (MEC) anunciou.'
+    const outerStart = 0
+    const outerEnd = 'Ministério da Educação (MEC)'.length
+    const mecStart = content.indexOf('MEC')
+    const segments = buildSegments(content, [
+      ann(mecStart, mecStart + 3, 'MEC', 'ORG'),
+      ann(outerStart, outerEnd, 'Ministério da Educação (MEC)', 'ORG'),
+    ])
+    const entities = segments.filter((s) => s.kind === 'entity')
+    expect(entities).toHaveLength(1)
+    expect(entities[0].text).toBe('Ministério da Educação (MEC)')
+  })
+
+  it('destaca múltiplas entidades distintas em ordem', () => {
+    const content = 'Lula e Haddad reuniram-se.'
+    const segments = buildSegments(content, [
+      ann(0, 4, 'Lula', 'PER', 'Q8412'),
+      ann(7, 13, 'Haddad', 'PER'),
+    ])
+    const entities = segments.filter((s) => s.kind === 'entity')
+    expect(entities.map((e) => e.text)).toEqual(['Lula', 'Haddad'])
+  })
+})
+
+describe('SemanticLens render', () => {
+  it('renderiza o destaque como link para a entidade canônica', () => {
+    const content = 'Sobre o Pé-de-Meia.'
+    const start = content.indexOf('Pé-de-Meia')
+    const end = start + 'Pé-de-Meia'.length
+    render(
+      <SemanticLens
+        content={content}
+        annotations={[ann(start, end, 'Pé-de-Meia', 'POLICY', 'dgb_xyz')]}
+      />,
+    )
+    const link = screen.getByRole('link', {
+      name: /Ver notícias sobre Pé-de-Meia/i,
+    })
+    expect(link).toHaveAttribute('href', '/entidades/dgb_xyz')
+  })
+
+  it('faz fallback para slug de texto quando não há id canônico', () => {
+    const content = 'Sobre o Pé-de-Meia.'
+    const start = content.indexOf('Pé-de-Meia')
+    const end = start + 'Pé-de-Meia'.length
+    render(
+      <SemanticLens
+        content={content}
+        annotations={[ann(start, end, 'Pé-de-Meia', 'POLICY', null)]}
+      />,
+    )
+    const link = screen.getByRole('link', {
+      name: /Ver notícias sobre Pé-de-Meia/i,
+    })
+    expect(link).toHaveAttribute('href', '/entidades/pe-de-meia')
+  })
+})

--- a/src/lib/__tests__/entity-slug.test.ts
+++ b/src/lib/__tests__/entity-slug.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest'
+import {
+  deslugifyEntity,
+  isCanonicalEntityId,
+  matchEntityBySlug,
+  slugifyEntity,
+} from '@/lib/entity-slug'
+
+describe('slugifyEntity', () => {
+  it('converte texto acentuado em kebab-case sem acentos', () => {
+    expect(slugifyEntity('Ministério da Saúde')).toBe('ministerio-da-saude')
+    expect(slugifyEntity('Lula')).toBe('lula')
+  })
+
+  it('remove pontuação e hífens nas pontas', () => {
+    expect(slugifyEntity('Minha Casa, Minha Vida')).toBe(
+      'minha-casa-minha-vida',
+    )
+    expect(slugifyEntity('  (FINEP)  ')).toBe('finep')
+  })
+})
+
+describe('isCanonicalEntityId', () => {
+  it('reconhece QIDs do Wikidata', () => {
+    expect(isCanonicalEntityId('Q216330')).toBe(true)
+    expect(isCanonicalEntityId('Q1')).toBe(true)
+  })
+
+  it('reconhece ids internos dgb_', () => {
+    expect(isCanonicalEntityId('dgb_01h8xyz')).toBe(true)
+    expect(isCanonicalEntityId('dgb_')).toBe(true)
+  })
+
+  it('trata texto legado (kebab-case) como NÃO canônico', () => {
+    expect(isCanonicalEntityId('ministerio-da-saude')).toBe(false)
+    expect(isCanonicalEntityId('lula')).toBe(false)
+    expect(isCanonicalEntityId('bolsa-familia')).toBe(false)
+  })
+
+  it('não confunde QID parcial/inválido com canônico', () => {
+    // 'Q' sem dígitos, ou 'Q' seguido de não-dígitos → legado.
+    expect(isCanonicalEntityId('Q')).toBe(false)
+    expect(isCanonicalEntityId('Qabc')).toBe(false)
+    expect(isCanonicalEntityId('Q216330-extra')).toBe(false)
+  })
+})
+
+describe('matchEntityBySlug', () => {
+  it('prefere match exato de slug', () => {
+    const candidates = ['Ministério da Saúde', 'Ministério da Saúde do Líbano']
+    expect(matchEntityBySlug('ministerio-da-saude', candidates)).toBe(
+      'Ministério da Saúde',
+    )
+  })
+
+  it('cai em match por prefixo quando não há exato', () => {
+    const candidates = ['Ministério da Saúde do Líbano']
+    expect(matchEntityBySlug('ministerio-da-saude', candidates)).toBe(
+      'Ministério da Saúde do Líbano',
+    )
+  })
+
+  it('retorna null quando nada casa', () => {
+    expect(matchEntityBySlug('inexistente', ['Lula'])).toBeNull()
+  })
+})
+
+describe('deslugifyEntity', () => {
+  it('reconstrói uma string de busca aproximada', () => {
+    expect(deslugifyEntity('ministerio-da-saude')).toBe('ministerio da saude')
+  })
+})

--- a/src/lib/entity-slug.ts
+++ b/src/lib/entity-slug.ts
@@ -12,6 +12,22 @@
 import { removeDiacritics } from '@/lib/utils'
 
 /**
+ * Um slug de entidade é um **id canônico** (chave do `entity_registry`) quando
+ * é um QID do Wikidata (`Q` seguido de dígitos, ex.: `Q216330`) ou um id interno
+ * `dgb_<ulid>`. Nesse caso a página resolve o cabeçalho via `entity(id)` e lista
+ * artigos por `filter.entityCanonical`. Caso contrário, o slug é texto legado
+ * (kebab-case) e mantém o comportamento fuzzy-text (`resolveEntity`).
+ *
+ * @example
+ * isCanonicalEntityId('Q216330') // true
+ * isCanonicalEntityId('dgb_01h8...') // true
+ * isCanonicalEntityId('ministerio-da-saude') // false
+ */
+export function isCanonicalEntityId(slug: string): boolean {
+  return /^Q\d+$/.test(slug) || /^dgb_/.test(slug)
+}
+
+/**
  * Converte o texto canônico de uma entidade em um slug URL-safe.
  *
  * @example

--- a/src/lib/entity-types.ts
+++ b/src/lib/entity-types.ts
@@ -1,0 +1,103 @@
+/**
+ * Fonte única de verdade do esquema visual de tipos de entidade (NER).
+ *
+ * Os mesmos tipos e cores são consumidos por:
+ *   - `ArticleFeatures.tsx` (chips agrupados "Entidades mencionadas")
+ *   - `EntityPageClient.tsx` (cabeçalho da página de entidade canônica)
+ *   - `SemanticLens.tsx` (destaque inline da lente semântica)
+ *
+ * A paleta segue o esquema institucional (government-blue/green/yellow já em uso)
+ * e atribui cores distintas a cada tipo, mantendo coesão com o design do artigo.
+ */
+
+import {
+  Building2,
+  CalendarDays,
+  Landmark,
+  type LucideIcon,
+  MapPin,
+  Tag as TagIcon,
+  User,
+} from 'lucide-react'
+
+/** Tipos de entidade sancionados pela taxonomia NER evoluída. */
+export type EntityTypeKey = 'ORG' | 'PER' | 'LOC' | 'EVENT' | 'POLICY' | 'OTHER'
+
+/** Estilo visual de um tipo de entidade. */
+export type EntityTypeStyle = {
+  /** Rótulo do grupo (plural), exibido no cabeçalho de seção dos chips. */
+  label: string
+  /** Ícone lucide representativo do tipo. */
+  icon: LucideIcon
+  /** Classe Tailwind de cor de fundo do "dot" (marcador do grupo). */
+  dot: string
+  /**
+   * Classes Tailwind do destaque inline da lente: tint de fundo sutil + borda
+   * inferior colorida. NÃO é um chip cheio — preserva o fluxo de leitura.
+   */
+  lens: string
+}
+
+/**
+ * Mapa tipo → estilo. As cores government-* já existem no tema (globals.css);
+ * EVENT/POLICY ganham tons coerentes (roxo/laranja) que se distinguem dos três
+ * tipos base sem destoar do esquema institucional.
+ */
+export const ENTITY_TYPE_STYLES: Record<EntityTypeKey, EntityTypeStyle> = {
+  ORG: {
+    label: 'Instituições',
+    icon: Building2,
+    dot: 'bg-government-blue',
+    lens: 'bg-government-blue/10 border-b-2 border-government-blue/50 hover:bg-government-blue/20',
+  },
+  PER: {
+    label: 'Pessoas',
+    icon: User,
+    dot: 'bg-government-green',
+    lens: 'bg-government-green/10 border-b-2 border-government-green/50 hover:bg-government-green/20',
+  },
+  LOC: {
+    label: 'Locais',
+    icon: MapPin,
+    dot: 'bg-government-yellow',
+    lens: 'bg-government-yellow/15 border-b-2 border-government-yellow/60 hover:bg-government-yellow/25',
+  },
+  EVENT: {
+    label: 'Eventos',
+    icon: CalendarDays,
+    dot: 'bg-purple-500',
+    lens: 'bg-purple-500/10 border-b-2 border-purple-500/50 hover:bg-purple-500/20',
+  },
+  POLICY: {
+    label: 'Políticas Públicas',
+    icon: Landmark,
+    dot: 'bg-orange-500',
+    lens: 'bg-orange-500/10 border-b-2 border-orange-500/50 hover:bg-orange-500/20',
+  },
+  OTHER: {
+    label: 'Outros',
+    icon: TagIcon,
+    dot: 'bg-primary/40',
+    lens: 'bg-primary/5 border-b-2 border-primary/30 hover:bg-primary/10',
+  },
+}
+
+/** Ordem canônica de exibição dos grupos de entidade. */
+export const ENTITY_TYPE_ORDER: EntityTypeKey[] = [
+  'ORG',
+  'PER',
+  'LOC',
+  'EVENT',
+  'POLICY',
+]
+
+/** Tipos com grupo/cor próprios (exclui o balde `OTHER`). */
+export const KNOWN_ENTITY_TYPES = new Set<string>(ENTITY_TYPE_ORDER)
+
+/**
+ * Resolve o estilo de um tipo de entidade (string crua do backend), caindo em
+ * `OTHER` para qualquer tipo fora da taxonomia conhecida.
+ */
+export function entityTypeStyle(type: string): EntityTypeStyle {
+  return ENTITY_TYPE_STYLES[type as EntityTypeKey] ?? ENTITY_TYPE_STYLES.OTHER
+}

--- a/src/lib/graphql/queries/articles.ts
+++ b/src/lib/graphql/queries/articles.ts
@@ -127,6 +127,15 @@ export const ARTICLE_QUERY = gql`
           text
           type
           count
+          canonicalId
+          salience
+        }
+        contentAnnotations {
+          start
+          end
+          type
+          text
+          canonicalId
         }
         viewCount
         uniqueSessions
@@ -134,6 +143,26 @@ export const ARTICLE_QUERY = gql`
         wordCount
         readabilityFlesch
       }
+    }
+  }
+`
+
+/**
+ * Resolve uma entidade canônica pelo seu `entityId` (QID Wikidata `Q…` ou
+ * `dgb_<ulid>`) — usado no cabeçalho das páginas `/entidades/[id-canônico]`.
+ * Retorna `null` quando o id não existe no `entity_registry`.
+ */
+export const ENTITY_QUERY = gql`
+  query Entity($id: String!) {
+    entity(id: $id) {
+      entityId
+      canonicalName
+      type
+      aliases
+      wikidataId
+      wikidataUrl
+      description
+      agencyKey
     }
   }
 `
@@ -205,15 +234,54 @@ export type ArticleSort = 'RELEVANCE' | 'DATE' | 'TRENDING' | 'VIEWS'
 export interface EntityFacetGraphQL {
   value: string
   count: number
+  /** Id canônico (`Q…`/`dgb_…`) quando o facet já está canonicalizado. */
+  entityId?: string | null
+  /** Rótulo de exibição (canonical_name) quando disponível. */
+  label?: string | null
 }
 
 export interface EntitySuggestionsQueryData {
   entitySuggestions: EntityFacetGraphQL[]
 }
 
+/** Entidade canônica (nó do registry) resolvida por `entity(id)`. */
+export interface EntityNodeGraphQL {
+  entityId: string
+  canonicalName: string | null
+  type: string | null
+  aliases: string[]
+  wikidataId: string | null
+  wikidataUrl: string | null
+  description: string | null
+  agencyKey: string | null
+}
+
+export interface EntityQueryData {
+  entity: EntityNodeGraphQL | null
+}
+
+/** Menção de entidade no artigo (camelCase, graphql-api). */
+export interface ArticleEntityGraphQL {
+  text: string
+  type: string
+  count: number
+  canonicalId?: string | null
+  salience?: number | null
+}
+
+/** Anotação de span inline (lente semântica), com offsets char no `content`. */
+export interface ContentAnnotationGraphQL {
+  start: number
+  end: number
+  type: string
+  text: string
+  canonicalId?: string | null
+}
+
 /** Features computadas, como vêm do graphql-api (camelCase). Só no detalhe. */
 export interface ArticleFeaturesGraphQL {
-  entities: Array<{ text: string; type: string; count: number }>
+  entities: ArticleEntityGraphQL[]
+  contentAnnotations?: ContentAnnotationGraphQL[] | null
   viewCount: number | null
   uniqueSessions: number | null
   trendingScore: number | null

--- a/src/lib/graphql/schema.graphql
+++ b/src/lib/graphql/schema.graphql
@@ -94,6 +94,7 @@ type Article {
 
 type ArticleFeatures {
   entities: [EntityType!]!
+  contentAnnotations: [ContentAnnotation!]!
   viewCount: Int
   uniqueSessions: Int
   trendingScore: Float
@@ -101,15 +102,38 @@ type ArticleFeatures {
   readabilityFlesch: Float
 }
 
+type ContentAnnotation {
+  start: Int!
+  end: Int!
+  type: String!
+  text: String!
+  canonicalId: String
+}
+
 type EntityType {
   text: String!
   type: String!
   count: Int!
+  canonicalId: String
+  salience: Float
 }
 
 type EntityFacet {
   value: String!
   count: Int!
+  entityId: String
+  label: String
+}
+
+type EntityNode {
+  entityId: String!
+  canonicalName: String
+  type: String
+  aliases: [String!]!
+  wikidataId: String
+  wikidataUrl: String
+  description: String
+  agencyKey: String
 }
 
 enum ArticleSort {
@@ -129,6 +153,7 @@ input ArticleFilter {
   dedup: Boolean = null
   entities: [String!] = null
   sentiment: [String!] = null
+  entityCanonical: [String!] = null
 }
 
 type ArticlesResult {
@@ -700,6 +725,11 @@ type Query {
     type: String = null
     limit: Int! = 10
   ): [EntityFacet!]!
+
+  """
+  Resolve uma entidade canonica pelo seu id (QID Wikidata ou dgb_<ulid>) do entity_registry. Retorna None se o id nao existe. PUBLICO.
+  """
+  entity(id: String!): EntityNode
 
   """
   Contagem de artigos por code de tema (nivel `level`) nos ultimos `days` dias. `label` e None (o portal mapeia pela config). PUBLICO.

--- a/src/services/content/__tests__/graphql.test.ts
+++ b/src/services/content/__tests__/graphql.test.ts
@@ -243,6 +243,90 @@ describe('createGraphQLContentService', () => {
     })
   })
 
+  describe('getEntity', () => {
+    it('envia a query entity com id e mapeia o nó canônico', async () => {
+      const { client, queries } = makeClientStub({
+        onQuery: () => ({
+          entity: {
+            entityId: 'Q216330',
+            canonicalName: 'Ministério da Saúde',
+            type: 'ORG',
+            aliases: ['MS', 'Ministério da Saúde'],
+            wikidataId: 'Q216330',
+            wikidataUrl: 'https://www.wikidata.org/wiki/Q216330',
+            description: 'Órgão do governo federal',
+            agencyKey: 'ministerio-da-saude',
+          },
+        }),
+      })
+      const svc = createGraphQLContentService(client)
+      const res = await svc.getEntity('Q216330')
+      expect(queries[0].query).toContain('query Entity')
+      expect(queries[0].vars).toEqual({ id: 'Q216330' })
+      expect(res).toEqual({
+        entityId: 'Q216330',
+        canonicalName: 'Ministério da Saúde',
+        type: 'ORG',
+        aliases: ['MS', 'Ministério da Saúde'],
+        wikidataId: 'Q216330',
+        wikidataUrl: 'https://www.wikidata.org/wiki/Q216330',
+        description: 'Órgão do governo federal',
+        agencyKey: 'ministerio-da-saude',
+      })
+    })
+
+    it('retorna null quando o id não existe', async () => {
+      const { client } = makeClientStub({ onQuery: () => ({ entity: null }) })
+      const svc = createGraphQLContentService(client)
+      expect(await svc.getEntity('Q0')).toBeNull()
+    })
+
+    it('degrada para null quando a query falha (canonicalização pendente)', async () => {
+      const { client } = makeClientStub({
+        queryError: { graphQLErrors: [{ message: 'no entity resolver' }] },
+      })
+      const svc = createGraphQLContentService(client)
+      expect(await svc.getEntity('Q1')).toBeNull()
+    })
+  })
+
+  describe('getEntitySuggestions', () => {
+    it('faz passthrough de entityId/label quando presentes', async () => {
+      const { client, queries } = makeClientStub({
+        onQuery: () => ({
+          entitySuggestions: [
+            {
+              value: 'Ministério da Saúde',
+              count: 12,
+              entityId: 'Q216330',
+              label: 'Ministério da Saúde',
+            },
+          ],
+        }),
+      })
+      const svc = createGraphQLContentService(client)
+      const res = await svc.getEntitySuggestions('mini', 'ORG', 5)
+      expect(queries[0].query).toContain('query EntitySuggestions')
+      expect(queries[0].vars).toEqual({ query: 'mini', type: 'ORG', limit: 5 })
+      expect(res).toEqual([
+        {
+          value: 'Ministério da Saúde',
+          count: 12,
+          entityId: 'Q216330',
+          label: 'Ministério da Saúde',
+        },
+      ])
+    })
+
+    it('degrada para [] em erro (Fase 0 pendente)', async () => {
+      const { client } = makeClientStub({
+        queryError: { graphQLErrors: [{ message: 'no field entities' }] },
+      })
+      const svc = createGraphQLContentService(client)
+      expect(await svc.getEntitySuggestions('x')).toEqual([])
+    })
+  })
+
   describe('getReleaseArticles', () => {
     it('envia id e mapeia a lista', async () => {
       const { client, queries } = makeClientStub({

--- a/src/services/content/__tests__/mapper.test.ts
+++ b/src/services/content/__tests__/mapper.test.ts
@@ -168,3 +168,81 @@ describe('mapGraphqlArticleToRow', () => {
     expect(row.most_specific_theme_label).toBeNull()
   })
 })
+
+describe('mapGraphqlArticleToRow — features (entidades + lente)', () => {
+  it('mapeia canonicalId/salience das entidades e contentAnnotations', () => {
+    const row = mapGraphqlArticleToRow({
+      ...fullArticle(),
+      features: {
+        entities: [
+          {
+            text: 'Ministério da Saúde',
+            type: 'ORG',
+            count: 3,
+            canonicalId: 'Q216330',
+            salience: 0.82,
+          },
+        ],
+        contentAnnotations: [
+          {
+            start: 10,
+            end: 29,
+            type: 'ORG',
+            text: 'Ministério da Saúde',
+            canonicalId: 'Q216330',
+          },
+        ],
+        viewCount: 12,
+        uniqueSessions: 8,
+        trendingScore: 1.7,
+        wordCount: 420,
+        readabilityFlesch: 55.5,
+      },
+    })
+
+    expect(row.features?.entities[0]).toEqual({
+      text: 'Ministério da Saúde',
+      type: 'ORG',
+      count: 3,
+      canonical_id: 'Q216330',
+      salience: 0.82,
+    })
+    expect(row.features?.content_annotations).toEqual([
+      {
+        start: 10,
+        end: 29,
+        type: 'ORG',
+        text: 'Ministério da Saúde',
+        canonical_id: 'Q216330',
+      },
+    ])
+  })
+
+  it('campos canônicos ausentes → null; contentAnnotations ausente → []', () => {
+    const row = mapGraphqlArticleToRow({
+      ...fullArticle(),
+      features: {
+        entities: [{ text: 'Lula', type: 'PER', count: 5 }],
+        viewCount: null,
+        uniqueSessions: null,
+        trendingScore: null,
+        wordCount: null,
+        readabilityFlesch: null,
+      },
+    })
+
+    expect(row.features?.entities[0]).toEqual({
+      text: 'Lula',
+      type: 'PER',
+      count: 5,
+      canonical_id: null,
+      salience: null,
+    })
+    expect(row.features?.content_annotations).toEqual([])
+  })
+
+  it('features ausentes → null', () => {
+    const row = mapGraphqlArticleToRow(fullArticle())
+    expect(row.features).toBeNull()
+  })
+})

--- a/src/services/content/graphql.ts
+++ b/src/services/content/graphql.ts
@@ -21,7 +21,9 @@ import {
   type ArticleGraphQL,
   type ArticleQueryData,
   type ArticlesQueryData,
+  ENTITY_QUERY,
   ENTITY_SUGGESTIONS_QUERY,
+  type EntityQueryData,
   type EntitySuggestionsQueryData,
   ESTIMATE_RECORTE_COUNT_QUERY,
   type EstimateRecorteCountQueryData,
@@ -112,7 +114,18 @@ export function mapGraphqlArticleToRow(article: ArticleGraphQL): ArticleRow {
             text: e.text,
             type: e.type,
             count: e.count,
+            canonical_id: e.canonicalId ?? null,
+            salience: e.salience ?? null,
           })),
+          content_annotations: (article.features.contentAnnotations ?? []).map(
+            (a) => ({
+              start: a.start,
+              end: a.end,
+              type: a.type,
+              text: a.text,
+              canonical_id: a.canonicalId ?? null,
+            }),
+          ),
           view_count: article.features.viewCount ?? null,
           unique_sessions: article.features.uniqueSessions ?? null,
           trending_score: article.features.trendingScore ?? null,
@@ -282,7 +295,33 @@ export function createGraphQLContentService(
       return (result.data?.entitySuggestions ?? []).map((e) => ({
         value: e.value,
         count: e.count,
+        entityId: e.entityId ?? null,
+        label: e.label ?? null,
       }))
+    },
+
+    async getEntity(id: string) {
+      // Degrada para null enquanto a canonicalização não rodar: o `entity(id)`
+      // pode não existir ou retornar erro — a página de entidade cai no
+      // fallback de texto fuzzy. Não propagamos o erro.
+      const result = await client
+        .query<EntityQueryData>(ENTITY_QUERY, { id })
+        .toPromise()
+      if (result.error) {
+        return null
+      }
+      const node = result.data?.entity ?? null
+      if (!node) return null
+      return {
+        entityId: node.entityId,
+        canonicalName: node.canonicalName ?? null,
+        type: node.type ?? null,
+        aliases: node.aliases ?? [],
+        wikidataId: node.wikidataId ?? null,
+        wikidataUrl: node.wikidataUrl ?? null,
+        description: node.description ?? null,
+        agencyKey: node.agencyKey ?? null,
+      }
     },
 
     async getReleaseArticles(id: string) {

--- a/src/services/content/types.ts
+++ b/src/services/content/types.ts
@@ -25,6 +25,11 @@ export interface ArticleFilterInput {
   entities?: string[] | null
   /** Sentimentos: `positive` / `neutral` / `negative`. */
   sentiment?: string[] | null
+  /**
+   * Ids canônicos de entidades (`Q…`/`dgb_…`) — facet dedup'd por `entity_id`.
+   * Usado pelas páginas `/entidades/[id-canônico]`. Depende da canonicalização.
+   */
+  entityCanonical?: string[] | null
 }
 
 export interface ListArticlesArgs {
@@ -71,6 +76,25 @@ export interface ThemeCount {
 export interface EntityFacet {
   value: string
   count: number
+  /** Id canônico (`Q…`/`dgb_…`) quando o facet já está canonicalizado. */
+  entityId?: string | null
+  /** Rótulo de exibição (canonical_name) quando disponível. */
+  label?: string | null
+}
+
+/**
+ * Entidade canônica (nó do registry) resolvida por `entity(id)` — cabeçalho das
+ * páginas `/entidades/[id-canônico]`.
+ */
+export interface EntityNode {
+  entityId: string
+  canonicalName: string | null
+  type: string | null
+  aliases: string[]
+  wikidataId: string | null
+  wikidataUrl: string | null
+  description: string | null
+  agencyKey: string | null
 }
 
 export interface EstimateRecorteCountArgs {
@@ -109,6 +133,13 @@ export interface ContentService {
     type?: string | null,
     limit?: number,
   ): Promise<EntityFacet[]>
+
+  /**
+   * Resolve uma entidade canônica pelo seu id (`Q…`/`dgb_…`). Retorna `null`
+   * quando o id não existe. Degrada para `null` enquanto o `entity(id)` não
+   * estiver disponível (canonicalização pendente).
+   */
+  getEntity(id: string): Promise<EntityNode | null>
 
   /** Artigos que compõem uma release de clipping. */
   getReleaseArticles(id: string): Promise<ArticleRow[]>

--- a/src/types/article.ts
+++ b/src/types/article.ts
@@ -1,13 +1,32 @@
-/** Entidade nomeada extraída do conteúdo (NER). type: ORG/PER/LOC/MISC/EVENT/… */
+/** Entidade nomeada extraída do conteúdo (NER). type: ORG/PER/LOC/EVENT/POLICY/… */
 export type ArticleEntity = {
   text: string
   type: string
   count: number
+  /** Id canônico (`Q…`/`dgb_…`) da entidade; `null` até canonicalizar. */
+  canonical_id?: string | null
+  /** Saliência [0,1] emitida pelo LLM; `null` quando ausente. */
+  salience?: number | null
+}
+
+/**
+ * Anotação de span inline (lente semântica). Offsets char em `content`,
+ * derivados deterministicamente no feature-worker. `canonical_id` liga ao
+ * `entity_registry` quando disponível.
+ */
+export type ContentAnnotation = {
+  start: number
+  end: number
+  type: string
+  text: string
+  canonical_id?: string | null
 }
 
 /** Features computadas (news_features), expostas no detalhe do artigo. */
 export type ArticleFeatures = {
   entities: ArticleEntity[]
+  /** Spans inline para a lente semântica (vazio até a derivação rodar). */
+  content_annotations?: ContentAnnotation[]
   view_count: number | null
   unique_sessions: number | null
   trending_score: number | null

--- a/src/types/search.ts
+++ b/src/types/search.ts
@@ -15,6 +15,8 @@ export type QueryArticlesArgs = {
   sentiment?: string[]
   /** Textos canônicos de entidades (depende da Fase 0). */
   entities?: string[]
+  /** Ids canônicos de entidades (`Q…`/`dgb_…`); depende da canonicalização. */
+  entityCanonical?: string[]
 }
 
 export type QueryArticlesResult = {


### PR DESCRIPTION
Parte da evolução do identificador de entidades (destaquesgovbr/data-platform#178). Base `development` (R1: nunca `main`).

## O que entra
- Chips agrupados **Eventos** e **Políticas Públicas** (`lib/entity-types.ts` como fonte única de cor/ícone).
- Páginas `/entidades/[id-canônico]`: header via `entity(id)` (nome, tipo, descrição, Wikidata) + lista via filtro `entityCanonical`; fallback gracioso p/ slug de texto legado.
- **`SemanticLens`**: lente que marca entidades inline no corpo (validate-then-split — nunca destaca a palavra errada), toggle ghost, **default off**, persistido em localStorage.
- Snapshot SDL atualizado; **drift gate (`graphql:codegen`) passa**.

## Testes
525 vitest verdes; `pnpm build` ok. Revisão adversarial: lente confirmada incapaz de destacar texto errado.

## Ordem
Mergear/deployar **após** o graphql-api (o runtime depende do schema novo). E2E no browser (Playwright `e2e/graphql`, serial) na integração final com graphql-api+portal de pé.

🤖 Generated with [Claude Code](https://claude.com/claude-code)