### PR TITLE
feat(entidades): entidades relacionadas + visualização de rede (Fase 6d)

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "react": "18.3.1",
     "react-day-picker": "^8.10.1",
     "react-dom": "18.3.1",
+    "react-force-graph-2d": "^1.29.1",
     "react-hook-form": "^7.61.1",
     "react-intersection-observer": "^9.16.0",
     "react-markdown": "^10.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -205,6 +205,9 @@ importers:
       react-dom:
         specifier: 18.3.1
         version: 18.3.1(react@18.3.1)
+      react-force-graph-2d:
+        specifier: ^1.29.1
+        version: 1.29.1(react@18.3.1)
       react-hook-form:
         specifier: ^7.61.1
         version: 7.62.0(react@18.3.1)
@@ -2751,6 +2754,9 @@ packages:
   '@ts-morph/common@0.23.0':
     resolution: {integrity: sha512-m7Lllj9n/S6sOkCkRftpM7L24uvmfXQFedlW/4hENcuJH1HHm9u5EgxZb9uVjQSCGrbBWBkOGgcTxNg36r6ywA==}
 
+  '@tweenjs/tween.js@25.0.0':
+    resolution: {integrity: sha512-XKLA6syeBUaPzx4j3qwMqzzq+V4uo72BnlbOjmuljLrRqdsd3qnzvZZoxvMHZ23ndsRS4aufU6JOZYpCbU6T1A==}
+
   '@types/aria-query@5.0.4':
     resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
 
@@ -2955,6 +2961,10 @@ packages:
     resolution: {integrity: sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==}
     engines: {node: '>=6.5'}
 
+  accessor-fn@1.5.3:
+    resolution: {integrity: sha512-rkAofCwe/FvYFUlMB0v0gWmhqtfAtV1IUkdPbfhTUyYniu5LrC0A0UJkTH0Jv3S8SvwkmfuAlY+mQIJATdocMA==}
+    engines: {node: '>=12'}
+
   agent-base@6.0.2:
     resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
     engines: {node: '>= 6.0.0'}
@@ -3070,6 +3080,9 @@ packages:
   before-after-hook@4.0.0:
     resolution: {integrity: sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ==}
 
+  bezier-js@6.1.4:
+    resolution: {integrity: sha512-PA0FW9ZpcHbojUCMu28z9Vg/fNkwTj5YhusSAjHHDfHDGLxJ6YUKrAN2vk1fP2MMOxVw4Oko16FMlRGVBGqLKg==}
+
   bignumber.js@9.3.1:
     resolution: {integrity: sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==}
 
@@ -3124,6 +3137,10 @@ packages:
 
   caniuse-lite@1.0.30001780:
     resolution: {integrity: sha512-llngX0E7nQci5BPJDqoZSbuZ5Bcs9F5db7EtgfwBerX9XGtkkiO4NwfDDIRzHTTwcYC8vC7bmeUEPGrKlR/TkQ==}
+
+  canvas-color-tracker@1.3.2:
+    resolution: {integrity: sha512-ryQkDX26yJ3CXzb3hxUVNlg1NKE4REc5crLBq661Nxzr8TNd236SaEf2ffYLXyI5tSABSeguHLqcVq4vf9L3Zg==}
+    engines: {node: '>=12'}
 
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
@@ -3355,12 +3372,27 @@ packages:
     resolution: {integrity: sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==}
     engines: {node: '>=12'}
 
+  d3-binarytree@1.0.2:
+    resolution: {integrity: sha512-cElUNH+sHu95L04m92pG73t2MEJXKu+GeKUN1TJkFsu93E5W8E9Sc3kHEGJKgenGvj19m6upSn2EunvMgMD2Yw==}
+
   d3-color@3.1.0:
     resolution: {integrity: sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==}
     engines: {node: '>=12'}
 
+  d3-dispatch@3.0.1:
+    resolution: {integrity: sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==}
+    engines: {node: '>=12'}
+
+  d3-drag@3.0.0:
+    resolution: {integrity: sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==}
+    engines: {node: '>=12'}
+
   d3-ease@3.0.1:
     resolution: {integrity: sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==}
+    engines: {node: '>=12'}
+
+  d3-force-3d@3.0.6:
+    resolution: {integrity: sha512-4tsKHUPLOVkyfEffZo1v6sFHvGFwAIIjt/W8IThbp08DYAsXZck+2pSHEG5W1+gQgEvFLdZkYvmJAbRM2EzMnA==}
     engines: {node: '>=12'}
 
   d3-format@3.1.0:
@@ -3371,12 +3403,27 @@ packages:
     resolution: {integrity: sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==}
     engines: {node: '>=12'}
 
+  d3-octree@1.1.0:
+    resolution: {integrity: sha512-F8gPlqpP+HwRPMO/8uOu5wjH110+6q4cgJvgJT6vlpy3BEaDIKlTZrgHKZSp/i1InRpVfh4puY/kvL6MxK930A==}
+
   d3-path@3.1.0:
     resolution: {integrity: sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==}
     engines: {node: '>=12'}
 
+  d3-quadtree@3.0.1:
+    resolution: {integrity: sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==}
+    engines: {node: '>=12'}
+
+  d3-scale-chromatic@3.1.0:
+    resolution: {integrity: sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ==}
+    engines: {node: '>=12'}
+
   d3-scale@4.0.2:
     resolution: {integrity: sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==}
+    engines: {node: '>=12'}
+
+  d3-selection@3.0.0:
+    resolution: {integrity: sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==}
     engines: {node: '>=12'}
 
   d3-shape@3.2.0:
@@ -3393,6 +3440,16 @@ packages:
 
   d3-timer@3.0.1:
     resolution: {integrity: sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==}
+    engines: {node: '>=12'}
+
+  d3-transition@3.0.1:
+    resolution: {integrity: sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==}
+    engines: {node: '>=12'}
+    peerDependencies:
+      d3-selection: 2 - 3
+
+  d3-zoom@3.0.0:
+    resolution: {integrity: sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==}
     engines: {node: '>=12'}
 
   data-uri-to-buffer@4.0.1:
@@ -3754,6 +3811,10 @@ packages:
   flatted@3.4.2:
     resolution: {integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==}
 
+  float-tooltip@1.7.5:
+    resolution: {integrity: sha512-/kXzuDnnBqyyWyhDMH7+PfP8J/oXiAavGzcRxASOMRHFuReDtofizLLJsf7nnDLAfEaMW4pVWaXrAjtnglpEkg==}
+    engines: {node: '>=12'}
+
   follow-redirects@1.16.0:
     resolution: {integrity: sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==}
     engines: {node: '>=4.0'}
@@ -3762,6 +3823,10 @@ packages:
     peerDependenciesMeta:
       debug:
         optional: true
+
+  force-graph@1.51.4:
+    resolution: {integrity: sha512-TdJ2KbkoiDQ7NIRx8IPGD0mAXXpLhamS7c+b7W98b0MHG7lphnda1VOQX/98UDTsttIAdH4TcP0l0MauSnLK8w==}
+    engines: {node: '>=12'}
 
   foreground-child@3.3.1:
     resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
@@ -4186,6 +4251,10 @@ packages:
     resolution: {integrity: sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg==}
     engines: {node: '>=12'}
 
+  index-array-by@1.4.2:
+    resolution: {integrity: sha512-SP23P27OUKzXWEC/TOyWlwLviofQkCSCKONnc62eItjp69yCZZPqDQtr3Pw5gJDnPeUMqExmKydNZaJO0FU9pw==}
+    engines: {node: '>=12'}
+
   index-to-position@1.2.0:
     resolution: {integrity: sha512-Yg7+ztRkqslMAS2iFaU+Oa4KTSidr63OsFGlOrJoW981kIYO3CGCS3wA95P1mUi/IVSJkn0D479KTJpVpvFNuw==}
     engines: {node: '>=18'}
@@ -4346,6 +4415,10 @@ packages:
     resolution: {integrity: sha512-qjdpeo2yKlYTH7nFdK0vbZWuTCesk4o63v5iVOlhMQPfuIZQfW/HI35SjfhA+4qpg36rnFSvUK5b1m+ckIblQQ==}
     engines: {node: '>= 0.6.0'}
 
+  jerrypick@1.1.2:
+    resolution: {integrity: sha512-YKnxXEekXKzhpf7CLYA0A+oDP8V0OhICNCr5lv96FvSsDEmrb0GKM776JgQvHTMjr7DTTPEVv/1Ciaw0uEWzBA==}
+    engines: {node: '>=12'}
+
   jiti@2.5.1:
     resolution: {integrity: sha512-twQoecYPiVA5K/h6SxtORw/Bs3ar+mLUtoPSc7iMXzQzK8d7eJ/R09wmTwAjiamETn1cXYPGfNnu7DMoHgu12w==}
     hasBin: true
@@ -4417,6 +4490,10 @@ packages:
 
   jws@4.0.1:
     resolution: {integrity: sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==}
+
+  kapsule@1.16.3:
+    resolution: {integrity: sha512-4+5mNNf4vZDSwPhKprKwz3330iisPrb08JyMgbsdFrimBCKNHecua/WBwvVg3n7vwx0C1ARjfhwIpbrbd9n5wg==}
+    engines: {node: '>=12'}
 
   keyv@5.6.0:
     resolution: {integrity: sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==}
@@ -5422,6 +5499,12 @@ packages:
     peerDependencies:
       react: ^18.3.1
 
+  react-force-graph-2d@1.29.1:
+    resolution: {integrity: sha512-1Rl/1Z3xy2iTHKj6a0jRXGyiI86xUti81K+jBQZ+Oe46csaMikp47L5AjrzA9hY9fNGD63X8ffrqnvaORukCuQ==}
+    engines: {node: '>=12'}
+    peerDependencies:
+      react: '*'
+
   react-hook-form@7.62.0:
     resolution: {integrity: sha512-7KWFejc98xqG/F4bAxpL41NB3o1nnvQO1RWZT3TqRZYL8RryQETGfEdVnJN2fy1crCiBLLjkRBVK05j24FxJGA==}
     engines: {node: '>=18.0.0'}
@@ -5445,6 +5528,12 @@ packages:
 
   react-is@18.3.1:
     resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
+
+  react-kapsule@2.5.7:
+    resolution: {integrity: sha512-kifAF4ZPD77qZKc4CKLmozq6GY1sBzPEJTIJb0wWFK6HsePJatK3jXplZn2eeAt3x67CDozgi7/rO8fNQ/AL7A==}
+    engines: {node: '>=12'}
+    peerDependencies:
+      react: '>=16.13.1'
 
   react-markdown@10.1.0:
     resolution: {integrity: sha512-qKxVopLT/TyA6BX3Ue5NwabOsAzm0Q7kAPwq6L+wWDwisYs7R8vZ0nRXqq6rkueboxpkjvLGU9fWifiX/ZZFxQ==}
@@ -5991,6 +6080,9 @@ packages:
 
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinycolor2@1.6.0:
+    resolution: {integrity: sha512-XPaBkWQJdsf3pLKJV9p4qN/S+fm2Oj8AIPo1BTUhg5oxkvm9+SVEGFdhyOz7tTdUTfvxMiAs4sp6/eZO2Ew+pw==}
 
   tinyexec@0.3.2:
     resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
@@ -9022,6 +9114,8 @@ snapshots:
       mkdirp: 3.0.1
       path-browserify: 1.0.1
 
+  '@tweenjs/tween.js@25.0.0': {}
+
   '@types/aria-query@5.0.4': {}
 
   '@types/babel__core@7.20.5':
@@ -9287,6 +9381,8 @@ snapshots:
       event-target-shim: 5.0.1
     optional: true
 
+  accessor-fn@1.5.3: {}
+
   agent-base@6.0.2:
     dependencies:
       debug: 4.4.3
@@ -9386,6 +9482,8 @@ snapshots:
 
   before-after-hook@4.0.0: {}
 
+  bezier-js@6.1.4: {}
+
   bignumber.js@9.3.1: {}
 
   bottleneck@2.19.5: {}
@@ -9438,6 +9536,10 @@ snapshots:
   caniuse-lite@1.0.30001760: {}
 
   caniuse-lite@1.0.30001780: {}
+
+  canvas-color-tracker@1.3.2:
+    dependencies:
+      tinycolor2: 1.6.0
 
   ccount@2.0.1: {}
 
@@ -9664,9 +9766,26 @@ snapshots:
     dependencies:
       internmap: 2.0.3
 
+  d3-binarytree@1.0.2: {}
+
   d3-color@3.1.0: {}
 
+  d3-dispatch@3.0.1: {}
+
+  d3-drag@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-selection: 3.0.0
+
   d3-ease@3.0.1: {}
+
+  d3-force-3d@3.0.6:
+    dependencies:
+      d3-binarytree: 1.0.2
+      d3-dispatch: 3.0.1
+      d3-octree: 1.1.0
+      d3-quadtree: 3.0.1
+      d3-timer: 3.0.1
 
   d3-format@3.1.0: {}
 
@@ -9674,7 +9793,16 @@ snapshots:
     dependencies:
       d3-color: 3.1.0
 
+  d3-octree@1.1.0: {}
+
   d3-path@3.1.0: {}
+
+  d3-quadtree@3.0.1: {}
+
+  d3-scale-chromatic@3.1.0:
+    dependencies:
+      d3-color: 3.1.0
+      d3-interpolate: 3.0.1
 
   d3-scale@4.0.2:
     dependencies:
@@ -9683,6 +9811,8 @@ snapshots:
       d3-interpolate: 3.0.1
       d3-time: 3.1.0
       d3-time-format: 4.1.0
+
+  d3-selection@3.0.0: {}
 
   d3-shape@3.2.0:
     dependencies:
@@ -9697,6 +9827,23 @@ snapshots:
       d3-array: 3.2.4
 
   d3-timer@3.0.1: {}
+
+  d3-transition@3.0.1(d3-selection@3.0.0):
+    dependencies:
+      d3-color: 3.1.0
+      d3-dispatch: 3.0.1
+      d3-ease: 3.0.1
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-timer: 3.0.1
+
+  d3-zoom@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-drag: 3.0.0
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-transition: 3.0.1(d3-selection@3.0.0)
 
   data-uri-to-buffer@4.0.1: {}
 
@@ -10080,7 +10227,31 @@ snapshots:
 
   flatted@3.4.2: {}
 
+  float-tooltip@1.7.5:
+    dependencies:
+      d3-selection: 3.0.0
+      kapsule: 1.16.3
+      preact: 10.24.3
+
   follow-redirects@1.16.0: {}
+
+  force-graph@1.51.4:
+    dependencies:
+      '@tweenjs/tween.js': 25.0.0
+      accessor-fn: 1.5.3
+      bezier-js: 6.1.4
+      canvas-color-tracker: 1.3.2
+      d3-array: 3.2.4
+      d3-drag: 3.0.0
+      d3-force-3d: 3.0.6
+      d3-scale: 4.0.2
+      d3-scale-chromatic: 3.1.0
+      d3-selection: 3.0.0
+      d3-zoom: 3.0.0
+      float-tooltip: 1.7.5
+      index-array-by: 1.4.2
+      kapsule: 1.16.3
+      lodash-es: 4.18.1
 
   foreground-child@3.3.1:
     dependencies:
@@ -10649,6 +10820,8 @@ snapshots:
 
   indent-string@5.0.0: {}
 
+  index-array-by@1.4.2: {}
+
   index-to-position@1.2.0: {}
 
   inherits@2.0.4: {}
@@ -10784,6 +10957,8 @@ snapshots:
 
   java-properties@1.0.2: {}
 
+  jerrypick@1.1.2: {}
+
   jiti@2.5.1: {}
 
   jose@4.15.9: {}
@@ -10884,6 +11059,10 @@ snapshots:
     dependencies:
       jwa: 2.0.1
       safe-buffer: 5.1.2
+
+  kapsule@1.16.3:
+    dependencies:
+      lodash-es: 4.18.1
 
   keyv@5.6.0:
     dependencies:
@@ -11933,6 +12112,13 @@ snapshots:
       react: 18.3.1
       scheduler: 0.23.2
 
+  react-force-graph-2d@1.29.1(react@18.3.1):
+    dependencies:
+      force-graph: 1.51.4
+      prop-types: 15.8.1
+      react: 18.3.1
+      react-kapsule: 2.5.7(react@18.3.1)
+
   react-hook-form@7.62.0(react@18.3.1):
     dependencies:
       react: 18.3.1
@@ -11948,6 +12134,11 @@ snapshots:
   react-is@17.0.2: {}
 
   react-is@18.3.1: {}
+
+  react-kapsule@2.5.7(react@18.3.1):
+    dependencies:
+      jerrypick: 1.1.2
+      react: 18.3.1
 
   react-markdown@10.1.0(@types/react@19.1.13)(react@18.3.1):
     dependencies:
@@ -12615,6 +12806,8 @@ snapshots:
   tiny-invariant@1.3.3: {}
 
   tinybench@2.9.0: {}
+
+  tinycolor2@1.6.0: {}
 
   tinyexec@0.3.2: {}
 

--- a/src/app/(public)/entidades/[slug]/EntityPageClient.tsx
+++ b/src/app/(public)/entidades/[slug]/EntityPageClient.tsx
@@ -1,14 +1,20 @@
 'use client'
 
-import { useInfiniteQuery } from '@tanstack/react-query'
+import { useInfiniteQuery, useQuery } from '@tanstack/react-query'
 import { motion } from 'framer-motion'
 import { ExternalLink, Tag as TagIcon } from 'lucide-react'
 import { useInView } from 'react-intersection-observer'
 import NewsCard from '@/components/articles/NewsCard'
+import EntityNetwork from '@/components/entities/EntityNetwork'
+import { RelatedEntities } from '@/components/entities/RelatedEntities'
 import { Badge } from '@/components/ui/badge'
 import { entityTypeStyle } from '@/lib/entity-types'
 import type { EntityNode } from '@/services/content/types'
-import { getEntityArticles } from './actions'
+import {
+  getEntityArticles,
+  getEntityNetwork,
+  getRelatedEntities,
+} from './actions'
 
 type EntityPageClientProps = {
   /** Id canônico (`Q…`/`dgb_…`) quando a página é canônica; senão `null`. */
@@ -48,6 +54,16 @@ export default function EntityPageClient({
     getNextPageParam: (lastPage) => lastPage.page ?? undefined,
     initialPageParam: 1,
     enabled: resolved,
+  })
+
+  // Entidades relacionadas (co-menção, 1-hop) — só no caminho canônico, onde há
+  // um id (`Q…`/`dgb_…`) para travessia no grafo. Degrada para [] enquanto o
+  // grafo não estiver populado; a seção então se esconde.
+  const relatedQ = useQuery({
+    queryKey: ['entity-related', canonicalId],
+    queryFn: () => getRelatedEntities(canonicalId as string),
+    enabled: canonicalId != null,
+    staleTime: 5 * 60 * 1000,
   })
 
   const { ref } = useInView({
@@ -120,6 +136,23 @@ export default function EntityPageClient({
           </div>
         )}
       </div>
+
+      {/* Grafo de entidades (só no caminho canônico, com id para travessia) */}
+      {canonicalId != null && (
+        <div className="container mx-auto px-4">
+          {/* Entidades relacionadas — esconde-se sozinha quando vazio */}
+          <RelatedEntities entities={relatedQ.data} />
+
+          {/* Rede ego-centrada (toggle default OFF) */}
+          <EntityNetwork
+            entityId={canonicalId}
+            depth={1}
+            fetchNetwork={(id, depth, limit) =>
+              getEntityNetwork(id, depth, limit)
+            }
+          />
+        </div>
+      )}
 
       {/* Conteúdo */}
       <div className="container mx-auto px-4">

--- a/src/app/(public)/entidades/[slug]/actions.ts
+++ b/src/app/(public)/entidades/[slug]/actions.ts
@@ -7,7 +7,11 @@ import {
 } from '@/lib/entity-slug'
 import { createSSRClient } from '@/lib/graphql/client'
 import { createGraphQLContentService } from '@/services/content/graphql'
-import type { EntityNode } from '@/services/content/types'
+import type {
+  EntityNetwork,
+  EntityNode,
+  RelatedEntity,
+} from '@/services/content/types'
 import type { ArticleRow } from '@/types/article'
 
 /** Cliente GraphQL público (sem token) para as server actions de entidade. */
@@ -112,4 +116,32 @@ export async function getEntityArticles(
     page: page + 1,
     found: result.found,
   }
+}
+
+/**
+ * Entidades relacionadas (co-menção, 1-hop) a uma entidade canônica, ordenadas
+ * por peso. Só faz sentido no caminho canônico (`id` = `Q…`/`dgb_…`); para
+ * qualquer outra entrada retorna `[]`. Degrada para `[]` enquanto o grafo
+ * (`entity_edges`) não estiver populado.
+ */
+export async function getRelatedEntities(
+  id: string,
+  limit = 12,
+): Promise<RelatedEntity[]> {
+  if (!isCanonicalEntityId(id)) return []
+  return content().getRelatedEntities(id, limit)
+}
+
+/**
+ * Rede ego-centrada (nós + arestas) de uma entidade canônica, para a
+ * visualização de rede. Retorna rede vazia para entradas não-canônicas ou
+ * enquanto o grafo não estiver disponível.
+ */
+export async function getEntityNetwork(
+  id: string,
+  depth = 1,
+  limit = 50,
+): Promise<EntityNetwork> {
+  if (!isCanonicalEntityId(id)) return { nodes: [], edges: [] }
+  return content().getEntityNetwork(id, depth, limit)
 }

--- a/src/components/entities/EntityNetwork.tsx
+++ b/src/components/entities/EntityNetwork.tsx
@@ -1,0 +1,121 @@
+'use client'
+
+/**
+ * Visualização de rede ego-centrada de uma entidade (Fase 6d).
+ *
+ * Wrapper client com toggle (default OFF): o grafo só carrega/renderiza quando
+ * o usuário liga — economiza a query e o canvas pesado para quem só quer ler as
+ * notícias. O canvas (`EntityNetworkGraph`) é importado dinamicamente com
+ * `ssr:false` porque `react-force-graph-2d` depende de `window`.
+ *
+ * A query (`entityNetwork`) roda via react-query através da server action
+ * `getEntityNetwork`. Toda a rede (nós + arestas) já vem capada pelo backend
+ * (`limit` + threshold de peso) para evitar hairball.
+ */
+
+import { useQuery } from '@tanstack/react-query'
+import { Network } from 'lucide-react'
+import dynamic from 'next/dynamic'
+import { useState } from 'react'
+import { Button } from '@/components/ui/button'
+
+// Client-only: depende de window/canvas. ssr:false evita quebrar o SSR da página.
+const EntityNetworkGraph = dynamic(() => import('./EntityNetworkGraph'), {
+  ssr: false,
+  loading: () => (
+    <div className="flex h-[420px] items-center justify-center rounded-lg border border-primary/10 bg-primary/[0.02] text-sm text-primary/50">
+      Carregando rede…
+    </div>
+  ),
+})
+
+export type EntityNetworkProps = {
+  /** Id canônico da entidade-foco (`Q…`/`dgb_…`). */
+  entityId: string
+  /** Profundidade da rede (saltos). Default 1 (vizinhos imediatos). */
+  depth?: number
+  /** Limite de nós retornados pelo backend. Default 50. */
+  limit?: number
+  /**
+   * Busca a rede. Injetável para testes; default usa a server action
+   * `getEntityNetwork` (resolvida no consumidor para evitar acoplar este
+   * componente client à action diretamente nos testes).
+   */
+  fetchNetwork: (
+    id: string,
+    depth: number,
+    limit: number,
+  ) => Promise<import('@/services/content/types').EntityNetwork>
+}
+
+export default function EntityNetwork({
+  entityId,
+  depth = 1,
+  limit = 50,
+  fetchNetwork,
+}: EntityNetworkProps) {
+  const [open, setOpen] = useState(false)
+
+  const networkQ = useQuery({
+    queryKey: ['entity-network', entityId, depth, limit],
+    queryFn: () => fetchNetwork(entityId, depth, limit),
+    // Só dispara a query depois que o usuário liga o toggle.
+    enabled: open,
+    staleTime: 5 * 60 * 1000,
+  })
+
+  const network = networkQ.data
+  const hasGraph = (network?.nodes.length ?? 0) > 0
+
+  return (
+    <section className="mx-auto mb-12 max-w-3xl">
+      <div className="mb-4 flex items-center justify-between gap-3">
+        <h2 className="text-sm font-semibold uppercase tracking-wide text-primary/70">
+          Rede de entidades
+        </h2>
+        <Button
+          variant="ghost"
+          size="sm"
+          aria-pressed={open}
+          onClick={() => setOpen((v) => !v)}
+        >
+          <Network className="h-4 w-4" aria-hidden />
+          {open ? 'Ocultar rede' : 'Ver rede'}
+        </Button>
+      </div>
+
+      {open && (
+        <div>
+          {networkQ.isLoading && (
+            <div className="flex h-[420px] items-center justify-center rounded-lg border border-primary/10 bg-primary/[0.02] text-sm text-primary/50">
+              Carregando rede…
+            </div>
+          )}
+
+          {!networkQ.isLoading && networkQ.isError && (
+            <p className="text-center text-sm text-red-500">
+              Não foi possível carregar a rede de entidades.
+            </p>
+          )}
+
+          {!networkQ.isLoading && !networkQ.isError && !hasGraph && (
+            <p className="text-center text-sm text-primary/50">
+              Ainda não há conexões suficientes para montar a rede desta
+              entidade.
+            </p>
+          )}
+
+          {!networkQ.isLoading && !networkQ.isError && hasGraph && network && (
+            <>
+              <EntityNetworkGraph network={network} egoId={entityId} />
+              <p className="mt-2 text-center text-xs text-primary/40">
+                Clique em uma entidade para navegar. A espessura da linha indica
+                quantas notícias mencionam o par.
+              </p>
+            </>
+          )}
+        </div>
+      )}
+    </section>
+  )
+}

--- a/src/components/entities/EntityNetworkGraph.tsx
+++ b/src/components/entities/EntityNetworkGraph.tsx
@@ -1,0 +1,99 @@
+'use client'
+
+/**
+ * Renderização da rede de entidades em canvas (force-directed), Fase 6d.
+ *
+ * Componente client-only: `react-force-graph-2d` depende de `window`/canvas e
+ * NÃO pode rodar em SSR — por isso é importado dinamicamente (ssr:false) pelo
+ * `EntityNetwork.tsx`. Aqui só assumimos que estamos no browser.
+ *
+ * Estética (frontend-design):
+ *   - cor do nó por tipo (reusa `entity-types.ts`, fonte única de verdade);
+ *   - a entidade-foco (ego) recebe anel destacado e raio maior;
+ *   - espessura da aresta ∝ peso (co-menção); grafo já vem capado pelo backend
+ *     (`limit`/threshold) — aqui só ajustamos legibilidade;
+ *   - clique no nó navega para a página da entidade.
+ */
+
+import { useRouter } from 'next/navigation'
+import { useMemo, useRef } from 'react'
+import ForceGraph2D from 'react-force-graph-2d'
+import type { EntityNetwork } from '@/services/content/types'
+import {
+  type GraphLink,
+  type GraphNode,
+  maxEdgeWeight,
+  toGraphData,
+} from './entity-network-data'
+
+export type EntityNetworkGraphProps = {
+  /** Rede a desenhar (nós + arestas). */
+  network: EntityNetwork
+  /** Id canônico da entidade-foco (ego). */
+  egoId: string
+  /** Altura do canvas (px). Default 420. */
+  height?: number
+}
+
+export default function EntityNetworkGraph({
+  network,
+  egoId,
+  height = 420,
+}: EntityNetworkGraphProps) {
+  const router = useRouter()
+  const containerRef = useRef<HTMLDivElement>(null)
+
+  const data = useMemo(() => toGraphData(network, egoId), [network, egoId])
+
+  // Peso máximo p/ normalizar a espessura das arestas (evita divisão por zero).
+  const maxWeight = useMemo(() => maxEdgeWeight(data.links), [data.links])
+
+  return (
+    <div
+      ref={containerRef}
+      className="w-full overflow-hidden rounded-lg border border-primary/10 bg-primary/[0.02]"
+      style={{ height }}
+    >
+      <ForceGraph2D
+        graphData={data}
+        height={height}
+        nodeRelSize={4}
+        nodeColor={(node) => (node as GraphNode).color}
+        nodeVal={(node) => (node as GraphNode).val}
+        cooldownTicks={80}
+        linkColor={() => 'rgba(15, 23, 42, 0.12)'}
+        linkWidth={(link) =>
+          0.5 + ((link as unknown as GraphLink).weight / maxWeight) * 3
+        }
+        onNodeClick={(node) => {
+          const id = (node as GraphNode).id
+          if (id) router.push(`/entidades/${id}`)
+        }}
+        nodeCanvasObjectMode={() => 'after'}
+        nodeCanvasObject={(node, ctx, globalScale) => {
+          const n = node as GraphNode & { x?: number; y?: number }
+          if (n.x == null || n.y == null) return
+
+          // Anel destacado para a entidade-foco (ego).
+          if (n.isEgo) {
+            ctx.beginPath()
+            ctx.arc(n.x, n.y, n.val + 2, 0, 2 * Math.PI)
+            ctx.strokeStyle = n.color
+            ctx.lineWidth = 1.5 / globalScale
+            ctx.stroke()
+          }
+
+          // Rótulo só quando há zoom suficiente — evita poluição no overview.
+          if (globalScale >= 1.2) {
+            const fontSize = 11 / globalScale
+            ctx.font = `${fontSize}px sans-serif`
+            ctx.textAlign = 'center'
+            ctx.textBaseline = 'top'
+            ctx.fillStyle = 'rgba(15, 23, 42, 0.75)'
+            ctx.fillText(n.name, n.x, n.y + n.val + 1)
+          }
+        }}
+      />
+    </div>
+  )
+}

--- a/src/components/entities/RelatedEntities.tsx
+++ b/src/components/entities/RelatedEntities.tsx
@@ -1,0 +1,66 @@
+/**
+ * Seção "Entidades relacionadas" da página `/entidades/[id]` (Fase 6d).
+ *
+ * Renderiza chips a partir de `relatedEntities` (co-menção, 1-hop): cada chip é
+ * um Link para a página da entidade vizinha (`/entidades/{canonicalId}`), com
+ * cor/ícone por tipo (reusando `lib/entity-types.ts`) e o peso da aresta
+ * ("N notícias juntas"). A seção se esconde quando não há vizinhos — o grafo é
+ * parcial (cresce conforme o backfill de canonicalização avança).
+ *
+ * Componente puro/presentacional (recebe os dados prontos) — testável sem rede.
+ */
+
+import Link from 'next/link'
+import { Badge } from '@/components/ui/badge'
+import { entityTypeStyle } from '@/lib/entity-types'
+import type { RelatedEntity } from '@/services/content/types'
+
+/** Rótulo do peso da aresta, em PT-BR ("3 notícias juntas"). */
+function weightLabel(weight: number): string {
+  const n = new Intl.NumberFormat('pt-BR').format(weight)
+  return `${n} notícia${weight === 1 ? '' : 's'} juntas`
+}
+
+function RelatedEntityChip({ entity }: { entity: RelatedEntity }) {
+  const style = entityTypeStyle(entity.type ?? 'OTHER')
+  const Icon = style.icon
+  const name = entity.canonicalName ?? entity.canonicalId
+
+  return (
+    <Link
+      href={`/entidades/${entity.canonicalId}`}
+      aria-label={`Ver a entidade ${name} (${weightLabel(entity.weight)})`}
+    >
+      <Badge className="gap-1.5 bg-white py-1 pr-2.5 pl-2 font-medium text-primary transition-colors hover:bg-primary/5 cursor-pointer">
+        <span
+          className={`inline-block h-1.5 w-1.5 rounded-full ${style.dot}`}
+          aria-hidden
+        />
+        <Icon className="h-3.5 w-3.5 text-primary/50" aria-hidden />
+        {name}
+        <span className="ml-0.5 text-primary/40">{entity.weight}</span>
+      </Badge>
+    </Link>
+  )
+}
+
+export function RelatedEntities({
+  entities,
+}: {
+  entities?: RelatedEntity[] | null
+}) {
+  if (!entities || entities.length === 0) return null
+
+  return (
+    <section className="mx-auto mb-12 max-w-3xl">
+      <h2 className="mb-4 text-sm font-semibold uppercase tracking-wide text-primary/70">
+        Entidades relacionadas
+      </h2>
+      <div className="flex flex-wrap gap-2">
+        {entities.map((entity) => (
+          <RelatedEntityChip key={entity.canonicalId} entity={entity} />
+        ))}
+      </div>
+    </section>
+  )
+}

--- a/src/components/entities/__tests__/EntityNetwork.test.tsx
+++ b/src/components/entities/__tests__/EntityNetwork.test.tsx
@@ -1,0 +1,104 @@
+import { screen, waitFor } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import { render } from '@/__tests__/test-utils'
+import type { EntityNetwork as EntityNetworkData } from '@/services/content/types'
+import EntityNetwork from '../EntityNetwork'
+
+// Mock do canvas (client-only, depende de window): substituímos por um marcador
+// simples para validar a orquestração (toggle/fetch/estados) sem renderizar o
+// force-graph de verdade.
+vi.mock('../EntityNetworkGraph', () => ({
+  default: ({ egoId }: { egoId: string }) => (
+    <div data-testid="network-graph">graph:{egoId}</div>
+  ),
+}))
+
+const NETWORK: EntityNetworkData = {
+  nodes: [
+    { entityId: 'Q1', canonicalName: 'Finep', type: 'ORG', wikidataId: 'Q1' },
+    { entityId: 'Q2', canonicalName: 'MCTI', type: 'ORG', wikidataId: 'Q2' },
+  ],
+  edges: [{ src: 'Q1', dst: 'Q2', weight: 5, kind: 'co_mention' }],
+}
+
+const EMPTY: EntityNetworkData = { nodes: [], edges: [] }
+
+describe('EntityNetwork', () => {
+  it('começa com o toggle desligado (rede não carregada)', () => {
+    const fetchNetwork = vi.fn().mockResolvedValue(NETWORK)
+    render(<EntityNetwork entityId="Q1" fetchNetwork={fetchNetwork} />)
+
+    // Toggle visível, mas a query NÃO dispara enquanto OFF.
+    expect(
+      screen.getByRole('button', { name: /Ver rede/i }),
+    ).toBeInTheDocument()
+    expect(fetchNetwork).not.toHaveBeenCalled()
+    expect(screen.queryByTestId('network-graph')).not.toBeInTheDocument()
+  })
+
+  it('liga o toggle, busca e renderiza o grafo', async () => {
+    const fetchNetwork = vi.fn().mockResolvedValue(NETWORK)
+    const { user } = render(
+      <EntityNetwork entityId="Q1" fetchNetwork={fetchNetwork} />,
+    )
+
+    await user.click(screen.getByRole('button', { name: /Ver rede/i }))
+
+    await waitFor(() =>
+      expect(screen.getByTestId('network-graph')).toBeInTheDocument(),
+    )
+    expect(fetchNetwork).toHaveBeenCalledWith('Q1', 1, 50)
+    expect(screen.getByTestId('network-graph')).toHaveTextContent('graph:Q1')
+    // O botão passa a oferecer ocultar.
+    expect(
+      screen.getByRole('button', { name: /Ocultar rede/i }),
+    ).toBeInTheDocument()
+  })
+
+  it('mostra estado vazio quando a rede não tem nós', async () => {
+    const fetchNetwork = vi.fn().mockResolvedValue(EMPTY)
+    const { user } = render(
+      <EntityNetwork entityId="Q1" fetchNetwork={fetchNetwork} />,
+    )
+
+    await user.click(screen.getByRole('button', { name: /Ver rede/i }))
+
+    await waitFor(() =>
+      expect(
+        screen.getByText(/Ainda não há conexões suficientes/i),
+      ).toBeInTheDocument(),
+    )
+    expect(screen.queryByTestId('network-graph')).not.toBeInTheDocument()
+  })
+
+  it('mostra estado de erro quando a busca falha', async () => {
+    const fetchNetwork = vi.fn().mockRejectedValue(new Error('boom'))
+    const { user } = render(
+      <EntityNetwork entityId="Q1" fetchNetwork={fetchNetwork} />,
+    )
+
+    await user.click(screen.getByRole('button', { name: /Ver rede/i }))
+
+    await waitFor(() =>
+      expect(
+        screen.getByText(/Não foi possível carregar a rede/i),
+      ).toBeInTheDocument(),
+    )
+  })
+
+  it('repassa depth/limit customizados para o fetch', async () => {
+    const fetchNetwork = vi.fn().mockResolvedValue(NETWORK)
+    const { user } = render(
+      <EntityNetwork
+        entityId="Q9"
+        depth={2}
+        limit={30}
+        fetchNetwork={fetchNetwork}
+      />,
+    )
+
+    await user.click(screen.getByRole('button', { name: /Ver rede/i }))
+
+    await waitFor(() => expect(fetchNetwork).toHaveBeenCalledWith('Q9', 2, 30))
+  })
+})

--- a/src/components/entities/__tests__/RelatedEntities.test.tsx
+++ b/src/components/entities/__tests__/RelatedEntities.test.tsx
@@ -1,0 +1,71 @@
+import { screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import { render } from '@/__tests__/test-utils'
+import type { RelatedEntity } from '@/services/content/types'
+import { RelatedEntities } from '../RelatedEntities'
+
+function rel(
+  canonicalId: string,
+  canonicalName: string | null,
+  type: string | null,
+  weight: number,
+  kind = 'co_mention',
+): RelatedEntity {
+  return { canonicalId, canonicalName, type, wikidataId: null, weight, kind }
+}
+
+describe('RelatedEntities', () => {
+  it('não renderiza nada quando não há entidades', () => {
+    const { container } = render(<RelatedEntities entities={[]} />)
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('não renderiza nada quando entities é null/undefined', () => {
+    const { container } = render(<RelatedEntities entities={null} />)
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('renderiza o cabeçalho e um chip por entidade', () => {
+    render(
+      <RelatedEntities
+        entities={[
+          rel('Q216330', 'Ministério da Saúde', 'ORG', 12),
+          rel('Q12345', 'Lula', 'PER', 8),
+        ]}
+      />,
+    )
+    expect(screen.getByText('Entidades relacionadas')).toBeInTheDocument()
+    expect(screen.getAllByRole('link')).toHaveLength(2)
+  })
+
+  it('linka cada chip para a página canônica da entidade vizinha', () => {
+    render(
+      <RelatedEntities
+        entities={[rel('Q216330', 'Ministério da Saúde', 'ORG', 5)]}
+      />,
+    )
+    const link = screen.getByRole('link', {
+      name: /Ver a entidade Ministério da Saúde/i,
+    })
+    expect(link).toHaveAttribute('href', '/entidades/Q216330')
+  })
+
+  it('exibe o peso da aresta no aria-label ("N notícias juntas")', () => {
+    render(<RelatedEntities entities={[rel('Q1', 'Finep', 'ORG', 3)]} />)
+    expect(
+      screen.getByRole('link', { name: /3 notícias juntas/i }),
+    ).toBeInTheDocument()
+  })
+
+  it('singulariza o peso quando é 1 notícia', () => {
+    render(<RelatedEntities entities={[rel('Q1', 'Finep', 'ORG', 1)]} />)
+    expect(
+      screen.getByRole('link', { name: /1 notícia juntas/i }),
+    ).toBeInTheDocument()
+  })
+
+  it('cai no id canônico como rótulo quando não há canonicalName', () => {
+    render(<RelatedEntities entities={[rel('dgb_abc', null, 'ORG', 2)]} />)
+    expect(screen.getByText('dgb_abc')).toBeInTheDocument()
+  })
+})

--- a/src/components/entities/__tests__/entity-network-data.test.ts
+++ b/src/components/entities/__tests__/entity-network-data.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from 'vitest'
+import { entityTypeStyle } from '@/lib/entity-types'
+import type { EntityNetwork } from '@/services/content/types'
+import { maxEdgeWeight, toGraphData } from '../entity-network-data'
+
+const NETWORK: EntityNetwork = {
+  nodes: [
+    { entityId: 'Q1', canonicalName: 'Finep', type: 'ORG', wikidataId: 'Q1' },
+    { entityId: 'Q2', canonicalName: 'MCTI', type: 'ORG', wikidataId: 'Q2' },
+    { entityId: 'Q3', canonicalName: 'Lula', type: 'PER', wikidataId: 'Q3' },
+  ],
+  edges: [
+    { src: 'Q1', dst: 'Q2', weight: 7, kind: 'co_mention' },
+    { src: 'Q1', dst: 'Q3', weight: 3, kind: 'co_mention' },
+  ],
+}
+
+describe('toGraphData', () => {
+  it('mapeia nós e links 1:1', () => {
+    const data = toGraphData(NETWORK, 'Q1')
+    expect(data.nodes).toHaveLength(3)
+    expect(data.links).toHaveLength(2)
+    expect(data.links[0]).toMatchObject({
+      source: 'Q1',
+      target: 'Q2',
+      weight: 7,
+    })
+  })
+
+  it('marca a entidade-foco como ego com raio maior', () => {
+    const data = toGraphData(NETWORK, 'Q1')
+    const ego = data.nodes.find((n) => n.id === 'Q1')
+    const other = data.nodes.find((n) => n.id === 'Q3')
+    expect(ego?.isEgo).toBe(true)
+    expect(other?.isEgo).toBe(false)
+    // Ego (grau 2, piso 6) > nó folha (grau 1, piso 2).
+    expect(ego?.val).toBeGreaterThan(other?.val ?? 0)
+  })
+
+  it('atribui cor por tipo (fonte única: entity-types)', () => {
+    const data = toGraphData(NETWORK, 'Q1')
+    const org = data.nodes.find((n) => n.id === 'Q1')
+    const per = data.nodes.find((n) => n.id === 'Q3')
+    expect(org?.color).toBe(entityTypeStyle('ORG').color)
+    expect(per?.color).toBe(entityTypeStyle('PER').color)
+  })
+
+  it('usa o id como nome quando canonicalName é nulo', () => {
+    const data = toGraphData(
+      {
+        nodes: [
+          {
+            entityId: 'dgb_x',
+            canonicalName: null,
+            type: null,
+            wikidataId: null,
+          },
+        ],
+        edges: [],
+      },
+      'dgb_x',
+    )
+    expect(data.nodes[0].name).toBe('dgb_x')
+    // Tipo nulo cai no estilo OTHER.
+    expect(data.nodes[0].color).toBe(entityTypeStyle('OTHER').color)
+  })
+})
+
+describe('maxEdgeWeight', () => {
+  it('retorna o maior peso', () => {
+    expect(
+      maxEdgeWeight([
+        { source: 'a', target: 'b', weight: 2 },
+        { source: 'a', target: 'c', weight: 9 },
+      ]),
+    ).toBe(9)
+  })
+
+  it('retorna 1 (piso) quando não há arestas — evita divisão por zero', () => {
+    expect(maxEdgeWeight([])).toBe(1)
+  })
+})

--- a/src/components/entities/entity-network-data.ts
+++ b/src/components/entities/entity-network-data.ts
@@ -1,0 +1,68 @@
+/**
+ * Transformação pura rede → dados do force-graph (Fase 6d).
+ *
+ * Isolada do componente de canvas (`EntityNetworkGraph.tsx`) para ser testável
+ * sem importar `react-force-graph-2d` (client-only, depende de `window`).
+ *
+ * Deduz cor por tipo (reusa `entity-types.ts`) e o raio (`val`) a partir do grau
+ * (nº de arestas incidentes); a entidade-foco (ego) ganha um piso de raio maior.
+ */
+
+import { entityTypeStyle } from '@/lib/entity-types'
+import type { EntityNetwork } from '@/services/content/types'
+
+export type GraphNode = {
+  id: string
+  name: string
+  type: string | null
+  color: string
+  isEgo: boolean
+  val: number
+}
+
+export type GraphLink = {
+  source: string
+  target: string
+  weight: number
+}
+
+export type GraphData = {
+  nodes: GraphNode[]
+  links: GraphLink[]
+}
+
+/** Converte a rede do facade em nós/links do force-graph. */
+export function toGraphData(network: EntityNetwork, egoId: string): GraphData {
+  const degree = new Map<string, number>()
+  for (const edge of network.edges) {
+    degree.set(edge.src, (degree.get(edge.src) ?? 0) + 1)
+    degree.set(edge.dst, (degree.get(edge.dst) ?? 0) + 1)
+  }
+
+  const nodes: GraphNode[] = network.nodes.map((n) => {
+    const isEgo = n.entityId === egoId
+    const deg = degree.get(n.entityId) ?? 0
+    return {
+      id: n.entityId,
+      name: n.canonicalName ?? n.entityId,
+      type: n.type,
+      color: entityTypeStyle(n.type ?? 'OTHER').color,
+      isEgo,
+      // Raio cresce com o grau (suave), com piso maior para o ego.
+      val: (isEgo ? 6 : 2) + Math.sqrt(deg),
+    }
+  })
+
+  const links: GraphLink[] = network.edges.map((e) => ({
+    source: e.src,
+    target: e.dst,
+    weight: e.weight,
+  }))
+
+  return { nodes, links }
+}
+
+/** Maior peso entre as arestas (>= 1), p/ normalizar a espessura das linhas. */
+export function maxEdgeWeight(links: GraphLink[]): number {
+  return Math.max(1, ...links.map((l) => l.weight))
+}

--- a/src/lib/entity-types.ts
+++ b/src/lib/entity-types.ts
@@ -36,6 +36,11 @@ export type EntityTypeStyle = {
    * inferior colorida. NÃO é um chip cheio — preserva o fluxo de leitura.
    */
   lens: string
+  /**
+   * Cor sólida em CSS (hex/hsl) — espelha o `dot`. Usada onde Tailwind não se
+   * aplica (ex.: nós da visualização de rede desenhados em canvas).
+   */
+  color: string
 }
 
 /**
@@ -49,36 +54,48 @@ export const ENTITY_TYPE_STYLES: Record<EntityTypeKey, EntityTypeStyle> = {
     icon: Building2,
     dot: 'bg-government-blue',
     lens: 'bg-government-blue/10 border-b-2 border-government-blue/50 hover:bg-government-blue/20',
+    // hsl(211, 100%, 32%) — government-blue
+    color: 'hsl(211, 100%, 32%)',
   },
   PER: {
     label: 'Pessoas',
     icon: User,
     dot: 'bg-government-green',
     lens: 'bg-government-green/10 border-b-2 border-government-green/50 hover:bg-government-green/20',
+    // hsl(146, 100%, 24%) — government-green
+    color: 'hsl(146, 100%, 24%)',
   },
   LOC: {
     label: 'Locais',
     icon: MapPin,
     dot: 'bg-government-yellow',
     lens: 'bg-government-yellow/15 border-b-2 border-government-yellow/60 hover:bg-government-yellow/25',
+    // hsl(44, 100%, 57%) — government-yellow
+    color: 'hsl(44, 100%, 57%)',
   },
   EVENT: {
     label: 'Eventos',
     icon: CalendarDays,
     dot: 'bg-purple-500',
     lens: 'bg-purple-500/10 border-b-2 border-purple-500/50 hover:bg-purple-500/20',
+    // tailwind purple-500
+    color: '#a855f7',
   },
   POLICY: {
     label: 'Políticas Públicas',
     icon: Landmark,
     dot: 'bg-orange-500',
     lens: 'bg-orange-500/10 border-b-2 border-orange-500/50 hover:bg-orange-500/20',
+    // tailwind orange-500
+    color: '#f97316',
   },
   OTHER: {
     label: 'Outros',
     icon: TagIcon,
     dot: 'bg-primary/40',
     lens: 'bg-primary/5 border-b-2 border-primary/30 hover:bg-primary/10',
+    // primary institucional (azul escuro), atenuado
+    color: '#6b7a90',
   },
 }
 

--- a/src/lib/graphql/queries/entities.ts
+++ b/src/lib/graphql/queries/entities.ts
@@ -1,0 +1,100 @@
+/**
+ * Operações GraphQL do grafo de entidades (Fase 6d).
+ *
+ * Alimentam a página `/entidades/[id]`:
+ *   - `relatedEntities(id, limit)`: vizinhos por co-menção (1-hop), ordenados por
+ *     peso (nº de artigos em co-menção). Origem da seção "Entidades relacionadas".
+ *   - `entityNetwork(id, depth, limit)`: ego-network (nós + arestas) da entidade,
+ *     consumida pela visualização de rede (`EntityNetwork.tsx`).
+ *
+ * IDs são `String` (scalar do schema, não `ID`). As listas e o `EntityNetwork`
+ * são non-null no retorno; o arg `id` é obrigatório, `limit`/`depth` têm default.
+ *
+ * Schema de referência: `src/lib/graphql/schema.graphql`.
+ */
+
+import { gql } from '@urql/core'
+
+// ---------- Queries ----------
+
+/**
+ * Entidades relacionadas a `id` por co-menção (1-hop), ordenadas por `weight`
+ * desc. Cada item é o nó vizinho + o peso/tipo da aresta. Roda sobre Postgres
+ * (`entity_edges`), sem dependência de Neo4j.
+ */
+export const RELATED_ENTITIES_QUERY = gql`
+  query RelatedEntities($id: String!, $limit: Int!) {
+    relatedEntities(id: $id, limit: $limit) {
+      canonicalId
+      canonicalName
+      type
+      wikidataId
+      weight
+      kind
+    }
+  }
+`
+
+/**
+ * Rede ego-centrada na entidade `id` (nós + arestas) até `depth` saltos. Usada
+ * pela visualização de rede. `depth<=2` roda via CTE recursiva em `entity_edges`.
+ */
+export const ENTITY_NETWORK_QUERY = gql`
+  query EntityNetwork($id: String!, $depth: Int!, $limit: Int!) {
+    entityNetwork(id: $id, depth: $depth, limit: $limit) {
+      nodes {
+        entityId
+        canonicalName
+        type
+        wikidataId
+      }
+      edges {
+        src
+        dst
+        weight
+        kind
+      }
+    }
+  }
+`
+
+// ---------- TypeScript shapes ----------
+
+/** Entidade relacionada (vizinho de co-menção) como vem do graphql-api. */
+export interface RelatedEntityGraphQL {
+  canonicalId: string
+  canonicalName: string | null
+  type: string | null
+  wikidataId: string | null
+  weight: number
+  kind: string
+}
+
+export interface RelatedEntitiesQueryData {
+  relatedEntities: RelatedEntityGraphQL[]
+}
+
+/** Nó da rede de entidades (camelCase, graphql-api). */
+export interface EntityNetworkNodeGraphQL {
+  entityId: string
+  canonicalName: string | null
+  type: string | null
+  wikidataId: string | null
+}
+
+/** Aresta da rede de entidades (par direcionado src→dst + peso/tipo). */
+export interface EntityNetworkEdgeGraphQL {
+  src: string
+  dst: string
+  weight: number
+  kind: string
+}
+
+export interface EntityNetworkGraphQL {
+  nodes: EntityNetworkNodeGraphQL[]
+  edges: EntityNetworkEdgeGraphQL[]
+}
+
+export interface EntityNetworkQueryData {
+  entityNetwork: EntityNetworkGraphQL
+}

--- a/src/lib/graphql/schema.graphql
+++ b/src/lib/graphql/schema.graphql
@@ -136,6 +136,34 @@ type EntityNode {
   agencyKey: String
 }
 
+type RelatedEntity {
+  canonicalId: String!
+  canonicalName: String
+  type: String
+  wikidataId: String
+  weight: Int!
+  kind: String!
+}
+
+type EntityNetworkNode {
+  entityId: String!
+  canonicalName: String
+  type: String
+  wikidataId: String
+}
+
+type EntityNetworkEdge {
+  src: String!
+  dst: String!
+  weight: Int!
+  kind: String!
+}
+
+type EntityNetwork {
+  nodes: [EntityNetworkNode!]!
+  edges: [EntityNetworkEdge!]!
+}
+
 enum ArticleSort {
   RELEVANCE
   DATE
@@ -730,6 +758,16 @@ type Query {
   Resolve uma entidade canonica pelo seu id (QID Wikidata ou dgb_<ulid>) do entity_registry. Retorna None se o id nao existe. PUBLICO.
   """
   entity(id: String!): EntityNode
+
+  """
+  Entidades relacionadas a `id` por co-mencao (1-hop), ordenadas por `weight` (numero de artigos em co-mencao) desc. Le `entity_edges` (Postgres); nao depende de Neo4j. PUBLICO.
+  """
+  relatedEntities(id: String!, limit: Int! = 12): [RelatedEntity!]!
+
+  """
+  Rede ego-centrada na entidade `id` (nos + arestas) ate `depth` saltos. `depth<=2` roda via CTE recursiva em `entity_edges`; `limit` capa o numero de nos para legibilidade. PUBLICO.
+  """
+  entityNetwork(id: String!, depth: Int! = 1, limit: Int! = 50): EntityNetwork!
 
   """
   Contagem de artigos por code de tema (nivel `level`) nos ultimos `days` dias. `label` e None (o portal mapeia pela config). PUBLICO.

--- a/src/services/content/__tests__/graphql.test.ts
+++ b/src/services/content/__tests__/graphql.test.ts
@@ -380,4 +380,98 @@ describe('createGraphQLContentService', () => {
       })
     })
   })
+
+  describe('getRelatedEntities', () => {
+    it('envia id/limit e mapeia os vizinhos', async () => {
+      const { client, queries } = makeClientStub({
+        onQuery: () => ({
+          relatedEntities: [
+            {
+              canonicalId: 'Q2',
+              canonicalName: 'MCTI',
+              type: 'ORG',
+              wikidataId: 'Q2',
+              weight: 7,
+              kind: 'co_mention',
+            },
+          ],
+        }),
+      })
+      const svc = createGraphQLContentService(client)
+      const rels = await svc.getRelatedEntities('Q1', 5)
+      expect(queries[0].query).toContain('query RelatedEntities')
+      expect(queries[0].vars).toEqual({ id: 'Q1', limit: 5 })
+      expect(rels).toEqual([
+        {
+          canonicalId: 'Q2',
+          canonicalName: 'MCTI',
+          type: 'ORG',
+          wikidataId: 'Q2',
+          weight: 7,
+          kind: 'co_mention',
+        },
+      ])
+    })
+
+    it('usa limit default 12', async () => {
+      const { client, queries } = makeClientStub({
+        onQuery: () => ({ relatedEntities: [] }),
+      })
+      const svc = createGraphQLContentService(client)
+      await svc.getRelatedEntities('Q1')
+      expect(queries[0].vars).toEqual({ id: 'Q1', limit: 12 })
+    })
+
+    it('degrada para [] em erro (grafo ainda não populado)', async () => {
+      const { client } = makeClientStub({ queryError: new Error('boom') })
+      const svc = createGraphQLContentService(client)
+      expect(await svc.getRelatedEntities('Q1')).toEqual([])
+    })
+  })
+
+  describe('getEntityNetwork', () => {
+    it('envia id/depth/limit e mapeia nós + arestas', async () => {
+      const { client, queries } = makeClientStub({
+        onQuery: () => ({
+          entityNetwork: {
+            nodes: [
+              {
+                entityId: 'Q1',
+                canonicalName: 'Finep',
+                type: 'ORG',
+                wikidataId: 'Q1',
+              },
+            ],
+            edges: [{ src: 'Q1', dst: 'Q2', weight: 3, kind: 'co_mention' }],
+          },
+        }),
+      })
+      const svc = createGraphQLContentService(client)
+      const net = await svc.getEntityNetwork('Q1', 2, 30)
+      expect(queries[0].query).toContain('query EntityNetwork')
+      expect(queries[0].vars).toEqual({ id: 'Q1', depth: 2, limit: 30 })
+      expect(net.nodes).toHaveLength(1)
+      expect(net.edges).toEqual([
+        { src: 'Q1', dst: 'Q2', weight: 3, kind: 'co_mention' },
+      ])
+    })
+
+    it('usa depth=1/limit=50 default', async () => {
+      const { client, queries } = makeClientStub({
+        onQuery: () => ({ entityNetwork: { nodes: [], edges: [] } }),
+      })
+      const svc = createGraphQLContentService(client)
+      await svc.getEntityNetwork('Q1')
+      expect(queries[0].vars).toEqual({ id: 'Q1', depth: 1, limit: 50 })
+    })
+
+    it('degrada para rede vazia em erro', async () => {
+      const { client } = makeClientStub({ queryError: new Error('boom') })
+      const svc = createGraphQLContentService(client)
+      expect(await svc.getEntityNetwork('Q1')).toEqual({
+        nodes: [],
+        edges: [],
+      })
+    })
+  })
 })

--- a/src/services/content/graphql.ts
+++ b/src/services/content/graphql.ts
@@ -38,6 +38,12 @@ import {
   THEME_ARTICLE_COUNTS_QUERY,
   type ThemeArticleCountsQueryData,
 } from '@/lib/graphql/queries/articles'
+import {
+  ENTITY_NETWORK_QUERY,
+  type EntityNetworkQueryData,
+  RELATED_ENTITIES_QUERY,
+  type RelatedEntitiesQueryData,
+} from '@/lib/graphql/queries/entities'
 import type { ArticleRow } from '@/types/article'
 import type {
   ContentService,
@@ -347,6 +353,56 @@ export function createGraphQLContentService(
         throw unwrapError(result.error, 'Erro ao estimar contagem')
       }
       return result.data?.estimateRecorteCount ?? 0
+    },
+
+    async getRelatedEntities(id: string, limit = 12) {
+      // Degrada para [] enquanto o grafo (`entity_edges`) não estiver populado:
+      // o resolver pode retornar vazio/erro — a seção "Entidades relacionadas"
+      // simplesmente não aparece. Não propagamos o erro.
+      const result = await client
+        .query<RelatedEntitiesQueryData>(RELATED_ENTITIES_QUERY, { id, limit })
+        .toPromise()
+      if (result.error) {
+        return []
+      }
+      return (result.data?.relatedEntities ?? []).map((e) => ({
+        canonicalId: e.canonicalId,
+        canonicalName: e.canonicalName ?? null,
+        type: e.type ?? null,
+        wikidataId: e.wikidataId ?? null,
+        weight: e.weight,
+        kind: e.kind,
+      }))
+    },
+
+    async getEntityNetwork(id: string, depth = 1, limit = 50) {
+      // Degrada para uma rede vazia quando o grafo não estiver disponível — a
+      // visualização não renderiza nós. Não propagamos o erro.
+      const result = await client
+        .query<EntityNetworkQueryData>(ENTITY_NETWORK_QUERY, {
+          id,
+          depth,
+          limit,
+        })
+        .toPromise()
+      if (result.error) {
+        return { nodes: [], edges: [] }
+      }
+      const network = result.data?.entityNetwork
+      return {
+        nodes: (network?.nodes ?? []).map((n) => ({
+          entityId: n.entityId,
+          canonicalName: n.canonicalName ?? null,
+          type: n.type ?? null,
+          wikidataId: n.wikidataId ?? null,
+        })),
+        edges: (network?.edges ?? []).map((e) => ({
+          src: e.src,
+          dst: e.dst,
+          weight: e.weight,
+          kind: e.kind,
+        })),
+      }
     },
   }
 }

--- a/src/services/content/types.ts
+++ b/src/services/content/types.ts
@@ -97,6 +97,44 @@ export interface EntityNode {
   agencyKey: string | null
 }
 
+/**
+ * Entidade relacionada (vizinho de co-menção, 1-hop) — alimenta a seção
+ * "Entidades relacionadas" da página `/entidades/[id]`.
+ */
+export interface RelatedEntity {
+  /** Id canônico do vizinho (`Q…`/`dgb_…`) — destino do link da página. */
+  canonicalId: string
+  canonicalName: string | null
+  type: string | null
+  wikidataId: string | null
+  /** Peso da aresta (nº de artigos em co-menção). */
+  weight: number
+  /** Tipo da aresta: `co_mention` | `subordinate_to` | `is_agency`. */
+  kind: string
+}
+
+/** Nó da rede ego-centrada (`entityNetwork`). */
+export interface EntityNetworkNode {
+  entityId: string
+  canonicalName: string | null
+  type: string | null
+  wikidataId: string | null
+}
+
+/** Aresta da rede ego-centrada (par direcionado `src`→`dst`). */
+export interface EntityNetworkEdge {
+  src: string
+  dst: string
+  weight: number
+  kind: string
+}
+
+/** Rede de entidades (nós + arestas) consumida pela visualização. */
+export interface EntityNetwork {
+  nodes: EntityNetworkNode[]
+  edges: EntityNetworkEdge[]
+}
+
 export interface EstimateRecorteCountArgs {
   themes: string[]
   agencies: string[]
@@ -146,4 +184,20 @@ export interface ContentService {
 
   /** Estima a contagem de artigos para um recorte. */
   estimateRecorteCount(args: EstimateRecorteCountArgs): Promise<number>
+
+  /**
+   * Entidades relacionadas (co-menção, 1-hop) a uma entidade canônica, por peso.
+   * Degrada para `[]` enquanto o grafo (`entity_edges`) não estiver populado.
+   */
+  getRelatedEntities(id: string, limit?: number): Promise<RelatedEntity[]>
+
+  /**
+   * Rede ego-centrada (nós + arestas) de uma entidade canônica, até `depth`
+   * saltos. Degrada para uma rede vazia quando o grafo não estiver disponível.
+   */
+  getEntityNetwork(
+    id: string,
+    depth?: number,
+    limit?: number,
+  ): Promise<EntityNetwork>
 }


### PR DESCRIPTION
## Fase 6d — UI do grafo de entidades

Parte da **Fase 6** (projeção em grafo). Base = \`development\` (R1). Consome \`relatedEntities\`/\`entityNetwork\` (graphql-api Fase 6c).

### O que entra
- **Seção "Entidades relacionadas"** em \`/entidades/[id]\` — chips \`Link\` p/ \`/entidades/{canonicalId}\`, cor/ícone por tipo, peso visível; escondida se vazia.
- **\`EntityNetwork\`** — visualização de rede ego-centrada: **toggle default OFF** (query só dispara ao ligar), canvas \`react-force-graph-2d\` via \`next/dynamic\` (ssr:false), cor por tipo, ego destacado, espessura ∝ peso, clique navega.
- ops GraphQL + service degradável + snapshot SDL atualizado.

### Verificação
- **drift gate / codegen** ✓; **vitest 549/549** (+18 novos); typecheck dos arquivos tocados ✓; biome ✓.
- Pendente (gate de browser, pós-deploy do graphql-api): **Playwright \`e2e/graphql\` serial** contra o ambiente novo.

### Dependência
- graphql-api Fase 6c deployado + grafo populado (DAG project_entity_graph). Sem dados, as seções ficam ocultas (degradação graciosa).

🤖 Generated with [Claude Code](https://claude.com/claude-code)