### PR TITLE
feature: seção Entidades em Alta na homepage /noticias

### DIFF
--- a/e2e/graphql/public-content.spec.ts
+++ b/e2e/graphql/public-content.spec.ts
@@ -323,4 +323,51 @@ test.describe('Conteúdo público via GraphQL', () => {
       `órgão "${agency.code}" (${agency.label}) deveria listar artigos`,
     ).toBeGreaterThan(0)
   })
+
+  test('/noticias exibe seção "Entidades em Alta" quando há dados de trending', async ({
+    page,
+  }) => {
+    // Verificar se o graphql-api já tem dados de entity_trending_scores.
+    // A seção não renderiza quando a lista está vazia — isso é esperado enquanto
+    // o DAG `compute_entity_trending` não tiver rodado após a migration 025.
+    type TrendingData = { trendingEntities: Array<{ entityId: string }> }
+    let hasTrendingData = false
+    try {
+      const data = await publicGraphQL<TrendingData>(
+        /* GraphQL */ `query { trendingEntities(limit: 1) { entityId } }`,
+      )
+      hasTrendingData = (data.trendingEntities?.length ?? 0) > 0
+    } catch {
+      // graphql-api pode não ter o resolver ainda (PR 2 pendente)
+      hasTrendingData = false
+    }
+
+    await page.goto('/noticias')
+    await page.waitForLoadState('networkidle')
+
+    if (!hasTrendingData) {
+      // Sem dados ainda — seção não deve aparecer (fallback gracioso)
+      await expect(
+        page.getByTestId('trending-entities-section'),
+      ).not.toBeVisible()
+      return
+    }
+
+    // Com dados — seção e ao menos 1 card devem estar visíveis
+    const section = page.getByTestId('trending-entities-section')
+    await expect(section).toBeVisible({ timeout: 20_000 })
+
+    const entityCards = page.getByTestId('trending-entity-card')
+    expect(
+      await entityCards.count(),
+      'deve haver ao menos 1 card de entidade em alta',
+    ).toBeGreaterThan(0)
+
+    // Card deve linkar para /entidades/[id]
+    const firstLink = entityCards.first().locator('..').or(entityCards.first())
+    const href = await firstLink.getAttribute('href')
+    expect(href ?? '', 'link do card deve apontar para /entidades/').toMatch(
+      /\/entidades\//,
+    )
+  })
 })

--- a/src/app/(public)/actions.ts
+++ b/src/app/(public)/actions.ts
@@ -202,3 +202,16 @@ const fetchLatestByThemes = cache(
 
 // Public API with Result wrapper
 export const getLatestByThemes = withResult(fetchLatestByThemes)
+
+// Internal function for fetching trending entities
+const fetchTrendingEntities = cache(async (limit = 6) => {
+  try {
+    return await content().getTrendingEntities(limit)
+  } catch (error) {
+    console.error('[getTrendingEntities] Error:', error)
+    return []
+  }
+})
+
+// Public API with Result wrapper
+export const getTrendingEntities = withResult(fetchTrendingEntities)

--- a/src/app/(public)/noticias/page.tsx
+++ b/src/app/(public)/noticias/page.tsx
@@ -1,6 +1,7 @@
 import { ArrowRight } from 'lucide-react'
 import Link from 'next/link'
 import NewsCard from '@/components/articles/NewsCard'
+import { TrendingEntitiesSection } from '@/components/entities/TrendingEntitiesSection'
 import { Button } from '@/components/ui/button'
 import THEME_ICONS from '@/data/themes'
 import { formatDateTime } from '@/lib/utils'
@@ -11,6 +12,7 @@ import {
   getLatestArticles,
   getLatestByThemes,
   getThemes,
+  getTrendingEntities,
 } from '../actions'
 
 // Revalidate every 10 minutes (600 seconds)
@@ -18,13 +20,19 @@ export const revalidate = 600
 
 export default async function Home() {
   // ===== Fetch principal =====
-  const [latestNewsResult, themesResult, newsThisMonth, totalNews] =
-    await Promise.all([
-      getLatestArticles(),
-      getThemes(),
-      countMonthlyNews(),
-      countTotalNews(),
-    ])
+  const [
+    latestNewsResult,
+    themesResult,
+    _newsThisMonth,
+    _totalNews,
+    trendingEntitiesResult,
+  ] = await Promise.all([
+    getLatestArticles(),
+    getThemes(),
+    countMonthlyNews(),
+    countTotalNews(),
+    getTrendingEntities(6),
+  ])
 
   if (themesResult.type !== 'ok') return <div>Erro ao carregar os temas.</div>
   if (latestNewsResult.type !== 'ok')
@@ -111,7 +119,12 @@ export default async function Home() {
         </div>
       </section>
 
-      {/* 2️⃣ ÚLTIMAS NOTÍCIAS — grade */}
+      {/* 2️⃣ ENTIDADES EM ALTA — top NER trending */}
+      {trendingEntitiesResult.type === 'ok' && (
+        <TrendingEntitiesSection entities={trendingEntitiesResult.data} />
+      )}
+
+      {/* 3️⃣ ÚLTIMAS NOTÍCIAS — grade */}
       <section className="py-12">
         <div className="container mx-auto px-4">
           <div className="flex items-center justify-between mb-8">
@@ -153,7 +166,7 @@ export default async function Home() {
         </div>
       </section>
 
-      {/* 3️⃣ TEMAS EM FOCO — 3 blocos com 2 notícias cada */}
+      {/* 4️⃣ TEMAS EM FOCO — 3 blocos com 2 notícias cada */}
       <section className="py-12 bg-muted/50">
         <div className="container mx-auto px-4">
           <div className="flex items-center justify-between mb-8">
@@ -261,7 +274,7 @@ export default async function Home() {
         </div>
       </section>
 
-      {/* 4️⃣ TRANSPARÊNCIA / DADOS PÚBLICOS — 3 cards verticais com SVG de fundo */}
+      {/* 5️⃣ TRANSPARÊNCIA / DADOS PÚBLICOS — 3 cards verticais com SVG de fundo */}
       <section className="py-12">
         <div className="container mx-auto px-4">
           <div className="flex items-start mb-8">

--- a/src/components/entities/TrendingEntitiesSection.tsx
+++ b/src/components/entities/TrendingEntitiesSection.tsx
@@ -1,0 +1,98 @@
+import Link from 'next/link'
+import { entityTypeStyle } from '@/lib/entity-types'
+import type { TrendingEntity } from '@/services/content/types'
+
+function GrowthBadge({ volumeRatio }: { volumeRatio: number }) {
+  const label = `↑${volumeRatio.toFixed(1)}×`
+  return (
+    <span className="inline-flex items-center rounded-full bg-green-100 px-2 py-0.5 text-xs font-semibold text-green-800">
+      {label}
+    </span>
+  )
+}
+
+function TrendingEntityCard({ entity }: { entity: TrendingEntity }) {
+  const style = entityTypeStyle(entity.type)
+  const Icon = style.icon
+
+  return (
+    <Link
+      href={`/entidades/${entity.entityId}`}
+      className="
+        group relative rounded-xl border bg-card p-5 flex flex-col gap-3
+        overflow-hidden transition-all duration-300 hover:shadow-lg hover:-translate-y-[2px]
+      "
+      data-testid="trending-entity-card"
+    >
+      <div className="flex items-start justify-between gap-2">
+        <div className="flex items-center gap-2 min-w-0">
+          <span
+            className="flex-shrink-0 flex h-7 w-7 items-center justify-center rounded-md"
+            style={{ backgroundColor: `${style.color}20`, color: style.color }}
+          >
+            <Icon className="h-4 w-4" />
+          </span>
+          <span className="text-xs font-medium text-muted-foreground truncate">
+            {style.label}
+          </span>
+        </div>
+        <GrowthBadge volumeRatio={entity.volumeRatio} />
+      </div>
+
+      <p className="font-semibold text-sm leading-snug text-foreground group-hover:text-primary transition-colors line-clamp-2">
+        {entity.canonicalName}
+      </p>
+
+      <p className="text-xs text-muted-foreground mt-auto">
+        {entity.windowCount} {entity.windowCount === 1 ? 'artigo' : 'artigos'}{' '}
+        esta semana
+      </p>
+    </Link>
+  )
+}
+
+export function TrendingEntitiesSection({
+  entities,
+}: {
+  entities: TrendingEntity[]
+}) {
+  if (entities.length === 0) return null
+
+  return (
+    <section
+      className="py-12 bg-muted/30"
+      data-testid="trending-entities-section"
+    >
+      <div className="container mx-auto px-4">
+        <div className="flex items-center justify-between mb-8">
+          <div className="flex items-start">
+            <img
+              src="/vertical-ribbon.svg"
+              alt="decorativo"
+              className="w-2 h-14 mr-4 mt-1"
+            />
+            <div>
+              <h2 className="text-2xl font-bold">Entidades em Alta</h2>
+              <p className="text-sm text-muted-foreground mt-1">
+                Organizações e pessoas com maior crescimento de cobertura nos
+                últimos 7 dias.
+              </p>
+            </div>
+          </div>
+          <Link
+            href="/entidades"
+            className="text-sm text-primary hover:underline whitespace-nowrap"
+          >
+            Ver todas
+          </Link>
+        </div>
+
+        <div className="grid grid-cols-2 md:grid-cols-3 gap-4">
+          {entities.map((entity) => (
+            <TrendingEntityCard key={entity.entityId} entity={entity} />
+          ))}
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/src/lib/graphql/queries/entities.ts
+++ b/src/lib/graphql/queries/entities.ts
@@ -98,3 +98,36 @@ export interface EntityNetworkGraphQL {
 export interface EntityNetworkQueryData {
   entityNetwork: EntityNetworkGraphQL
 }
+
+/**
+ * Top entidades NER com maior crescimento de cobertura (pré-computado pelo DAG
+ * `compute_entity_trending`). Lê `entity_trending_scores` ordenado por score DESC.
+ */
+export const TRENDING_ENTITIES_QUERY = gql`
+  query TrendingEntities($limit: Int) {
+    trendingEntities(limit: $limit) {
+      entityId
+      canonicalName
+      type
+      trendingScore
+      volumeRatio
+      windowCount
+      computedAt
+    }
+  }
+`
+
+/** Entidade em alta como vem do graphql-api. */
+export interface TrendingEntityGraphQL {
+  entityId: string
+  canonicalName: string | null
+  type: string | null
+  trendingScore: number
+  volumeRatio: number
+  windowCount: number
+  computedAt: string | null
+}
+
+export interface TrendingEntitiesQueryData {
+  trendingEntities: TrendingEntityGraphQL[]
+}

--- a/src/lib/graphql/schema.graphql
+++ b/src/lib/graphql/schema.graphql
@@ -164,6 +164,17 @@ type EntityNetwork {
   edges: [EntityNetworkEdge!]!
 }
 
+type TrendingEntityResult {
+  entityId: String!
+  canonicalName: String!
+  type: String!
+  trendingScore: Float!
+  volumeRatio: Float!
+  windowCount: Int!
+  windowAgencies: Int!
+  computedAt: String
+}
+
 enum ArticleSort {
   RELEVANCE
   DATE
@@ -788,6 +799,11 @@ type Query {
     keywords: [String!]!
     sinceHours: Int! = 24
   ): Int!
+
+  """
+  Entidades NER com maior crescimento de cobertura (pre-computado pelo DAG compute_entity_trending). Le entity_trending_scores ordenado por score DESC. PUBLICO.
+  """
+  trendingEntities(limit: Int! = 10): [TrendingEntityResult!]!
 }
 
 type Recorte {

--- a/src/services/content/graphql.ts
+++ b/src/services/content/graphql.ts
@@ -43,6 +43,8 @@ import {
   type EntityNetworkQueryData,
   RELATED_ENTITIES_QUERY,
   type RelatedEntitiesQueryData,
+  TRENDING_ENTITIES_QUERY,
+  type TrendingEntitiesQueryData,
 } from '@/lib/graphql/queries/entities'
 import type { ArticleRow } from '@/types/article'
 import type {
@@ -403,6 +405,24 @@ export function createGraphQLContentService(
           kind: e.kind,
         })),
       }
+    },
+
+    async getTrendingEntities(limit = 6) {
+      // Degrada para [] enquanto entity_trending_scores não existir / DAG não rodou.
+      const result = await client
+        .query<TrendingEntitiesQueryData>(TRENDING_ENTITIES_QUERY, { limit })
+        .toPromise()
+      if (result.error) {
+        return []
+      }
+      return (result.data?.trendingEntities ?? []).map((e) => ({
+        entityId: e.entityId,
+        canonicalName: e.canonicalName ?? '',
+        type: e.type ?? '',
+        trendingScore: e.trendingScore,
+        volumeRatio: e.volumeRatio,
+        windowCount: e.windowCount,
+      }))
     },
   }
 }

--- a/src/services/content/types.ts
+++ b/src/services/content/types.ts
@@ -135,6 +135,18 @@ export interface EntityNetwork {
   edges: EntityNetworkEdge[]
 }
 
+/** Entidade NER em alta — alimenta a seção "Entidades em Alta" da homepage. */
+export interface TrendingEntity {
+  entityId: string
+  canonicalName: string
+  type: string
+  trendingScore: number
+  /** Multiplicador de volume: window_daily / baseline_daily. Ex: 3.2 → "↑3.2×" */
+  volumeRatio: number
+  /** Artigos na janela de 7 dias. */
+  windowCount: number
+}
+
 export interface EstimateRecorteCountArgs {
   themes: string[]
   agencies: string[]
@@ -200,4 +212,11 @@ export interface ContentService {
     depth?: number,
     limit?: number,
   ): Promise<EntityNetwork>
+
+  /**
+   * Top entidades NER com maior crescimento de cobertura (pré-computado). Lê
+   * `entity_trending_scores` via graphql-api. Degrada para `[]` enquanto a
+   * tabela não existir / o DAG não tiver rodado ainda.
+   */
+  getTrendingEntities(limit?: number): Promise<TrendingEntity[]>
 }


### PR DESCRIPTION
## Summary
- Novo componente `TrendingEntitiesSection` — grid 2×3 de cards com badge de crescimento (↑N×), ícone por tipo de entidade, link para `/entidades/[id]`
- `TRENDING_ENTITIES_QUERY` + tipos TypeScript em `src/lib/graphql/queries/entities.ts`
- Interface `TrendingEntity` e método `getTrendingEntities()` no `ContentService`
- Implementação em `graphql.ts` com fallback gracioso para `[]` quando o resolver falha
- Server action `getTrendingEntities` em `src/app/(public)/actions.ts` com React cache
- Seção inserida após hero (antes de "Últimas notícias") em `noticias/page.tsx`
- Teste E2E adicionado em `public-content.spec.ts`: skip automático quando `entity_trending_scores` está vazio (durante rollout), asserta presença da seção quando há dados

## Dependências
- **PR 1 (data-platform)**: migration 025 + DAG `compute_entity_trending` (tabela `entity_trending_scores`)
- **PR 2 (graphql-api)**: resolver `trendingEntities` + tipo `TrendingEntityResult`
- Enquanto esses dois PRs não estiverem em produção, a seção não renderiza (fallback gracioso)

## Test plan
- [ ] `pnpm tsc --noEmit` — sem erros nos arquivos modificados
- [ ] `pnpm lint` — sem erros nos arquivos modificados
- [ ] Após merge de data-platform + graphql-api: `pnpm e2e:staging` → `public-content.spec.ts` deve passar
- [ ] Visitar staging `/noticias` e confirmar seção "Entidades em Alta" visível com cards e badge ↑N×

## Notas
- Branch base: `development` (não `main`) — regra R1
- E2E tem skip automático enquanto `entity_trending_scores` estiver vazia

🤖 Generated with [Claude Code](https://claude.com/claude-code)