### PR TITLE
fix: página /entidades mostra artigos via Postgres (sem Typesense)

### DIFF
--- a/src/app/(public)/entidades/[slug]/actions.ts
+++ b/src/app/(public)/entidades/[slug]/actions.ts
@@ -85,30 +85,33 @@ export type GetEntityArticlesResult = {
 }
 
 /**
- * Lista paginada de artigos que mencionam a entidade. Reutiliza a busca
- * (`search`) filter-only (dedup por content_hash, sem busca semântica).
+ * Lista paginada de artigos que mencionam a entidade.
  *
- * - **Canônico** (`canonicalId`): filtra por `filter.entityCanonical=[id]` —
- *   dedup'd por `entity_id`, robusto a variantes de texto.
- * - **Legado** (texto): filtra por `filter.entities=[texto]` (migração graciosa).
+ * - **Canônico** (`canonicalId`): usa `entityArticles` (Postgres direto via
+ *   `news_entities`) — não depende do campo `entityCanonical` no Typesense.
+ * - **Legado** (texto): filtra por `filter.entities=[texto]` via Typesense.
  */
 export async function getEntityArticles(
   args: GetEntityArticlesArgs,
 ): Promise<GetEntityArticlesResult> {
   const { entity, canonicalId, page } = args
 
+  if (canonicalId) {
+    const result = await content().getArticlesByEntity(canonicalId, page)
+    return {
+      articles: result.articles,
+      page: page + 1,
+      found: result.found,
+    }
+  }
+
   const result = await content().searchArticles({
-    // Busca filter-only por entidade: o resolver `search` do graphql-api
-    // rejeita query vazia ("Query must not be empty"). `'*'` é o wildcard
-    // filter-only aceito (convenção já usada em outros call-sites).
     query: '*',
     page,
     semantic: false,
     dedup: true,
     sort: 'DATE',
-    filter: canonicalId
-      ? { entityCanonical: [canonicalId] }
-      : { entities: [entity] },
+    filter: { entities: [entity] },
   })
 
   return {

--- a/src/lib/graphql/queries/entities.ts
+++ b/src/lib/graphql/queries/entities.ts
@@ -100,6 +100,48 @@ export interface EntityNetworkQueryData {
 }
 
 /**
+ * Artigos de uma entidade canônica via Postgres (`news_entities` → `news`).
+ * Não depende do campo `entityCanonical` no Typesense — funciona sem reprocessamento.
+ */
+export const ENTITY_ARTICLES_QUERY = gql`
+  query EntityArticles($entityId: String!, $page: Int, $limit: Int) {
+    entityArticles(entityId: $entityId, page: $page, limit: $limit) {
+      articles {
+        uniqueId
+        title
+        url
+        image
+        videoUrl
+        agency
+        agencyName
+        publishedAt
+        extractedAt
+        theme1Level1Code
+        theme1Level1Label
+        theme1Level2Code
+        theme1Level2Label
+        theme1Level3Code
+        theme1Level3Label
+        mostSpecificThemeCode
+        mostSpecificThemeLabel
+      }
+      found
+      page
+    }
+  }
+`
+
+export interface EntityArticlesGraphQL {
+  articles: import('./articles').ArticleGraphQL[]
+  found: number
+  page: number
+}
+
+export interface EntityArticlesQueryData {
+  entityArticles: EntityArticlesGraphQL
+}
+
+/**
  * Top entidades NER com maior crescimento de cobertura (pré-computado pelo DAG
  * `compute_entity_trending`). Lê `entity_trending_scores` ordenado por score DESC.
  */

--- a/src/lib/graphql/schema.graphql
+++ b/src/lib/graphql/schema.graphql
@@ -3,6 +3,19 @@ type Agency {
   label: String!
 }
 
+type AgencyPeriodMetrics {
+  period: String!
+  agencyKey: String!
+  agencyName: String
+  articleCount: Int!
+  avgSentimentScore: Float
+  pctPositive: Float
+  pctNegative: Float
+  avgReadabilityFlesch: Float
+  avgWordCount: Float
+  topThemes: [ThemeStats!]!
+}
+
 """
 Agency statistics with article count
 """
@@ -89,6 +102,10 @@ type Article {
   theme1Level3Label: String
   mostSpecificThemeCode: String
   mostSpecificThemeLabel: String
+
+  """
+  Features computadas da notícia (entidades, popularidade/trending, leitura/legibilidade). Carregado sob demanda do Postgres (news_features) por unique_id via DataLoader; None quando não há features. Não onera listas/busca que não selecionam este campo.
+  """
   features: ArticleFeatures
 }
 
@@ -102,86 +119,6 @@ type ArticleFeatures {
   readabilityFlesch: Float
 }
 
-type ContentAnnotation {
-  start: Int!
-  end: Int!
-  type: String!
-  text: String!
-  canonicalId: String
-}
-
-type EntityType {
-  text: String!
-  type: String!
-  count: Int!
-  canonicalId: String
-  salience: Float
-}
-
-type EntityFacet {
-  value: String!
-  count: Int!
-  entityId: String
-  label: String
-}
-
-type EntityNode {
-  entityId: String!
-  canonicalName: String
-  type: String
-  aliases: [String!]!
-  wikidataId: String
-  wikidataUrl: String
-  description: String
-  agencyKey: String
-}
-
-type RelatedEntity {
-  canonicalId: String!
-  canonicalName: String
-  type: String
-  wikidataId: String
-  weight: Int!
-  kind: String!
-}
-
-type EntityNetworkNode {
-  entityId: String!
-  canonicalName: String
-  type: String
-  wikidataId: String
-}
-
-type EntityNetworkEdge {
-  src: String!
-  dst: String!
-  weight: Int!
-  kind: String!
-}
-
-type EntityNetwork {
-  nodes: [EntityNetworkNode!]!
-  edges: [EntityNetworkEdge!]!
-}
-
-type TrendingEntityResult {
-  entityId: String!
-  canonicalName: String!
-  type: String!
-  trendingScore: Float!
-  volumeRatio: Float!
-  windowCount: Int!
-  windowAgencies: Int!
-  computedAt: String
-}
-
-enum ArticleSort {
-  RELEVANCE
-  DATE
-  TRENDING
-  VIEWS
-}
-
 input ArticleFilter {
   agencies: [String!] = null
   themes: [String!] = null
@@ -193,6 +130,21 @@ input ArticleFilter {
   entities: [String!] = null
   sentiment: [String!] = null
   entityCanonical: [String!] = null
+}
+
+enum ArticleSort {
+  RELEVANCE
+  DATE
+  TRENDING
+  VIEWS
+}
+
+type ArticleSummary {
+  uniqueId: String!
+  title: String!
+  agencyName: String
+  publishedAt: String
+  trendingScore: Float
 }
 
 type ArticlesResult {
@@ -292,6 +244,14 @@ input ClippingInput {
   deliveryChannels: DeliveryChannelsInput = null
 }
 
+type ContentAnnotation {
+  start: Int!
+  end: Int!
+  type: String!
+  text: String!
+  canonicalId: String
+}
+
 """
 Daily article count
 """
@@ -326,6 +286,82 @@ input DeliveryChannelsInput {
   webhook: Boolean! = false
 }
 
+type EntityCoveragePoint {
+  period: String!
+  agencyKey: String!
+  agencyName: String
+  articleCount: Int!
+  totalMentions: Int!
+  avgSentimentScore: Float
+}
+
+type EntityFacet {
+  value: String!
+  count: Int!
+  entityId: String
+  label: String
+}
+
+enum EntityKind {
+  ORG
+  PER
+  LOC
+  EVENT
+  POLICY
+  LAW
+}
+
+type EntityNetwork {
+  nodes: [EntityNetworkNode!]!
+  edges: [EntityNetworkEdge!]!
+}
+
+type EntityNetworkEdge {
+  src: String!
+  dst: String!
+  weight: Int!
+  kind: String!
+}
+
+type EntityNetworkNode {
+  entityId: String!
+  canonicalName: String
+  type: String
+  wikidataId: String
+}
+
+type EntityNode {
+  entityId: String!
+  canonicalName: String
+  type: String
+  aliases: [String!]!
+  wikidataId: String
+  wikidataUrl: String
+  description: String
+  agencyKey: String
+}
+
+type EntitySearchResult {
+  entityId: String!
+  canonicalName: String!
+  type: String!
+  description: String
+  wikidataUrl: String
+  agencyKey: String
+  aliases: [String!]!
+  articleCount: Int!
+  confidence: Float!
+  matchType: String!
+}
+
+type EntityType {
+  text: String!
+  type: String!
+  count: Int!
+  canonicalId: String
+  salience: Float
+}
+
 type EstimateResult {
   totalEstimate: Int!
 }
@@ -355,6 +391,12 @@ type FollowedListing {
   extraEmails: [String!]!
   webhookUrl: String
   followedAt: DateTime
+}
+
+enum Granularity {
+  DAY
+  WEEK
+  MONTH
 }
 
 type IntegrityCandidateType {
@@ -409,6 +451,13 @@ type MarketplaceRecorte {
   themes: [String!]!
   agencies: [String!]!
   keywords: [String!]!
+}
+
+enum MetricType {
+  VOLUME
+  SENTIMENT
+  READABILITY
+  THEMES
 }
 
 type Mutation {
@@ -578,7 +627,7 @@ type Query {
   ping: String!
 
   """
-  Lista artigos com filtros e paginação
+  Lista artigos com filtros, paginação e ordenação
   """
   articles(
     page: Int! = 1
@@ -644,6 +693,29 @@ type Query {
   Daily article counts for the given date range
   """
   articlesTimeline(range: DateRange!): [DailyCount!]!
+
+  """
+  Métricas de publicação por agência e período
+  """
+  agencyAnalytics(
+    agencies: [String!]!
+    dateFrom: String!
+    dateTo: String!
+    granularity: Granularity! = MONTH
+    metrics: [MetricType!] = null
+  ): [AgencyPeriodMetrics!]!
+
+  """
+  Temas em crescimento comparando janela recente com baseline histórico
+  """
+  trendingThemes(
+    windowDays: Int! = 7
+    baselineDays: Int! = 28
+    minArticles: Int! = 3
+    growthThreshold: Float! = 1.5
+    agencyKey: String = null
+    limit: Int! = 10
+  ): [TrendingThemeResult!]!
 
   """
   Lista todos os clippings do usuario autenticado (autorados + inscritos)
@@ -752,12 +824,12 @@ type Query {
   integrityBatch(batchSize: Int! = 50): [IntegrityCandidateType!]!
 
   """
-  Artigos relacionados a `uniqueId`, baseados no theme-code (Typesense). Replica a logica do portal: usa most_specific_theme_code quando presente, senao theme_1_level_1_code; exclui o proprio artigo; ordena por publishedAt desc; deduplica por content_hash. PUBLICO. (Distinto do `similarArticles` interno, baseado em embedding postgres.)
+  Artigos relacionados a `uniqueId` por similaridade semântica (embedding pgvector via news.content_embedding). O SQL exclui o próprio artigo, aplica threshold de similaridade e ordena por similaridade desc; os vizinhos são hidratados do índice Typesense preservando essa ordem. Retorna [] se o artigo não tiver embedding ou vizinhos. PÚBLICO. (Distinto do `similarArticles` interno, que devolve apenas unique_id/score.)
   """
   relatedArticles(uniqueId: String!, limit: Int! = 4): [Article!]!
 
   """
-  Sugestoes de entidades (facet) para o filtro de busca e as paginas de entidade. `type` (ORG/PER/LOC) restringe ao campo tipado; ausente usa o campo combinado. `query` filtra por prefixo. PUBLICO.
+  Sugestões de entidades (facet) para o filtro de busca e as páginas de entidade. `type` (ORG/PER/LOC/EVENT/POLICY) restringe ao campo tipado; ausente usa o campo combinado `entities`. `type: CANONICAL` ativa o modo canônico: faceta `entity_canonical` e retorna `{value/entityId = canonical_id, label = canonical_name, count}` (label resolvido do entity_registry; None se ausente). `query` filtra por prefixo. Ordenado por nº de artigos desc. PÚBLICO.
   """
   entitySuggestions(
     query: String! = ""
@@ -766,17 +838,17 @@ type Query {
   ): [EntityFacet!]!
 
   """
-  Resolve uma entidade canonica pelo seu id (QID Wikidata ou dgb_<ulid>) do entity_registry. Retorna None se o id nao existe. PUBLICO.
+  Entidade canônica do entity_registry por `id` (entity_id: QID Wikidata 'Q216330' ou 'dgb_<ulid>'). None quando não existe. PÚBLICO.
   """
   entity(id: String!): EntityNode
 
   """
-  Entidades relacionadas a `id` por co-mencao (1-hop), ordenadas por `weight` (numero de artigos em co-mencao) desc. Le `entity_edges` (Postgres); nao depende de Neo4j. PUBLICO.
+  Entidades relacionadas a `id` (entity_id) por co-menção (Fase 6c). Lê a rede de co-menção materializada (`entity_edges`, 1-hop), retorna os vizinhos hidratados do entity_registry, ordenados por `weight` (nº de artigos em co-menção) desc, até `limit`. Retorna [] sem Postgres ou sem vizinhos. PÚBLICO.
   """
   relatedEntities(id: String!, limit: Int! = 12): [RelatedEntity!]!
 
   """
-  Rede ego-centrada na entidade `id` (nos + arestas) ate `depth` saltos. `depth<=2` roda via CTE recursiva em `entity_edges`; `limit` capa o numero de nos para legibilidade. PUBLICO.
+  Ego-network (nós + arestas) ao redor de `id` (entity_id) para a visualização de rede (Fase 6c). Travessia não-direcionada na rede de co-menção (`entity_edges`) via CTE recursiva até `depth` saltos (CLAMPado a no máx 2; profundidades maiores ficam para o Neo4j futuro). `limit` limita o nº de arestas (cap de tamanho do grafo). Retorna {nodes:[], edges:[]} sem Postgres. PÚBLICO.
   """
   entityNetwork(id: String!, depth: Int! = 1, limit: Int! = 50): EntityNetwork!
 
@@ -801,7 +873,35 @@ type Query {
   ): Int!
 
   """
-  Entidades NER com maior crescimento de cobertura (pre-computado pelo DAG compute_entity_trending). Le entity_trending_scores ordenado por score DESC. PUBLICO.
+  Série temporal de cobertura de uma entidade por agência
+  """
+  entityCoverage(
+    entityId: String!
+    dateFrom: String = null
+    dateTo: String = null
+    granularity: Granularity! = MONTH
+  ): [EntityCoveragePoint!]!
+
+  """
+  Busca fuzzy de entidades por nome ou alias
+  """
+  entitySearch(
+    query: String!
+    entityType: EntityKind = null
+    limit: Int! = 5
+  ): [EntitySearchResult!]!
+
+  """
+  Artigos de uma entidade canônica via news_entities (Postgres direto). Não depende do campo entityCanonical no Typesense.
+  """
+  entityArticles(
+    entityId: String!
+    page: Int! = 1
+    limit: Int! = 10
+  ): ArticlesResult!
+
+  """
+  Entidades NER com maior crescimento de cobertura (pré-computado)
   """
   trendingEntities(limit: Int! = 10): [TrendingEntityResult!]!
 }
@@ -819,6 +919,15 @@ input RecorteInput {
   themes: [String!]! = []
   agencies: [String!]! = []
   keywords: [String!]! = []
+}
+
+type RelatedEntity {
+  canonicalId: String!
+  canonicalName: String
+  type: String
+  wikidataId: String
+  weight: Int!
+  kind: String!
 }
 
 type Release {
@@ -887,6 +996,26 @@ Theme statistics with article count
 type ThemeStats {
   label: String!
   count: Int!
+}
+
+type TrendingEntityResult {
+  entityId: String!
+  canonicalName: String!
+  type: String!
+  trendingScore: Float!
+  volumeRatio: Float!
+  windowCount: Int!
+  windowAgencies: Int!
+  computedAt: String
+}
+
+type TrendingThemeResult {
+  themeLabel: String!
+  themeCode: String
+  windowCount: Int!
+  baselineDailyAvg: Float!
+  growthScore: Float!
+  topArticles: [ArticleSummary!]!
 }
 
 type TypesenseDocRecordType {

--- a/src/services/content/graphql.ts
+++ b/src/services/content/graphql.ts
@@ -39,7 +39,9 @@ import {
   type ThemeArticleCountsQueryData,
 } from '@/lib/graphql/queries/articles'
 import {
+  ENTITY_ARTICLES_QUERY,
   ENTITY_NETWORK_QUERY,
+  type EntityArticlesQueryData,
   type EntityNetworkQueryData,
   RELATED_ENTITIES_QUERY,
   type RelatedEntitiesQueryData,
@@ -423,6 +425,25 @@ export function createGraphQLContentService(
         volumeRatio: e.volumeRatio,
         windowCount: e.windowCount,
       }))
+    },
+
+    async getArticlesByEntity(entityId: string, page = 1, limit = 10) {
+      const result = await client
+        .query<EntityArticlesQueryData>(ENTITY_ARTICLES_QUERY, {
+          entityId,
+          page,
+          limit,
+        })
+        .toPromise()
+      if (result.error) {
+        throw unwrapError(result.error, 'Erro ao carregar artigos da entidade')
+      }
+      const data = result.data?.entityArticles
+      return {
+        articles: (data?.articles ?? []).map(mapGraphqlArticleToRow),
+        found: data?.found ?? 0,
+        page: data?.page ?? page,
+      }
     },
   }
 }

--- a/src/services/content/types.ts
+++ b/src/services/content/types.ts
@@ -219,4 +219,14 @@ export interface ContentService {
    * tabela não existir / o DAG não tiver rodado ainda.
    */
   getTrendingEntities(limit?: number): Promise<TrendingEntity[]>
+
+  /**
+   * Artigos de uma entidade canônica via Postgres (`news_entities`). Não depende
+   * do campo `entityCanonical` no Typesense — funciona sem reprocessamento.
+   */
+  getArticlesByEntity(
+    entityId: string,
+    page?: number,
+    limit?: number,
+  ): Promise<SearchArticlesResult>
 }


### PR DESCRIPTION
## Problema

As páginas `/entidades/Q5933752` e `/entidades/dgb_ministerio-publico-do-estado-de-pernambuco-mppe` (e qualquer entidade canônica) mostravam "nenhuma notícia encontrada". Causa raiz: `getEntityArticles` filtrava por `filter.entityCanonical` no Typesense, mas o campo `entity_canonical` dos documentos ainda não foi populado (reprocessamento pendente, bloqueado em infra#198).

## Solução

Novo caminho Postgres direto para o case canônico, sem alterar o legado fuzzy-texto:

1. **graphql-api#22**: novo resolver `entityArticles(entityId, page, limit)` — JOIN `news_entities → news` no Postgres, sem tocar no Typesense
2. **Este PR**: portal usa `getArticlesByEntity()` (Postgres) quando `canonicalId` está presente; legado via `filter.entities` no Typesense permanece inalterado

## Mudanças

| Arquivo | Mudança |
|---------|---------|
| `queries/entities.ts` | `ENTITY_ARTICLES_QUERY` + interfaces TS |
| `services/content/types.ts` | `getArticlesByEntity(entityId, page?, limit?)` |
| `services/content/graphql.ts` | Implementação `getArticlesByEntity` |
| `actions.ts` | `getEntityArticles` usa Postgres quando `canonicalId` presente |
| `schema.graphql` | SDL snapshot atualizado (entityArticles) |

## Dependência

Requer graphql-api#22 em produção (staging já está pendente) antes de funcionar. Após merge de graphql-api#22 → deploy → as páginas de entidade passarão a mostrar artigos.

## Teste manual

```
/entidades/Q5933752 → deve mostrar ~7 artigos (Masoud Pezeshkian)
/entidades/dgb_ministerio-publico-do-estado-de-pernambuco-mppe → deve mostrar artigos
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)