### PR TITLE
fix: corrige 500 em /minha-conta/clipping (token Keycloak expirado)

### DIFF
--- a/src/app/(logged-in)/layout.tsx
+++ b/src/app/(logged-in)/layout.tsx
@@ -8,5 +8,11 @@ export default async function LoggedInLayout({
 }) {
   const session = await auth()
   if (!session) redirect('/api/auth/signin')
+  // Token Keycloak expirado e não renovável (refresh token também morto): a
+  // sessão NextAuth ainda existe, mas toda chamada autenticada ao graphql-api
+  // falharia com UNAUTHENTICATED. Força re-login em vez de servir páginas quebradas.
+  if (session.error === 'RefreshAccessTokenError') {
+    redirect('/api/auth/signin?error=SessionExpired')
+  }
   return <>{children}</>
 }

--- a/src/app/(logged-in)/minha-conta/clipping/page.tsx
+++ b/src/app/(logged-in)/minha-conta/clipping/page.tsx
@@ -1,3 +1,4 @@
+import type { Client } from '@urql/core'
 import Link from 'next/link'
 import { auth } from '@/auth'
 import { FollowCard } from '@/components/marketplace/FollowCard'
@@ -7,6 +8,7 @@ import { createSSRClient } from '@/lib/graphql/client'
 import { getHasTelegram } from '@/lib/graphql/user'
 import { createGraphQLClippingService } from '@/services/clipping/graphql'
 import { createGraphQLMarketplaceService } from '@/services/marketplace/graphql'
+import type { FollowedListing } from '@/services/marketplace/types'
 import type { Clipping } from '@/types/clipping'
 import { ClippingListClient } from './ClippingListClient'
 
@@ -25,6 +27,18 @@ export async function getClippings(): Promise<Clipping[]> {
   }
 }
 
+// Degradação graciosa idêntica à de `getClippings`: uma falha de auth/rede no
+// graphql-api não pode derrubar o SSR da página (era a causa do 500 — digest
+// 1082197660, `listFollowedListings` lançando UNAUTHENTICATED sem try/catch).
+async function getFollows(client: Client): Promise<FollowedListing[]> {
+  try {
+    return await createGraphQLMarketplaceService(client).listFollowedListings()
+  } catch (error) {
+    console.error('Error reading follows:', error)
+    return []
+  }
+}
+
 export default async function ClippingPage() {
   const session = await auth()
   const userId = session?.user?.id
@@ -35,9 +49,7 @@ export default async function ClippingPage() {
       getClippings(),
       getThemesWithHierarchy(),
       getAgenciesList(),
-      userId
-        ? createGraphQLMarketplaceService(ssrClient).listFollowedListings()
-        : Promise.resolve([]),
+      userId ? getFollows(ssrClient) : Promise.resolve([]),
       userId ? getHasTelegram(ssrClient) : Promise.resolve(false),
     ],
   )

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -138,6 +138,10 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
       // origens de script. Mitigação futura: proxy GraphQL server-side para
       // manter o Bearer fora do browser.
       session.accessToken = (token.accessToken as string) ?? undefined
+      // Propaga falha de refresh (token Keycloak morto e não renovável) para a
+      // guarda de `(logged-in)`, que força re-login em vez de deixar o usuário
+      // com sessão viva mas token inválido (toda chamada GraphQL → UNAUTHENTICATED).
+      session.error = (token.error as string) ?? undefined
       return session
     },
   },

--- a/src/types/next-auth.d.ts
+++ b/src/types/next-auth.d.ts
@@ -12,6 +12,8 @@ declare module 'next-auth' {
     }
     /** Access token (JWT Keycloak) para chamadas autenticadas ao graphql-api. */
     accessToken?: string
+    /** Erro de refresh do token (ex: 'RefreshAccessTokenError') — força re-login. */
+    error?: string
   }
 
   interface User {


### PR DESCRIPTION
## Problema

Acessar `/minha-conta/clipping` em produção retornava **"Application error: a server-side exception has occurred"** (digest `1082197660`).

Logs do Cloud Run (`destaquesgovbr-portal`) revelam a causa exata:

```
Error reading clippings: Error: UNAUTHENTICATED        ← capturado (getClippings tem try/catch)
    at Object.listClippings (...)
 ⨯ Error: UNAUTHENTICATED                               ← NÃO capturado → crash do SSR
    at Object.listFollowedListings (...)
  digest: '1082197660'
```

### Duas camadas

1. **Sintoma (crash):** no `Promise.all` de `clipping/page.tsx`, `listFollowedListings()` era a **única** das 5 chamadas sem `try/catch`. As outras (`getClippings`, `getHasTelegram`) degradam graciosamente; essa propagava o `UNAUTHENTICATED` e derrubava o SSR (500).
2. **Causa raiz (`UNAUTHENTICATED`):** o usuário passa pela guarda de `(logged-in)` (tem sessão NextAuth), mas o access token Keycloak enviado ao graphql-api está expirado e não foi renovado. `refreshGovBrToken`, ao falhar, retorna o token velho + `error: 'RefreshAccessTokenError'` — porém `JWT.error` nunca era exposto na sessão nem verificado pela guarda. Resultado: sessão viva com token morto, e toda chamada GraphQL autenticada falha.

## Mudanças

**Parte A — Resiliência (mata o 500)**
- `clipping/page.tsx`: extrai `listFollowedListings()` para `getFollows()` com `try/catch → []`, mesmo padrão de `getClippings`.

**Parte B — Re-auth quando o token está morto (causa raiz)**
- `auth.ts`: expõe `session.error = token.error` no callback `session`.
- `types/next-auth.d.ts`: adiciona `error?: string` à interface `Session`.
- `(logged-in)/layout.tsx`: redireciona para `/api/auth/signin?error=SessionExpired` quando `session.error === 'RefreshAccessTokenError'` — cobre todas as rotas logadas.

## Verificação

- `npx tsc --noEmit` — sem novos erros nos arquivos tocados (erros remanescentes são pré-existentes em `__tests__`).
- `biome check` — limpo nos 4 arquivos (pre-commit hook passou).
- Pendente em staging: acessar `/minha-conta/clipping` logado e confirmar ausência do 500 nos logs; validar redirect de re-login com token expirado.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
