### PR TITLE
release: entidades (NER v2) + correções (clipping 500, /entidades, CI)

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -15,6 +15,8 @@ env:
 jobs:
   validate-tag:
     runs-on: ubuntu-latest
+    # Only validate tag when triggered by actual release event
+    if: github.event_name == 'release'
     steps:
       - name: Validate semver tag
         run: |

--- a/_plan/enriquecer-noticia-features-e-navegacao-cruzada.md
+++ b/_plan/enriquecer-noticia-features-e-navegacao-cruzada.md
@@ -1,0 +1,130 @@
+# Enriquecer a tela da notícia com features do feature_worker + navegação cruzada
+
+> **Diretrizes de implementação (desta execução):**
+> - **Workflow orchestration** (ultracode) para as fases.
+> - **TDD** sempre que possível: teste primeiro → implementação → verde.
+> - **Local-first**: subir graphql-api (`make dev` :8000) + portal (`pnpm dev` :3000) localmente para debug rápido antes de qualquer CI/deploy. graphql-api dev fala com Postgres/Typesense **reais** do GCP.
+> - **Frontend** via skill `/frontend-design:frontend-design` para UI nova (chips de entidade, páginas de entidade, controles de filtro).
+> - **Branches**: portal → `development` (NUNCA `main` durante R1); graphql-api → `feat/*` → `main`; data-platform → fluxo próprio.
+
+## Context
+
+Hoje a página de uma notícia (`/artigos/[articleId]`) mostra "notícias relacionadas", mas a seleção **não usa** as features calculadas pelo `data-platform`. O resolver público `relatedArticles` (graphql-api, `public_content.py:93-125`) escolhe por **theme-code no Typesense** (`most_specific_theme_code` → senão `theme_1_level_1_code`, dedup por `content_hash`, top 4 por data). A similaridade semântica real (`similar_articles`, pgvector cosine) e a extração de entidades (`entities`, NER via Bedrock) **existem** em `news_features` (JSONB), mas o tipo público `Article` não expõe **nenhuma** feature — ele é populado só do Typesense.
+
+Objetivo: (1) trocar relacionadas para similaridade semântica; (2) enriquecer a tela da notícia com **entidades** (instituições/pessoas/locais), **popularidade & trending** e **leitura & legibilidade**; (3) habilitar **navegação cruzada** por entidade — tanto via filtro na `/busca` quanto via **páginas dedicadas de entidade** (`/entidades/[slug]`); (4) adicionar filtros novos à `/busca`: **entidades**, **sentimento** e **ordenação por trending/views**.
+
+Decisões tomadas com o usuário:
+- Relacionadas → **semântica (embedding)**.
+- Exibir na notícia → **entidades, popularidade & trending, leitura & legibilidade** (sem sentimento na tela).
+- Navegação cruzada → **ambos**: filtro na busca **e** páginas de entidade.
+- Novos filtros → **entidades, sentimento, ordenar por trending/views**.
+
+## Arquitetura-alvo (dois caminhos de dados)
+
+| Capacidade | Caminho | Custo |
+|---|---|---|
+| **Exibir** features numa notícia (entidades, views, trending, word_count, flesch) | **Postgres** — `news_features.features` JSONB, lookup por `unique_id` (lazy, batched) | Baixo. Nenhum reindex. |
+| **Relacionadas** semânticas | **Postgres** — `get_similar_articles()` (pgvector) → hidrata via Typesense | Baixo. Resolver já existe. |
+| **Filtrar / facetar / ordenar** por entidade, sentimento, trending, views | **Typesense** — campos facetáveis/sortáveis | Médio. Exige schema-update + reindex no data-platform. |
+
+Princípio: o que é só **leitura de uma notícia** sai do Postgres (rápido, sem mexer no Typesense). O que precisa de **busca/agregação em escala** vai pro Typesense.
+
+## Pré-requisito / Gate de dados (verificar ANTES de construir)
+
+O `enrichment-worker` (entities/sentiment) foi reportado como "em desenvolvimento". **Confirmar cobertura real** de `entities` em produção antes de investir na trilha de entidades:
+
+```sql
+SELECT count(*) FILTER (WHERE features ? 'entities') AS com_entities,
+       count(*) AS total
+FROM news_features;
+SELECT features->'entities' FROM news_features WHERE features ? 'entities' LIMIT 5;
+```
+- Se cobertura baixa → rodar/agendar backfill do enrichment (`data-science/src/news_enrichment/`) antes das fases que dependem de entidades.
+- `trending_score`, `view_count`, `word_count`, `readability_flesch` já têm pipeline (DAGs + feature-worker) e parcialmente já vão pro Typesense.
+
+---
+
+## Fase 0 — data-platform: indexar entidades + view_count no Typesense
+
+Necessária só para **filtro/facet/ordenação** (Fases 2/4). A exibição na notícia (Fases 1/3) não depende disto.
+
+**Arquivos:**
+- `data-platform/src/data_platform/typesense/collection.py` (`COLLECTION_SCHEMA`): adicionar
+  - `entity_org`, `entity_per`, `entity_loc`, `entity_misc` → `type: "string[]", facet: true, optional: true`
+  - opcional: `entities` (string[] facet) achatado para filtro "qualquer tipo"
+  - `view_count` → `type: "int32", facet: false, optional: true, sort: true`
+  - (`trending_score` já `sort:true`; `sentiment_label` já `facet:true`.)
+- `data-platform/src/data_platform/workers/typesense_sync/handler.py` (+ `typesense/indexer.py`): mapear `features.entities` → arrays por tipo e `features.view_count` → `view_count`.
+
+**Deploy/backfill (workflows manuais, NÃO terraform local):**
+- `gh workflow run typesense-schema-update.yaml` (PATCH aditivo idempotente).
+- `gh workflow run typesense-maintenance-sync.yaml` para popular nos docs existentes.
+
+## Fase 1 — graphql-api: expor features no `Article` + relacionadas semânticas
+
+**Branch:** `feat/*` → `main`. Rodar `e2e/graphql` antes de mergear.
+
+**1a. Novos tipos** (`schema/types/`):
+- `EntityType { text: String!, type: String!, count: Int! }`
+- `ArticleFeatures { entities: [EntityType!]!, viewCount: Int, uniqueSessions: Int, trendingScore: Float, wordCount: Int, readabilityFlesch: Float }`
+
+**1b. Campo `features` lazy no `Article`** (`schema/types/article.py`):
+- `@strawberry.field async def features(self, info) -> Optional[ArticleFeatures]` usando `self.unique_id` + **DataLoader** novo. Só resolve quando a operação seleciona `features { ... }` — listas/busca que pedem só `...ArticleFields` não pagam custo.
+- DataLoader em `dataloaders.py` (`create_features_loader(postgres_ds)`): batch por `unique_id` lendo `news_features.features` (reusar `PostgresDatasource.get_news_batch()`). Registrar no `context.py`.
+- `entities` ausente → `[]`.
+
+**1c. `relatedArticles` → semântico** (`schema/resolvers/public_content.py:93-125`):
+- Trocar theme-code por `postgres_ds.get_similar_articles(unique_id, threshold≈0.7, limit)` → hidratar para `Article` via **novo** `TypesenseDatasource.get_articles_by_ids(ids)`, **preservando ordem de similaridade**.
+- Assinatura GraphQL **inalterada** → zero drift; portal já chama e já rotula como "similaridade semântica".
+- Resolver passa a `async`. Fallback: sem embedding/sem vizinhos → `[]`.
+
+**1d.** `make docs-schema` + testes (`tests/test_schema.py`).
+
+## Fase 2 — graphql-api: filtros + ordenação na busca
+
+**2a. `ArticleFilter`** (`schema/types/article.py:43`): `entities: Optional[list[str]]`, `sentiment: Optional[list[str]]`.
+**2b. `sort`** nos resolvers `search`/`articles`: enum `RELEVANCE | DATE | TRENDING | VIEWS` → `sort_by` Typesense.
+**2c. `search_articles`** (`datasources/typesense.py:159`): tratar `entities` (`entity_*:=[...]` OR), `sentiment` (`sentiment_label:[...]`), `sort_by`.
+**2d. `entitySuggestions(query, type, limit): [EntityFacet!]`** via Typesense `facet_query`/`facet_by` sobre `entity_*`. ⚠️ Loaders em `dataloaders.py:12,31` usam `collections["articles"]`, mas a coleção é `"news"` — usar `"news"` no código novo.
+**2e.** `make docs-schema` + testes.
+
+## Fase 3 — portal: tela da notícia enriquecida
+
+**Branch:** `development`. Skills: `portal-implementation`, `frontend-design`, `use-button-component`, `reuse-components`, `no-index-key`.
+
+**3a. Query** (`src/lib/graphql/queries/articles.ts`): estender **só** `ARTICLE_QUERY` (não o fragment) com `features { entities { text type count } viewCount uniqueSessions trendingScore wordCount readabilityFlesch }`. Atualizar interfaces + mapper (`services/content/graphql.ts`, `types/article.ts`).
+
+**3b. UI `components/articles/ClientArticle.tsx`:**
+- **Entidades**: chips agrupados (Instituições/Pessoas/Locais via `type`), clicáveis → `/entidades/[slug]`. Componente `Button` + chips existentes.
+- **Popularidade & trending**: views + selo "Em alta" por `trendingScore`.
+- **Leitura & legibilidade**: tempo ≈ `wordCount/200` min + faixa de `readabilityFlesch`.
+- `features == null` → esconder seções. Manter ISR.
+
+**3c.** Relacionadas já vêm semânticas (Fase 1, sem mudança de operação). Ajustar título se desejado.
+
+## Fase 4 — portal: filtros na busca + páginas de entidade
+
+**4a. Filtros `/busca`** (`components/articles/ArticleFilters.tsx` + `app/(public)/busca/QueryPageClient.tsx` + `actions.ts`): multiselect de entidades (typeahead via `entitySuggestions`), select de sentimento, dropdown de ordenação. Params `entidades`, `sentimento`, `ordenar`. Passar `filter.entities`, `filter.sentiment`, `sort` ao `SEARCH_QUERY`.
+
+**4b. Páginas de entidade** — `app/(public)/entidades/[slug]/page.tsx` (+ client): helpers slug; header resolve label/tipo/contagem via `entitySuggestions`; lista paginada via `search` com `filter.entities=[label]` (reusar `NewsCard` + `useInfiniteQuery`). `generateMetadata` p/ SEO. Frontend via `frontend-design`.
+
+## Reuso (não recriar)
+
+- `PostgresDatasource.get_similar_articles()` (`datasources/postgres.py:381`).
+- `_NEWS_BASE_SQL` / `get_news_batch()` (já faz `LEFT JOIN news_features`, devolve `.features`).
+- Padrão DataLoader (`dataloaders.py`).
+- `update_schema()` (`typesense/collection.py:267`) — PATCH aditivo.
+- Portal: `NewsCard`, `Button`, `useInfiniteQuery`, facade `services/content/graphql.ts`, sync filtro↔URL de `/busca`.
+
+## Riscos & gates
+
+- **Cobertura de `entities`** (gate Fase 0) — sem dados, a trilha de entidades não renderiza. Verificar/backfill primeiro.
+- **Canonicalização de entidades** — texto livre do LLM; v1 = match exato; normalização (cruzar com `agencies`) é fast-follow.
+- **Drift gate (R1-01)** — `relatedArticles` não muda assinatura; `features`/`ArticleFilter.entities,sentiment`/`sort` são aditivos/nullable. `make docs-schema` + `e2e/graphql` antes de mergear o graphql-api.
+- **Ordem**: Fase 0 → 1/2 → 3/4. Exibição de entidades (1/3) é independente do Typesense (0) — pode sair antes do filtro/facet.
+
+## Verificação (E2E)
+
+1. **graphql-api** (`make dev` :8000): `pytest` + `make docs-schema` sem diff; smoke `article{features{...}}`, `relatedArticles`, `search(filter:{entities})`, `sort:TRENDING`.
+2. **portal** (gate real = Playwright no browser): estender `e2e/graphql/public-content.spec.ts` (chips + stats + clique→`/entidades`); novo spec `/busca` (filtro entidade/sentimento + ordenação). Suíte `e2e/graphql` **serial** (`--workers=1`). Rodar portal + graphql-api locais.
+3. **data-platform**: após `typesense-maintenance-sync`, conferir doc com `entity_org`/`view_count`; validar facet via `entitySuggestions`.

--- a/e2e/.auth/user.json
+++ b/e2e/.auth/user.json
@@ -2,7 +2,7 @@
   "cookies": [
     {
       "name": "authjs.csrf-token",
-      "value": "d1eca29124139b8708d1a13eb315c2a4bf1296cac3a73deada05e77f4f68a98e%7C0454b278f9c6a3d7e25295192beb19cc7f1e257339f9991cd691a2b3f11c692f",
+      "value": "260d12fa45a0fdf8201332c050b4baa9904106dbc6d6bf2ccccba49617830040%7C96aa34199519dd8867ef00e23badc70d55799d942b80b932705512a1552bb909",
       "domain": "localhost",
       "path": "/",
       "expires": -1,
@@ -21,15 +21,35 @@
       "sameSite": "Lax"
     },
     {
-      "name": "authjs.session-token",
-      "value": "eyJhbGciOiJkaXIiLCJlbmMiOiJBMjU2Q0JDLUhTNTEyIiwia2lkIjoidFpjcFhHTGhHcFE5TUYzdl9XUHZodkg0b0hNOUUtWnhGOE83RkhFbFhYdFh5cjlSSjFVM1BLeENuaWxmUDRUVjB4MDM2TkFxbC1uOWVZcVhfakllRkEifQ..r-sAkRwMmnS6_FpE5iNXAA.sziwNfpuSm7rnLsZS34luuXB2PUCB9fhrF6qPbl0QPIPDPQ0_dLrxZSFWNAKi9m64Var_Pl_6QhHiTK5COPzE56sxwH1cuE6b7pwWCmt6NJ1g_IVKPg-RatLJuMdiEUykKIZT9hSNEtO2GhA5pwpcZ2O8KR2x70roHV3UT8LhPOV48pQnk627-0ZW-GjV_pq5bRYKpO-TBLtTeOyVhCZ3v4eGwN7KkfXG_-7s_Lh6Z1_YSj5tEpVhwOBEpRs_BH_9lDPkYJ5s0tT7xjoOUnrCjkuyGwcZ6CSiDg-woFrPRVWwre8qGZgkzKpwvJC9X5XJ048qzfYHBCMP_k4MpCf4zanKDVS1kLTDeh9BY-nEt4.G3EPE7PMobEyKQ0Jmpg2HeaaXO2Cp7F0Km6bk3Jr1Ho",
+      "name": "ab_user_id",
+      "value": "1781732268021-vgylq3fq82c",
       "domain": "localhost",
       "path": "/",
-      "expires": 1778105209.959095,
+      "expires": 1813268268.02124,
+      "httpOnly": false,
+      "secure": false,
+      "sameSite": "Lax"
+    },
+    {
+      "name": "authjs.session-token",
+      "value": "eyJhbGciOiJkaXIiLCJlbmMiOiJBMjU2Q0JDLUhTNTEyIiwia2lkIjoiRDdZTzkxa1VQMThJaUxybjdfbUUzSllRM0hLVnhMbHNJQzg3eTBZWVo0RWRYV0t6NjgzYWdjRUJJY3ZaTi1pcWIzcWNEWVFZbjdBRTdVNEtSQ2FQOFEifQ..Z2cgYyVwL63IZphRPNjTrQ.-bosK1qU5N0-QH1MlFFZnAw6O1PBTPQcCvv8WE6z1EEQ620hb32Ot3VsWHGHsenWP53v9_wTVDHDXtJH8qTGw3W1WJQa9klQsmE8puQvUTHFZ9LbCmoGWtgMhhCFnbBCIMBPluYzHlcxpydrRKZ-nWOMlZ94pHaTuROE19yxIcUCxxBy7a1QsbV3MXKY4-kf6Dc1ZEbLqCXq_1AwrLMxEYl2gXdkM1fuCI6JFAI226itTWe3Z9rmV6dvflh0wBzRpxs-xLtcYp9bTOhUElyM0sNY0uQ0qAf9a4hcqi3XA-tAlMH7Xq2jQ3ofF219rDuAxuN5x2IGKeeeJkPrihVTBS5ZDEUksQfCfbW-FPwPOIc.Wud4okcAthYNAa5DJgTUO5_5R7aLeYE9tWpjCCc3pAg",
+      "domain": "localhost",
+      "path": "/",
+      "expires": 1784324268.684804,
       "httpOnly": true,
       "secure": false,
       "sameSite": "Lax"
     }
   ],
-  "origins": []
+  "origins": [
+    {
+      "origin": "http://localhost:3000",
+      "localStorage": [
+        {
+          "name": "gbFeaturesCache",
+          "value": "[[\"https://destaquesgovbr-growthbook-api-klvx64dufq-rj.a.run.app||sdk-Qr6dxCOBEOvKK2z\",{\"data\":{\"status\":200,\"features\":{\"graphql.clippings\":{\"defaultValue\":false,\"rules\":[{\"id\":\"fr_6y3zli1mprcpf9f\",\"force\":true}]},\"graphql.marketplace\":{\"defaultValue\":false,\"rules\":[{\"id\":\"fr_6y3zli1mprdhjaa\",\"force\":true}]},\"graphql.agent\":{\"defaultValue\":false,\"rules\":[{\"id\":\"fr_6y3zli1mpre099x\",\"force\":true}]},\"graphql.push\":{\"defaultValue\":false,\"rules\":[{\"id\":\"fr_6y3zli1mpre9kq1\",\"force\":true}]},\"graphql.widgets\":{\"defaultValue\":false,\"rules\":[{\"id\":\"fr_6y3zli1mpre9lpc\",\"force\":true}]}},\"experiments\":[],\"dateUpdated\":\"2026-05-29T20:48:37.990Z\"},\"version\":\"2026-05-29T20:48:37.990Z\",\"staleAt\":\"2026-06-17T21:38:48.240Z\",\"sse\":false}]]"
+        }
+      ]
+    }
+  ]
 }

--- a/e2e/auth-setup.ts
+++ b/e2e/auth-setup.ts
@@ -11,8 +11,8 @@ setup('authenticate via dev-login', async ({ page }) => {
   await expect(emailInput).toBeVisible({ timeout: 10000 })
   await emailInput.fill('nitaibezerra@gmail.com')
 
-  // Submit the form
-  await page.locator('button[type="submit"]').click()
+  // Submit the form (use #submitButton to avoid ambiguity when Gov.Br is also enabled)
+  await page.locator('#submitButton').click()
 
   // Wait for redirect back to the app (session created)
   await page.waitForURL('/', { timeout: 15000 })

--- a/e2e/graphql/entities.spec.ts
+++ b/e2e/graphql/entities.spec.ts
@@ -321,4 +321,45 @@ test.describe('Grafo de entidades (Fase 6c/6d)', () => {
       canvas.or(loadingState).or(emptyState).or(errorState).or(navHint),
     ).toBeVisible({ timeout: 20_000 })
   })
+
+  test('botão "Maximizar" abre overlay e "Fechar" (e Esc) fecham', async ({
+    page,
+  }) => {
+    // Maximizar exige que o grafo esteja carregado (hasGraph=true); a server
+    // action pode ser lenta em dev — timeout generoso.
+    test.setTimeout(60_000)
+    const entity = await deriveEntityWithRelations()
+
+    await page.goto(`/entidades/${encodeURIComponent(entity.id)}`)
+
+    // Abre a rede.
+    const toggleBtn = page.getByRole('button', { name: 'Ver rede' })
+    await expect(toggleBtn).toBeVisible({ timeout: 20_000 })
+    await toggleBtn.click()
+
+    // Aguarda o botão "Maximizar" — aparece só após o grafo carregar (hasGraph).
+    const maximizeBtn = page.getByRole('button', { name: 'Maximizar' })
+    await expect(maximizeBtn).toBeVisible({ timeout: 40_000 })
+
+    // Abre o overlay maximizado.
+    await maximizeBtn.click()
+
+    // Botão "Fechar" deve estar visível (fixed z-[60], acima do canvas).
+    const closeBtn = page.getByRole('button', { name: /fechar/i })
+    await expect(closeBtn).toBeVisible({ timeout: 5_000 })
+
+    // Fechar via botão.
+    await closeBtn.click()
+    await expect(closeBtn).not.toBeVisible({ timeout: 3_000 })
+
+    // Reabre e fecha via Esc.
+    await maximizeBtn.click()
+    await expect(page.getByRole('button', { name: /fechar/i })).toBeVisible({
+      timeout: 5_000,
+    })
+    await page.keyboard.press('Escape')
+    await expect(page.getByRole('button', { name: /fechar/i })).not.toBeVisible(
+      { timeout: 3_000 },
+    )
+  })
 })

--- a/e2e/graphql/entities.spec.ts
+++ b/e2e/graphql/entities.spec.ts
@@ -1,0 +1,324 @@
+/**
+ * E2E — Grafo de entidades (Fase 6c/6d): relatedEntities + entityNetwork.
+ *
+ * Gate de validação da Fase 6 (projeção em grafo). Público (sem auth).
+ *
+ * Estratégia: deriva um id canônico real com vizinhos chamando o graphql-api
+ * direto (sem hardcode). Se nenhuma entidade tiver vizinhos ainda (grafo
+ * parcial), FALHA com mensagem acionável — a pré-condição é que `entity_edges`
+ * tenha arestas de co-menção (DAG `project_entity_graph` já rodou).
+ *
+ * Cobre:
+ *   - `relatedEntities`: query retorna vizinhos com shape correto
+ *   - `entityNetwork`: query retorna nós + arestas coerentes
+ *   - `/entidades/[id]`: h1, seção "Entidades relacionadas" com chips, botão "Ver rede"
+ *   - toggle "Ver rede": abre a seção e renderiza o grafo (ou estado vazio)
+ */
+
+import { expect, test } from '@playwright/test'
+import { assertDataPreconditions, graphqlApiUrl } from '../fixtures'
+
+// ---------- Cliente GraphQL público (sem auth) ----------
+
+async function publicGraphQL<T>(
+  query: string,
+  variables: Record<string, unknown> = {},
+): Promise<T> {
+  const url = graphqlApiUrl()
+  let res: Response
+  try {
+    res = await fetch(url, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Accept: 'application/json',
+      },
+      body: JSON.stringify({ query, variables }),
+    })
+  } catch (err) {
+    throw new Error(
+      `Falha de rede ao chamar ${url}: ${(err as Error).message}. ` +
+        'O graphql-api está no ar? (make dev / E2E_GRAPHQL_URL)',
+    )
+  }
+  if (!res.ok) {
+    throw new Error(`graphql-api HTTP ${res.status} em ${url}`)
+  }
+  const json = (await res.json()) as {
+    data?: T
+    errors?: Array<{ message: string }>
+  }
+  if (json.errors?.length) {
+    throw new Error(
+      `GraphQL errors: ${json.errors.map((e) => e.message).join('; ')}`,
+    )
+  }
+  if (json.data == null) throw new Error('GraphQL retornou data vazio')
+  return json.data
+}
+
+// ---------- Queries de derivação ----------
+
+// type: "CANONICAL" faz o resolver retornar entity_id = valor do facet canonical.
+// Sem esse tipo, entity_id é sempre null (modo texto-livre do Typesense).
+const ENTITY_SUGGESTIONS_QUERY = /* GraphQL */ `
+  query DeriveEntitySuggestions($query: String!, $limit: Int!) {
+    entitySuggestions(query: $query, type: "CANONICAL", limit: $limit) {
+      value
+      entityId
+      label
+    }
+  }
+`
+
+const RELATED_ENTITIES_QUERY = /* GraphQL */ `
+  query DeriveRelatedEntities($id: String!, $limit: Int!) {
+    relatedEntities(id: $id, limit: $limit) {
+      canonicalId
+      canonicalName
+      weight
+      kind
+    }
+  }
+`
+
+const ENTITY_NETWORK_QUERY = /* GraphQL */ `
+  query DeriveEntityNetwork($id: String!, $depth: Int!, $limit: Int!) {
+    entityNetwork(id: $id, depth: $depth, limit: $limit) {
+      nodes { entityId canonicalName type }
+      edges { src dst weight kind }
+    }
+  }
+`
+
+// ---------- Tipos ----------
+
+type RelatedEntity = {
+  canonicalId: string
+  canonicalName: string | null
+  weight: number
+  kind: string
+}
+
+type EntityWithRelations = {
+  id: string
+  name: string
+  relatedEntities: RelatedEntity[]
+}
+
+// ---------- Helpers de derivação ----------
+
+/**
+ * Encontra a primeira entidade canônica com ao menos um vizinho em `entity_edges`.
+ * Usa query vazia (type=CANONICAL) para recuperar as entidades mais mencionadas
+ * e itera até achar uma com vizinhos. FALHA com mensagem acionável se o grafo
+ * não tiver dados.
+ */
+async function deriveEntityWithRelations(): Promise<EntityWithRelations> {
+  // type=CANONICAL retorna facets cujo valor É o entity_id (Q…/dgb_*).
+  // Query vazia = top-N por frequência; query por texto não funciona nesse modo
+  // (o facet é indexado pelo id, não pelo nome canônico).
+  const { entitySuggestions } = await publicGraphQL<{
+    entitySuggestions: Array<{
+      value: string
+      entityId: string | null
+      label: string | null
+    }>
+  }>(ENTITY_SUGGESTIONS_QUERY, { query: '', limit: 50 })
+
+  const canonical = entitySuggestions.filter((s) => s.entityId)
+
+  if (canonical.length === 0) {
+    throw new Error(
+      'Pré-condição falhou: `entitySuggestions(type:"CANONICAL")` não retornou ' +
+        'nenhuma entidade. O Typesense foi reindexado com canonical_id? ' +
+        'Rode `typesense-maintenance-sync` para atualizar o índice.',
+    )
+  }
+
+  for (const suggestion of canonical) {
+    const { relatedEntities } = await publicGraphQL<{
+      relatedEntities: RelatedEntity[]
+    }>(RELATED_ENTITIES_QUERY, { id: suggestion.entityId, limit: 5 })
+
+    if (relatedEntities.length > 0) {
+      return {
+        id: suggestion.entityId as string,
+        name: suggestion.label ?? suggestion.value,
+        relatedEntities,
+      }
+    }
+  }
+
+  throw new Error(
+    'Pré-condição falhou: nenhuma entidade canônica com vizinhos encontrada ' +
+      'em `entity_edges`. O DAG `project_entity_graph` já rodou em produção? ' +
+      'Execute-o no Airflow e verifique se `entity_edges` tem arestas.',
+  )
+}
+
+// ---------- Suíte ----------
+
+test.beforeAll(async () => {
+  await assertDataPreconditions()
+})
+
+test.describe('Grafo de entidades (Fase 6c/6d)', () => {
+  test('relatedEntities retorna vizinhos com shape correto via GraphQL', async () => {
+    const entity = await deriveEntityWithRelations()
+
+    expect(
+      entity.relatedEntities.length,
+      'deve ter ao menos 1 vizinho',
+    ).toBeGreaterThan(0)
+
+    for (const related of entity.relatedEntities) {
+      expect(related.canonicalId, 'vizinho deve ter canonicalId').toBeTruthy()
+      expect(
+        related.weight,
+        'aresta deve ter weight >= 1',
+      ).toBeGreaterThanOrEqual(1)
+      expect(
+        ['co_mention', 'subordinate_to', 'is_agency'],
+        'kind deve ser um dos valores esperados',
+      ).toContain(related.kind)
+    }
+  })
+
+  test('entityNetwork retorna nós + arestas coerentes via GraphQL', async () => {
+    const entity = await deriveEntityWithRelations()
+
+    const { entityNetwork } = await publicGraphQL<{
+      entityNetwork: {
+        nodes: Array<{
+          entityId: string
+          canonicalName: string | null
+          type: string | null
+        }>
+        edges: Array<{
+          src: string
+          dst: string
+          weight: number
+          kind: string
+        }>
+      }
+    }>(ENTITY_NETWORK_QUERY, { id: entity.id, depth: 1, limit: 50 })
+
+    // Depth=1 com vizinhos existentes: ao menos o nó ego + 1 vizinho + 1 aresta.
+    expect(
+      entityNetwork.nodes.length,
+      'rede deve ter ao menos 2 nós (ego + vizinho)',
+    ).toBeGreaterThanOrEqual(2)
+    expect(
+      entityNetwork.edges.length,
+      'rede deve ter ao menos 1 aresta',
+    ).toBeGreaterThanOrEqual(1)
+
+    // Todas as arestas referenciam nós presentes.
+    const nodeIds = new Set(entityNetwork.nodes.map((n) => n.entityId))
+    for (const edge of entityNetwork.edges) {
+      expect(
+        nodeIds.has(edge.src) || nodeIds.has(edge.dst),
+        `aresta ${edge.src}→${edge.dst} deve referenciar ao menos um nó presente`,
+      ).toBe(true)
+    }
+
+    // A entidade-foco (ego) deve aparecer na lista de nós.
+    expect(
+      nodeIds.has(entity.id),
+      `nó ego (${entity.id}) deve estar presente na rede`,
+    ).toBe(true)
+  })
+
+  test('página /entidades/[id] renderiza h1, seção relacionadas e botão Ver rede', async ({
+    page,
+  }) => {
+    const entity = await deriveEntityWithRelations()
+
+    await page.goto(`/entidades/${encodeURIComponent(entity.id)}`)
+
+    // h1 canônico da entidade — usa classe específica da EntityPageClient para
+    // evitar o segundo h1 que o header do portal também tem.
+    const h1 = page.locator('h1.text-3xl')
+    await expect(h1).toBeVisible({ timeout: 20_000 })
+    const h1Text = await h1.textContent()
+    expect(
+      h1Text?.trim().length,
+      'h1 deve ter conteúdo (nome da entidade)',
+    ).toBeGreaterThan(0)
+
+    // Seção "Entidades relacionadas" com ao menos um chip de entidade vizinha.
+    // .last() descarta a section pai (py-16) que também contém esse texto via nesting.
+    const relatedSection = page
+      .locator('section')
+      .filter({ hasText: 'Entidades relacionadas' })
+      .last()
+    await expect(relatedSection).toBeVisible({ timeout: 20_000 })
+    await expect(
+      relatedSection.locator('a[href^="/entidades/"]').first(),
+    ).toBeVisible({ timeout: 20_000 })
+
+    // Cada chip deve ter href apontando para uma entidade canônica.
+    const chips = relatedSection.locator('a[href^="/entidades/"]')
+    const count = await chips.count()
+    expect(
+      count,
+      'deve ter ao menos 1 chip de entidade relacionada',
+    ).toBeGreaterThan(0)
+
+    // Botão "Ver rede" (toggle padrão = fechado / aria-pressed=false).
+    const toggleBtn = page.getByRole('button', { name: 'Ver rede' })
+    await expect(toggleBtn).toBeVisible({ timeout: 20_000 })
+  })
+
+  test('toggle "Ver rede" abre a seção e carrega a rede de entidades', async ({
+    page,
+  }) => {
+    // Navigation + hydration + toggle + content render can exceed the default 15s.
+    test.setTimeout(45_000)
+    const entity = await deriveEntityWithRelations()
+
+    await page.goto(`/entidades/${encodeURIComponent(entity.id)}`)
+
+    // Aguarda o botão aparecer (hidratação concluída).
+    const toggleBtn = page.getByRole('button', { name: 'Ver rede' })
+    await expect(toggleBtn).toBeVisible({ timeout: 20_000 })
+
+    // Clica para abrir a rede.
+    await toggleBtn.click()
+
+    // Botão passa a exibir "Ocultar rede" (confirma que o toggle disparou).
+    await expect(
+      page.getByRole('button', { name: 'Ocultar rede' }),
+    ).toBeVisible({ timeout: 10_000 })
+
+    // A seção "Rede de entidades" está presente.
+    // .last() descarta a section pai (py-16) que também contém o botão.
+    const networkSection = page
+      .locator('section')
+      .filter({ has: page.getByRole('button', { name: 'Ocultar rede' }) })
+      .last()
+    await expect(networkSection).toBeVisible({ timeout: 10_000 })
+
+    // Aguarda a query iniciar — um dos estados de feedback aparece.
+    // A CORREÇÃO dos dados (relatedEntities/entityNetwork) é coberta pelos
+    // testes de API acima (tests 1-2). Aqui só validamos que o toggle abre
+    // a seção e a query é disparada (estado de loading ou resultado aparece).
+    const canvas = page.locator('canvas').first()
+    const loadingState = page.getByText('Carregando rede', { exact: false })
+    const emptyState = page.getByText(
+      'Ainda não há conexões suficientes para montar a rede desta entidade.',
+    )
+    const errorState = page.getByText(
+      'Não foi possível carregar a rede de entidades.',
+    )
+    const navHint = page.getByText('Clique em uma entidade para navegar.', {
+      exact: false,
+    })
+
+    // Qualquer estado (incluindo loading) confirma que o conteúdo da seção renderizou.
+    await expect(
+      canvas.or(loadingState).or(emptyState).or(errorState).or(navHint),
+    ).toBeVisible({ timeout: 20_000 })
+  })
+})

--- a/e2e/graphql/public-content.spec.ts
+++ b/e2e/graphql/public-content.spec.ts
@@ -323,4 +323,51 @@ test.describe('Conteúdo público via GraphQL', () => {
       `órgão "${agency.code}" (${agency.label}) deveria listar artigos`,
     ).toBeGreaterThan(0)
   })
+
+  test('/noticias exibe seção "Entidades em Alta" quando há dados de trending', async ({
+    page,
+  }) => {
+    // Verificar se o graphql-api já tem dados de entity_trending_scores.
+    // A seção não renderiza quando a lista está vazia — isso é esperado enquanto
+    // o DAG `compute_entity_trending` não tiver rodado após a migration 025.
+    type TrendingData = { trendingEntities: Array<{ entityId: string }> }
+    let hasTrendingData = false
+    try {
+      const data = await publicGraphQL<TrendingData>(
+        /* GraphQL */ `query { trendingEntities(limit: 1) { entityId } }`,
+      )
+      hasTrendingData = (data.trendingEntities?.length ?? 0) > 0
+    } catch {
+      // graphql-api pode não ter o resolver ainda (PR 2 pendente)
+      hasTrendingData = false
+    }
+
+    await page.goto('/noticias')
+    await page.waitForLoadState('networkidle')
+
+    if (!hasTrendingData) {
+      // Sem dados ainda — seção não deve aparecer (fallback gracioso)
+      await expect(
+        page.getByTestId('trending-entities-section'),
+      ).not.toBeVisible()
+      return
+    }
+
+    // Com dados — seção e ao menos 1 card devem estar visíveis
+    const section = page.getByTestId('trending-entities-section')
+    await expect(section).toBeVisible({ timeout: 20_000 })
+
+    const entityCards = page.getByTestId('trending-entity-card')
+    expect(
+      await entityCards.count(),
+      'deve haver ao menos 1 card de entidade em alta',
+    ).toBeGreaterThan(0)
+
+    // Card deve linkar para /entidades/[id]
+    const firstLink = entityCards.first().locator('..').or(entityCards.first())
+    const href = await firstLink.getAttribute('href')
+    expect(href ?? '', 'link do card deve apontar para /entidades/').toMatch(
+      /\/entidades\//,
+    )
+  })
 })

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "react": "18.3.1",
     "react-day-picker": "^8.10.1",
     "react-dom": "18.3.1",
+    "react-force-graph-2d": "^1.29.1",
     "react-hook-form": "^7.61.1",
     "react-intersection-observer": "^9.16.0",
     "react-markdown": "^10.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -205,6 +205,9 @@ importers:
       react-dom:
         specifier: 18.3.1
         version: 18.3.1(react@18.3.1)
+      react-force-graph-2d:
+        specifier: ^1.29.1
+        version: 1.29.1(react@18.3.1)
       react-hook-form:
         specifier: ^7.61.1
         version: 7.62.0(react@18.3.1)
@@ -2751,6 +2754,9 @@ packages:
   '@ts-morph/common@0.23.0':
     resolution: {integrity: sha512-m7Lllj9n/S6sOkCkRftpM7L24uvmfXQFedlW/4hENcuJH1HHm9u5EgxZb9uVjQSCGrbBWBkOGgcTxNg36r6ywA==}
 
+  '@tweenjs/tween.js@25.0.0':
+    resolution: {integrity: sha512-XKLA6syeBUaPzx4j3qwMqzzq+V4uo72BnlbOjmuljLrRqdsd3qnzvZZoxvMHZ23ndsRS4aufU6JOZYpCbU6T1A==}
+
   '@types/aria-query@5.0.4':
     resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
 
@@ -2955,6 +2961,10 @@ packages:
     resolution: {integrity: sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==}
     engines: {node: '>=6.5'}
 
+  accessor-fn@1.5.3:
+    resolution: {integrity: sha512-rkAofCwe/FvYFUlMB0v0gWmhqtfAtV1IUkdPbfhTUyYniu5LrC0A0UJkTH0Jv3S8SvwkmfuAlY+mQIJATdocMA==}
+    engines: {node: '>=12'}
+
   agent-base@6.0.2:
     resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
     engines: {node: '>= 6.0.0'}
@@ -3070,6 +3080,9 @@ packages:
   before-after-hook@4.0.0:
     resolution: {integrity: sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ==}
 
+  bezier-js@6.1.4:
+    resolution: {integrity: sha512-PA0FW9ZpcHbojUCMu28z9Vg/fNkwTj5YhusSAjHHDfHDGLxJ6YUKrAN2vk1fP2MMOxVw4Oko16FMlRGVBGqLKg==}
+
   bignumber.js@9.3.1:
     resolution: {integrity: sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==}
 
@@ -3124,6 +3137,10 @@ packages:
 
   caniuse-lite@1.0.30001780:
     resolution: {integrity: sha512-llngX0E7nQci5BPJDqoZSbuZ5Bcs9F5db7EtgfwBerX9XGtkkiO4NwfDDIRzHTTwcYC8vC7bmeUEPGrKlR/TkQ==}
+
+  canvas-color-tracker@1.3.2:
+    resolution: {integrity: sha512-ryQkDX26yJ3CXzb3hxUVNlg1NKE4REc5crLBq661Nxzr8TNd236SaEf2ffYLXyI5tSABSeguHLqcVq4vf9L3Zg==}
+    engines: {node: '>=12'}
 
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
@@ -3355,12 +3372,27 @@ packages:
     resolution: {integrity: sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==}
     engines: {node: '>=12'}
 
+  d3-binarytree@1.0.2:
+    resolution: {integrity: sha512-cElUNH+sHu95L04m92pG73t2MEJXKu+GeKUN1TJkFsu93E5W8E9Sc3kHEGJKgenGvj19m6upSn2EunvMgMD2Yw==}
+
   d3-color@3.1.0:
     resolution: {integrity: sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==}
     engines: {node: '>=12'}
 
+  d3-dispatch@3.0.1:
+    resolution: {integrity: sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==}
+    engines: {node: '>=12'}
+
+  d3-drag@3.0.0:
+    resolution: {integrity: sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==}
+    engines: {node: '>=12'}
+
   d3-ease@3.0.1:
     resolution: {integrity: sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==}
+    engines: {node: '>=12'}
+
+  d3-force-3d@3.0.6:
+    resolution: {integrity: sha512-4tsKHUPLOVkyfEffZo1v6sFHvGFwAIIjt/W8IThbp08DYAsXZck+2pSHEG5W1+gQgEvFLdZkYvmJAbRM2EzMnA==}
     engines: {node: '>=12'}
 
   d3-format@3.1.0:
@@ -3371,12 +3403,27 @@ packages:
     resolution: {integrity: sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==}
     engines: {node: '>=12'}
 
+  d3-octree@1.1.0:
+    resolution: {integrity: sha512-F8gPlqpP+HwRPMO/8uOu5wjH110+6q4cgJvgJT6vlpy3BEaDIKlTZrgHKZSp/i1InRpVfh4puY/kvL6MxK930A==}
+
   d3-path@3.1.0:
     resolution: {integrity: sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==}
     engines: {node: '>=12'}
 
+  d3-quadtree@3.0.1:
+    resolution: {integrity: sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==}
+    engines: {node: '>=12'}
+
+  d3-scale-chromatic@3.1.0:
+    resolution: {integrity: sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ==}
+    engines: {node: '>=12'}
+
   d3-scale@4.0.2:
     resolution: {integrity: sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==}
+    engines: {node: '>=12'}
+
+  d3-selection@3.0.0:
+    resolution: {integrity: sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==}
     engines: {node: '>=12'}
 
   d3-shape@3.2.0:
@@ -3393,6 +3440,16 @@ packages:
 
   d3-timer@3.0.1:
     resolution: {integrity: sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==}
+    engines: {node: '>=12'}
+
+  d3-transition@3.0.1:
+    resolution: {integrity: sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==}
+    engines: {node: '>=12'}
+    peerDependencies:
+      d3-selection: 2 - 3
+
+  d3-zoom@3.0.0:
+    resolution: {integrity: sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==}
     engines: {node: '>=12'}
 
   data-uri-to-buffer@4.0.1:
@@ -3754,6 +3811,10 @@ packages:
   flatted@3.4.2:
     resolution: {integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==}
 
+  float-tooltip@1.7.5:
+    resolution: {integrity: sha512-/kXzuDnnBqyyWyhDMH7+PfP8J/oXiAavGzcRxASOMRHFuReDtofizLLJsf7nnDLAfEaMW4pVWaXrAjtnglpEkg==}
+    engines: {node: '>=12'}
+
   follow-redirects@1.16.0:
     resolution: {integrity: sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==}
     engines: {node: '>=4.0'}
@@ -3762,6 +3823,10 @@ packages:
     peerDependenciesMeta:
       debug:
         optional: true
+
+  force-graph@1.51.4:
+    resolution: {integrity: sha512-TdJ2KbkoiDQ7NIRx8IPGD0mAXXpLhamS7c+b7W98b0MHG7lphnda1VOQX/98UDTsttIAdH4TcP0l0MauSnLK8w==}
+    engines: {node: '>=12'}
 
   foreground-child@3.3.1:
     resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
@@ -4186,6 +4251,10 @@ packages:
     resolution: {integrity: sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg==}
     engines: {node: '>=12'}
 
+  index-array-by@1.4.2:
+    resolution: {integrity: sha512-SP23P27OUKzXWEC/TOyWlwLviofQkCSCKONnc62eItjp69yCZZPqDQtr3Pw5gJDnPeUMqExmKydNZaJO0FU9pw==}
+    engines: {node: '>=12'}
+
   index-to-position@1.2.0:
     resolution: {integrity: sha512-Yg7+ztRkqslMAS2iFaU+Oa4KTSidr63OsFGlOrJoW981kIYO3CGCS3wA95P1mUi/IVSJkn0D479KTJpVpvFNuw==}
     engines: {node: '>=18'}
@@ -4346,6 +4415,10 @@ packages:
     resolution: {integrity: sha512-qjdpeo2yKlYTH7nFdK0vbZWuTCesk4o63v5iVOlhMQPfuIZQfW/HI35SjfhA+4qpg36rnFSvUK5b1m+ckIblQQ==}
     engines: {node: '>= 0.6.0'}
 
+  jerrypick@1.1.2:
+    resolution: {integrity: sha512-YKnxXEekXKzhpf7CLYA0A+oDP8V0OhICNCr5lv96FvSsDEmrb0GKM776JgQvHTMjr7DTTPEVv/1Ciaw0uEWzBA==}
+    engines: {node: '>=12'}
+
   jiti@2.5.1:
     resolution: {integrity: sha512-twQoecYPiVA5K/h6SxtORw/Bs3ar+mLUtoPSc7iMXzQzK8d7eJ/R09wmTwAjiamETn1cXYPGfNnu7DMoHgu12w==}
     hasBin: true
@@ -4417,6 +4490,10 @@ packages:
 
   jws@4.0.1:
     resolution: {integrity: sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==}
+
+  kapsule@1.16.3:
+    resolution: {integrity: sha512-4+5mNNf4vZDSwPhKprKwz3330iisPrb08JyMgbsdFrimBCKNHecua/WBwvVg3n7vwx0C1ARjfhwIpbrbd9n5wg==}
+    engines: {node: '>=12'}
 
   keyv@5.6.0:
     resolution: {integrity: sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==}
@@ -5422,6 +5499,12 @@ packages:
     peerDependencies:
       react: ^18.3.1
 
+  react-force-graph-2d@1.29.1:
+    resolution: {integrity: sha512-1Rl/1Z3xy2iTHKj6a0jRXGyiI86xUti81K+jBQZ+Oe46csaMikp47L5AjrzA9hY9fNGD63X8ffrqnvaORukCuQ==}
+    engines: {node: '>=12'}
+    peerDependencies:
+      react: '*'
+
   react-hook-form@7.62.0:
     resolution: {integrity: sha512-7KWFejc98xqG/F4bAxpL41NB3o1nnvQO1RWZT3TqRZYL8RryQETGfEdVnJN2fy1crCiBLLjkRBVK05j24FxJGA==}
     engines: {node: '>=18.0.0'}
@@ -5445,6 +5528,12 @@ packages:
 
   react-is@18.3.1:
     resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
+
+  react-kapsule@2.5.7:
+    resolution: {integrity: sha512-kifAF4ZPD77qZKc4CKLmozq6GY1sBzPEJTIJb0wWFK6HsePJatK3jXplZn2eeAt3x67CDozgi7/rO8fNQ/AL7A==}
+    engines: {node: '>=12'}
+    peerDependencies:
+      react: '>=16.13.1'
 
   react-markdown@10.1.0:
     resolution: {integrity: sha512-qKxVopLT/TyA6BX3Ue5NwabOsAzm0Q7kAPwq6L+wWDwisYs7R8vZ0nRXqq6rkueboxpkjvLGU9fWifiX/ZZFxQ==}
@@ -5991,6 +6080,9 @@ packages:
 
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinycolor2@1.6.0:
+    resolution: {integrity: sha512-XPaBkWQJdsf3pLKJV9p4qN/S+fm2Oj8AIPo1BTUhg5oxkvm9+SVEGFdhyOz7tTdUTfvxMiAs4sp6/eZO2Ew+pw==}
 
   tinyexec@0.3.2:
     resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
@@ -9022,6 +9114,8 @@ snapshots:
       mkdirp: 3.0.1
       path-browserify: 1.0.1
 
+  '@tweenjs/tween.js@25.0.0': {}
+
   '@types/aria-query@5.0.4': {}
 
   '@types/babel__core@7.20.5':
@@ -9287,6 +9381,8 @@ snapshots:
       event-target-shim: 5.0.1
     optional: true
 
+  accessor-fn@1.5.3: {}
+
   agent-base@6.0.2:
     dependencies:
       debug: 4.4.3
@@ -9386,6 +9482,8 @@ snapshots:
 
   before-after-hook@4.0.0: {}
 
+  bezier-js@6.1.4: {}
+
   bignumber.js@9.3.1: {}
 
   bottleneck@2.19.5: {}
@@ -9438,6 +9536,10 @@ snapshots:
   caniuse-lite@1.0.30001760: {}
 
   caniuse-lite@1.0.30001780: {}
+
+  canvas-color-tracker@1.3.2:
+    dependencies:
+      tinycolor2: 1.6.0
 
   ccount@2.0.1: {}
 
@@ -9664,9 +9766,26 @@ snapshots:
     dependencies:
       internmap: 2.0.3
 
+  d3-binarytree@1.0.2: {}
+
   d3-color@3.1.0: {}
 
+  d3-dispatch@3.0.1: {}
+
+  d3-drag@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-selection: 3.0.0
+
   d3-ease@3.0.1: {}
+
+  d3-force-3d@3.0.6:
+    dependencies:
+      d3-binarytree: 1.0.2
+      d3-dispatch: 3.0.1
+      d3-octree: 1.1.0
+      d3-quadtree: 3.0.1
+      d3-timer: 3.0.1
 
   d3-format@3.1.0: {}
 
@@ -9674,7 +9793,16 @@ snapshots:
     dependencies:
       d3-color: 3.1.0
 
+  d3-octree@1.1.0: {}
+
   d3-path@3.1.0: {}
+
+  d3-quadtree@3.0.1: {}
+
+  d3-scale-chromatic@3.1.0:
+    dependencies:
+      d3-color: 3.1.0
+      d3-interpolate: 3.0.1
 
   d3-scale@4.0.2:
     dependencies:
@@ -9683,6 +9811,8 @@ snapshots:
       d3-interpolate: 3.0.1
       d3-time: 3.1.0
       d3-time-format: 4.1.0
+
+  d3-selection@3.0.0: {}
 
   d3-shape@3.2.0:
     dependencies:
@@ -9697,6 +9827,23 @@ snapshots:
       d3-array: 3.2.4
 
   d3-timer@3.0.1: {}
+
+  d3-transition@3.0.1(d3-selection@3.0.0):
+    dependencies:
+      d3-color: 3.1.0
+      d3-dispatch: 3.0.1
+      d3-ease: 3.0.1
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-timer: 3.0.1
+
+  d3-zoom@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-drag: 3.0.0
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-transition: 3.0.1(d3-selection@3.0.0)
 
   data-uri-to-buffer@4.0.1: {}
 
@@ -10080,7 +10227,31 @@ snapshots:
 
   flatted@3.4.2: {}
 
+  float-tooltip@1.7.5:
+    dependencies:
+      d3-selection: 3.0.0
+      kapsule: 1.16.3
+      preact: 10.24.3
+
   follow-redirects@1.16.0: {}
+
+  force-graph@1.51.4:
+    dependencies:
+      '@tweenjs/tween.js': 25.0.0
+      accessor-fn: 1.5.3
+      bezier-js: 6.1.4
+      canvas-color-tracker: 1.3.2
+      d3-array: 3.2.4
+      d3-drag: 3.0.0
+      d3-force-3d: 3.0.6
+      d3-scale: 4.0.2
+      d3-scale-chromatic: 3.1.0
+      d3-selection: 3.0.0
+      d3-zoom: 3.0.0
+      float-tooltip: 1.7.5
+      index-array-by: 1.4.2
+      kapsule: 1.16.3
+      lodash-es: 4.18.1
 
   foreground-child@3.3.1:
     dependencies:
@@ -10649,6 +10820,8 @@ snapshots:
 
   indent-string@5.0.0: {}
 
+  index-array-by@1.4.2: {}
+
   index-to-position@1.2.0: {}
 
   inherits@2.0.4: {}
@@ -10784,6 +10957,8 @@ snapshots:
 
   java-properties@1.0.2: {}
 
+  jerrypick@1.1.2: {}
+
   jiti@2.5.1: {}
 
   jose@4.15.9: {}
@@ -10884,6 +11059,10 @@ snapshots:
     dependencies:
       jwa: 2.0.1
       safe-buffer: 5.1.2
+
+  kapsule@1.16.3:
+    dependencies:
+      lodash-es: 4.18.1
 
   keyv@5.6.0:
     dependencies:
@@ -11933,6 +12112,13 @@ snapshots:
       react: 18.3.1
       scheduler: 0.23.2
 
+  react-force-graph-2d@1.29.1(react@18.3.1):
+    dependencies:
+      force-graph: 1.51.4
+      prop-types: 15.8.1
+      react: 18.3.1
+      react-kapsule: 2.5.7(react@18.3.1)
+
   react-hook-form@7.62.0(react@18.3.1):
     dependencies:
       react: 18.3.1
@@ -11948,6 +12134,11 @@ snapshots:
   react-is@17.0.2: {}
 
   react-is@18.3.1: {}
+
+  react-kapsule@2.5.7(react@18.3.1):
+    dependencies:
+      jerrypick: 1.1.2
+      react: 18.3.1
 
   react-markdown@10.1.0(@types/react@19.1.13)(react@18.3.1):
     dependencies:
@@ -12615,6 +12806,8 @@ snapshots:
   tiny-invariant@1.3.3: {}
 
   tinybench@2.9.0: {}
+
+  tinycolor2@1.6.0: {}
 
   tinyexec@0.3.2: {}
 

--- a/src/app/(logged-in)/layout.tsx
+++ b/src/app/(logged-in)/layout.tsx
@@ -8,5 +8,11 @@ export default async function LoggedInLayout({
 }) {
   const session = await auth()
   if (!session) redirect('/api/auth/signin')
+  // Token Keycloak expirado e não renovável (refresh token também morto): a
+  // sessão NextAuth ainda existe, mas toda chamada autenticada ao graphql-api
+  // falharia com UNAUTHENTICATED. Força re-login em vez de servir páginas quebradas.
+  if (session.error === 'RefreshAccessTokenError') {
+    redirect('/api/auth/signin?error=SessionExpired')
+  }
   return <>{children}</>
 }

--- a/src/app/(logged-in)/minha-conta/clipping/page.tsx
+++ b/src/app/(logged-in)/minha-conta/clipping/page.tsx
@@ -1,3 +1,4 @@
+import type { Client } from '@urql/core'
 import Link from 'next/link'
 import { auth } from '@/auth'
 import { FollowCard } from '@/components/marketplace/FollowCard'
@@ -7,6 +8,7 @@ import { createSSRClient } from '@/lib/graphql/client'
 import { getHasTelegram } from '@/lib/graphql/user'
 import { createGraphQLClippingService } from '@/services/clipping/graphql'
 import { createGraphQLMarketplaceService } from '@/services/marketplace/graphql'
+import type { FollowedListing } from '@/services/marketplace/types'
 import type { Clipping } from '@/types/clipping'
 import { ClippingListClient } from './ClippingListClient'
 
@@ -25,6 +27,18 @@ export async function getClippings(): Promise<Clipping[]> {
   }
 }
 
+// Degradação graciosa idêntica à de `getClippings`: uma falha de auth/rede no
+// graphql-api não pode derrubar o SSR da página (era a causa do 500 — digest
+// 1082197660, `listFollowedListings` lançando UNAUTHENTICATED sem try/catch).
+async function getFollows(client: Client): Promise<FollowedListing[]> {
+  try {
+    return await createGraphQLMarketplaceService(client).listFollowedListings()
+  } catch (error) {
+    console.error('Error reading follows:', error)
+    return []
+  }
+}
+
 export default async function ClippingPage() {
   const session = await auth()
   const userId = session?.user?.id
@@ -35,9 +49,7 @@ export default async function ClippingPage() {
       getClippings(),
       getThemesWithHierarchy(),
       getAgenciesList(),
-      userId
-        ? createGraphQLMarketplaceService(ssrClient).listFollowedListings()
-        : Promise.resolve([]),
+      userId ? getFollows(ssrClient) : Promise.resolve([]),
       userId ? getHasTelegram(ssrClient) : Promise.resolve(false),
     ],
   )

--- a/src/app/(public)/actions.ts
+++ b/src/app/(public)/actions.ts
@@ -202,3 +202,16 @@ const fetchLatestByThemes = cache(
 
 // Public API with Result wrapper
 export const getLatestByThemes = withResult(fetchLatestByThemes)
+
+// Internal function for fetching trending entities
+const fetchTrendingEntities = cache(async (limit = 6) => {
+  try {
+    return await content().getTrendingEntities(limit)
+  } catch (error) {
+    console.error('[getTrendingEntities] Error:', error)
+    return []
+  }
+})
+
+// Public API with Result wrapper
+export const getTrendingEntities = withResult(fetchTrendingEntities)

--- a/src/app/(public)/busca/QueryPageClient.tsx
+++ b/src/app/(public)/busca/QueryPageClient.tsx
@@ -11,13 +11,43 @@ import { ArticleFilters } from '@/components/articles/ArticleFilters'
 import NewsCard from '@/components/articles/NewsCard'
 import { FeedLink } from '@/components/common/FeedLink'
 import { Button } from '@/components/ui/button'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
 import type { AgencyOption } from '@/data/agencies-utils'
 import type { ThemeOption } from '@/data/themes-utils'
+import type { ArticleSort } from '@/services/content/types'
 import { queryArticles } from './actions'
 
 type QueryPageClientProps = {
   agencies: AgencyOption[]
   themes: ThemeOption[]
+}
+
+/** Opções de ordenação: valor URL (`ordenar`) ↔ enum ArticleSort. */
+const SORT_OPTIONS: Array<{
+  value: string
+  sort: ArticleSort
+  label: string
+  /** Mantida no mapeamento URL→enum, mas oculta do dropdown. */
+  hidden?: boolean
+}> = [
+  { value: 'relevance', sort: 'RELEVANCE', label: 'Relevância' },
+  { value: 'date', sort: 'DATE', label: 'Mais recentes' },
+  { value: 'trending', sort: 'TRENDING', label: 'Em alta' },
+  // "Mais vistas" (VIEWS) oculto até a DAG de engagement popular view_count (cobertura ~0,3%).
+  // O valor segue mapeado para não quebrar links antigos com ?ordenar=views.
+  { value: 'views', sort: 'VIEWS', label: 'Mais vistas', hidden: true },
+]
+
+const DEFAULT_SORT_VALUE = 'relevance'
+
+function sortValueToEnum(value: string): ArticleSort {
+  return SORT_OPTIONS.find((o) => o.value === value)?.sort ?? 'RELEVANCE'
 }
 
 export default function QueryPageClient({
@@ -54,6 +84,24 @@ export default function QueryPageClient({
     () => searchParams.get('semantica') !== '0',
   )
 
+  const [sortValue, setSortValue] = useState<string>(() => {
+    const ordenar = searchParams.get('ordenar')
+    // Opções ocultas (ex.: ?ordenar=views de links antigos) caem no default.
+    return SORT_OPTIONS.some((o) => o.value === ordenar && !o.hidden)
+      ? (ordenar as string)
+      : DEFAULT_SORT_VALUE
+  })
+
+  const [selectedSentiments, setSelectedSentiments] = useState<string[]>(() => {
+    const sentimento = searchParams.get('sentimento')
+    return sentimento ? sentimento.split(',') : []
+  })
+
+  const [selectedEntities, setSelectedEntities] = useState<string[]>(() => {
+    const entidades = searchParams.get('entidades')
+    return entidades ? entidades.split(',') : []
+  })
+
   // Analytics tracking
   const { track } = useUmamiTrack()
   const hasTrackedSearch = useRef(false)
@@ -65,6 +113,9 @@ export default function QueryPageClient({
       dataFim?: string | null
       agencias?: string | null
       temas?: string | null
+      ordenar?: string | null
+      sentimento?: string | null
+      entidades?: string | null
     }) => {
       const params = new URLSearchParams(searchParams.toString())
 
@@ -148,6 +199,51 @@ export default function QueryPageClient({
     [updateUrlParams, track],
   )
 
+  const handleSortChange = useCallback(
+    (value: string) => {
+      setSortValue(value)
+      updateUrlParams({
+        ordenar: value === DEFAULT_SORT_VALUE ? null : value,
+      })
+      track('filter_changed', {
+        filter_type: 'sort',
+        action: 'set',
+        value,
+      })
+    },
+    [updateUrlParams, track],
+  )
+
+  const handleSentimentsChange = useCallback(
+    (sentimentsList: string[]) => {
+      setSelectedSentiments(sentimentsList)
+      updateUrlParams({
+        sentimento: sentimentsList.length > 0 ? sentimentsList.join(',') : null,
+      })
+      track('filter_changed', {
+        filter_type: 'sentiment',
+        action: sentimentsList.length > 0 ? 'set' : 'clear',
+        value: sentimentsList.length > 0 ? sentimentsList.join(',') : null,
+      })
+    },
+    [updateUrlParams, track],
+  )
+
+  const handleEntitiesChange = useCallback(
+    (entitiesList: string[]) => {
+      setSelectedEntities(entitiesList)
+      updateUrlParams({
+        entidades: entitiesList.length > 0 ? entitiesList.join(',') : null,
+      })
+      track('filter_changed', {
+        filter_type: 'entities',
+        action: entitiesList.length > 0 ? 'set' : 'clear',
+        value: entitiesList.length > 0 ? entitiesList.join(',') : null,
+      })
+    },
+    [updateUrlParams, track],
+  )
+
   const handleSemanticToggle = useCallback(() => {
     const next = !semantic
     setSemantic(next)
@@ -173,6 +269,9 @@ export default function QueryPageClient({
       selectedAgencies,
       selectedThemes,
       semantic,
+      sortValue,
+      selectedSentiments,
+      selectedEntities,
     ],
     queryFn: ({ pageParam }: { pageParam: number | null }) =>
       queryArticles({
@@ -183,6 +282,10 @@ export default function QueryPageClient({
         agencies: selectedAgencies.length > 0 ? selectedAgencies : undefined,
         themes: selectedThemes.length > 0 ? selectedThemes : undefined,
         semantic,
+        sort: sortValueToEnum(sortValue),
+        sentiment:
+          selectedSentiments.length > 0 ? selectedSentiments : undefined,
+        entities: selectedEntities.length > 0 ? selectedEntities : undefined,
       }),
     getNextPageParam: (lastPage) => lastPage.page ?? undefined,
     initialPageParam: 1,
@@ -291,20 +394,26 @@ export default function QueryPageClient({
             endDate={endDate}
             selectedAgencies={selectedAgencies}
             selectedThemes={selectedThemes}
+            selectedSentiments={selectedSentiments}
+            selectedEntities={selectedEntities}
             onStartDateChange={handleStartDateChange}
             onEndDateChange={handleEndDateChange}
             onAgenciesChange={handleAgenciesChange}
             onThemesChange={handleThemesChange}
+            onSentimentsChange={handleSentimentsChange}
+            onEntitiesChange={handleEntitiesChange}
             getAgencyName={getAgencyName}
             getThemeName={getThemeName}
             getThemeHierarchyPath={getThemeHierarchyPath}
+            showSentimentFilter
+            showEntityFilter
           />
 
           {/* Right Content - Results Grid */}
           <main className="flex-1 min-w-0">
-            {/* Semantic search toggle */}
+            {/* Toolbar: busca inteligente + ordenação */}
             {query && (
-              <div className="mb-4 flex items-center gap-2">
+              <div className="mb-4 flex flex-wrap items-center justify-between gap-3">
                 <Button
                   type="button"
                   variant={semantic ? 'default' : 'secondary'}
@@ -317,6 +426,27 @@ export default function QueryPageClient({
                   <Sparkles className="h-3.5 w-3.5" />
                   Busca inteligente
                 </Button>
+
+                <div className="flex items-center gap-2">
+                  <span className="text-sm text-primary/70">Ordenar por</span>
+                  <Select value={sortValue} onValueChange={handleSortChange}>
+                    <SelectTrigger
+                      className="w-44 bg-white"
+                      aria-label="Ordenar resultados"
+                    >
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {SORT_OPTIONS.filter((option) => !option.hidden).map(
+                        (option) => (
+                          <SelectItem key={option.value} value={option.value}>
+                            {option.label}
+                          </SelectItem>
+                        ),
+                      )}
+                    </SelectContent>
+                  </Select>
+                </div>
               </div>
             )}
             <motion.div

--- a/src/app/(public)/busca/__tests__/actions.test.ts
+++ b/src/app/(public)/busca/__tests__/actions.test.ts
@@ -110,6 +110,40 @@ describe('queryArticles', () => {
     await queryArticles({ page: 1, query: 'x', semantic: false })
     expect(searchArticles.mock.calls[0][0].semantic).toBe(false)
   })
+
+  it('usa wildcard "*" quando não há texto mas há filtro (entidade)', async () => {
+    searchArticles.mockResolvedValue({ articles: [], found: 0, page: 1 })
+    await queryArticles({ page: 1, entities: ['Geraldo Alckmin'] })
+    const arg = searchArticles.mock.calls[0][0]
+    expect(arg.query).toBe('*')
+    expect(arg.filter.entities).toEqual(['Geraldo Alckmin'])
+  })
+
+  it('usa wildcard "*" quando não há texto mas há filtro (agência/sentimento)', async () => {
+    searchArticles.mockResolvedValue({ articles: [], found: 0, page: 1 })
+    await queryArticles({
+      page: 1,
+      agencies: ['min-a'],
+      sentiment: ['positive'],
+    })
+    expect(searchArticles.mock.calls[0][0].query).toBe('*')
+  })
+
+  it('mantém query vazia quando não há texto NEM filtro algum', async () => {
+    searchArticles.mockResolvedValue({ articles: [], found: 0, page: 1 })
+    await queryArticles({ page: 1 })
+    expect(searchArticles.mock.calls[0][0].query).toBe('')
+  })
+
+  it('prioriza o texto sobre o wildcard quando há texto E filtro', async () => {
+    searchArticles.mockResolvedValue({ articles: [], found: 0, page: 1 })
+    await queryArticles({
+      page: 1,
+      query: 'governo',
+      entities: ['Geraldo Alckmin'],
+    })
+    expect(searchArticles.mock.calls[0][0].query).toBe('governo')
+  })
 })
 
 describe('getSearchSuggestions', () => {

--- a/src/app/(public)/busca/actions.ts
+++ b/src/app/(public)/busca/actions.ts
@@ -3,6 +3,7 @@
 import { createSSRClient } from '@/lib/graphql/client'
 import { removeDiacritics } from '@/lib/utils'
 import { createGraphQLContentService } from '@/services/content/graphql'
+import type { EntityFacet } from '@/services/content/types'
 import type {
   CombinedSearchResults,
   InlineAutocompleteSuggestion,
@@ -186,6 +187,9 @@ export async function queryArticles(
     agencies,
     themes,
     semantic = true,
+    sort,
+    sentiment,
+    entities,
   } = args
 
   const normalizedQuery = query ? query.trim().replace(/\s+/g, ' ') : null
@@ -196,16 +200,32 @@ export async function queryArticles(
   const startIso = startDate ? new Date(startDate).toISOString() : null
   const endIso = endDate ? new Date(endDate + 86400000).toISOString() : null
 
+  // O resolver `search` do graphql-api rejeita query vazia. Quando NÃO há
+  // texto mas HÁ ao menos um filtro (entidade/sentimento/agência/tema/data),
+  // usamos `'*'` — o wildcard filter-only aceito. Sem texto E sem filtro
+  // algum, mantemos `''` (não disparamos uma busca "tudo").
+  const hasAnyFilter =
+    (agencies?.length ?? 0) > 0 ||
+    (themes?.length ?? 0) > 0 ||
+    (sentiment?.length ?? 0) > 0 ||
+    (entities?.length ?? 0) > 0 ||
+    startIso != null ||
+    endIso != null
+  const effectiveQuery = normalizedQuery ?? (hasAnyFilter ? '*' : '')
+
   const result = await content().searchArticles({
-    query: normalizedQuery ?? '',
+    query: effectiveQuery,
     page,
     // graphql-api faz embeddings + híbrido server-side (alpha:0.8, group_by content_hash).
     semantic,
     alpha: 0.8,
     dedup: true,
+    sort: sort ?? null,
     filter: {
       agencies: agencies && agencies.length > 0 ? agencies : null,
       themes: themes && themes.length > 0 ? themes : null,
+      sentiment: sentiment && sentiment.length > 0 ? sentiment : null,
+      entities: entities && entities.length > 0 ? entities : null,
       startDate: startIso,
       endDate: endIso,
     },
@@ -218,5 +238,27 @@ export async function queryArticles(
     articles: result.articles,
     page: page + 1,
     found: result.found,
+  }
+}
+
+/**
+ * Busca sugestões de entidades (facets) para o typeahead do filtro de busca e
+ * para as páginas `/entidades/[slug]`. `type` (ORG/PER/LOC) restringe ao campo
+ * tipado. Degrada para `[]` enquanto a Fase 0 (reindex Typesense) não rodar.
+ */
+export async function getEntitySuggestions(
+  query: string,
+  type?: string | null,
+  limit = 10,
+): Promise<EntityFacet[]> {
+  const normalizedQuery = query.trim().replace(/\s+/g, ' ')
+  try {
+    return await content().getEntitySuggestions(
+      normalizedQuery,
+      type ?? null,
+      limit,
+    )
+  } catch {
+    return []
   }
 }

--- a/src/app/(public)/busca/actions.ts
+++ b/src/app/(public)/busca/actions.ts
@@ -190,6 +190,7 @@ export async function queryArticles(
     sort,
     sentiment,
     entities,
+    entityCanonical,
   } = args
 
   const normalizedQuery = query ? query.trim().replace(/\s+/g, ' ') : null
@@ -209,6 +210,7 @@ export async function queryArticles(
     (themes?.length ?? 0) > 0 ||
     (sentiment?.length ?? 0) > 0 ||
     (entities?.length ?? 0) > 0 ||
+    (entityCanonical?.length ?? 0) > 0 ||
     startIso != null ||
     endIso != null
   const effectiveQuery = normalizedQuery ?? (hasAnyFilter ? '*' : '')
@@ -226,6 +228,8 @@ export async function queryArticles(
       themes: themes && themes.length > 0 ? themes : null,
       sentiment: sentiment && sentiment.length > 0 ? sentiment : null,
       entities: entities && entities.length > 0 ? entities : null,
+      entityCanonical:
+        entityCanonical && entityCanonical.length > 0 ? entityCanonical : null,
       startDate: startIso,
       endDate: endIso,
     },

--- a/src/app/(public)/entidades/[slug]/EntityPageClient.tsx
+++ b/src/app/(public)/entidades/[slug]/EntityPageClient.tsx
@@ -2,35 +2,47 @@
 
 import { useInfiniteQuery } from '@tanstack/react-query'
 import { motion } from 'framer-motion'
-import { Tag as TagIcon } from 'lucide-react'
+import { ExternalLink, Tag as TagIcon } from 'lucide-react'
 import { useInView } from 'react-intersection-observer'
 import NewsCard from '@/components/articles/NewsCard'
+import { Badge } from '@/components/ui/badge'
+import { entityTypeStyle } from '@/lib/entity-types'
+import type { EntityNode } from '@/services/content/types'
 import { getEntityArticles } from './actions'
 
 type EntityPageClientProps = {
-  /** Texto canônico exato da entidade (vazio quando não resolvida). */
+  /** Id canônico (`Q…`/`dgb_…`) quando a página é canônica; senão `null`. */
+  canonicalId: string | null
+  /** Texto canônico exato da entidade (caminho legado; vazio quando canônico). */
   entityText: string
-  /** Slug original da URL (usado no header quando a entidade não resolve). */
+  /** Rótulo do cabeçalho (nome canônico, ou o deslug do texto legado). */
   slugLabel: string
-  /** Contagem inicial (do facet), se disponível. */
+  /** Nó do registry (só no caminho canônico, pode ser `null` se não resolveu). */
+  entityNode: EntityNode | null
+  /** Contagem inicial (do facet, só no caminho legado), se disponível. */
   initialCount: number | null
 }
 
 export default function EntityPageClient({
+  canonicalId,
   entityText,
   slugLabel,
+  entityNode,
   initialCount,
 }: EntityPageClientProps) {
-  // Quando a entidade não resolve (Fase 0 pendente), não dispara a query —
-  // a página renderiza o estado vazio amigável.
-  const resolved = entityText.length > 0
-  const displayName = resolved ? entityText : slugLabel
+  // Dispara a query quando temos um id canônico OU um texto legado resolvido.
+  // Caso contrário (texto não resolvido, Fase 0 pendente), mostra o estado vazio.
+  const resolved = canonicalId != null || entityText.length > 0
+  const displayName = entityNode?.canonicalName ?? slugLabel
+  const typeStyle = entityNode?.type ? entityTypeStyle(entityNode.type) : null
+  const TypeIcon = typeStyle?.icon ?? TagIcon
 
   const articlesQ = useInfiniteQuery({
-    queryKey: ['entity-articles', entityText],
+    queryKey: ['entity-articles', canonicalId ?? entityText],
     queryFn: ({ pageParam }: { pageParam: number | null }) =>
       getEntityArticles({
         entity: entityText,
+        canonicalId,
         page: pageParam ?? 1,
       }),
     getNextPageParam: (lastPage) => lastPage.page ?? undefined,
@@ -54,8 +66,8 @@ export default function EntityPageClient({
       {/* Cabeçalho institucional da entidade */}
       <div className="container mx-auto px-4 text-center mb-12">
         <div className="mx-auto mb-3 inline-flex items-center gap-2 rounded-full bg-primary/5 px-4 py-1.5 text-sm font-medium text-primary/70">
-          <TagIcon className="h-4 w-4" aria-hidden />
-          Entidade
+          <TypeIcon className="h-4 w-4" aria-hidden />
+          {typeStyle?.label ?? 'Entidade'}
         </div>
 
         <h1 className="text-3xl font-bold text-primary">{displayName}</h1>
@@ -65,11 +77,47 @@ export default function EntityPageClient({
           <img src="/underscore.svg" alt="" />
         </div>
 
-        {resolved && found > 0 && (
+        {/* Descrição canônica (Wikidata/registry), quando disponível */}
+        {entityNode?.description && (
+          <p className="mx-auto mt-4 max-w-2xl text-base text-primary/70">
+            {entityNode.description}
+          </p>
+        )}
+
+        {found > 0 && (
           <p className="mt-4 text-base text-primary/80">
             {new Intl.NumberFormat('pt-BR').format(found)} notícia
             {found === 1 ? '' : 's'} mencionam esta entidade.
           </p>
+        )}
+
+        {/* Link para o verbete Wikidata da entidade canônica */}
+        {entityNode?.wikidataUrl && (
+          <div className="mt-4 flex justify-center">
+            <a
+              href={entityNode.wikidataUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-1.5 text-sm text-primary/70 hover:text-primary hover:underline"
+            >
+              <ExternalLink className="h-3.5 w-3.5" aria-hidden />
+              {entityNode.wikidataId ?? 'Wikidata'}
+            </a>
+          </div>
+        )}
+
+        {/* Aliases conhecidos da entidade canônica */}
+        {entityNode?.aliases && entityNode.aliases.length > 0 && (
+          <div className="mt-4 flex flex-wrap justify-center gap-2">
+            {entityNode.aliases.map((alias) => (
+              <Badge
+                key={alias}
+                className="bg-white text-primary/80 font-normal"
+              >
+                {alias}
+              </Badge>
+            ))}
+          </div>
         )}
       </div>
 

--- a/src/app/(public)/entidades/[slug]/EntityPageClient.tsx
+++ b/src/app/(public)/entidades/[slug]/EntityPageClient.tsx
@@ -1,0 +1,121 @@
+'use client'
+
+import { useInfiniteQuery } from '@tanstack/react-query'
+import { motion } from 'framer-motion'
+import { Tag as TagIcon } from 'lucide-react'
+import { useInView } from 'react-intersection-observer'
+import NewsCard from '@/components/articles/NewsCard'
+import { getEntityArticles } from './actions'
+
+type EntityPageClientProps = {
+  /** Texto canônico exato da entidade (vazio quando não resolvida). */
+  entityText: string
+  /** Slug original da URL (usado no header quando a entidade não resolve). */
+  slugLabel: string
+  /** Contagem inicial (do facet), se disponível. */
+  initialCount: number | null
+}
+
+export default function EntityPageClient({
+  entityText,
+  slugLabel,
+  initialCount,
+}: EntityPageClientProps) {
+  // Quando a entidade não resolve (Fase 0 pendente), não dispara a query —
+  // a página renderiza o estado vazio amigável.
+  const resolved = entityText.length > 0
+  const displayName = resolved ? entityText : slugLabel
+
+  const articlesQ = useInfiniteQuery({
+    queryKey: ['entity-articles', entityText],
+    queryFn: ({ pageParam }: { pageParam: number | null }) =>
+      getEntityArticles({
+        entity: entityText,
+        page: pageParam ?? 1,
+      }),
+    getNextPageParam: (lastPage) => lastPage.page ?? undefined,
+    initialPageParam: 1,
+    enabled: resolved,
+  })
+
+  const { ref } = useInView({
+    onChange: (inView) => {
+      if (inView && articlesQ.hasNextPage && !articlesQ.isFetchingNextPage) {
+        articlesQ.fetchNextPage()
+      }
+    },
+  })
+
+  const articles = articlesQ.data?.pages.flatMap((page) => page.articles) ?? []
+  const found = articlesQ.data?.pages[0]?.found ?? initialCount ?? 0
+
+  return (
+    <section className="py-16">
+      {/* Cabeçalho institucional da entidade */}
+      <div className="container mx-auto px-4 text-center mb-12">
+        <div className="mx-auto mb-3 inline-flex items-center gap-2 rounded-full bg-primary/5 px-4 py-1.5 text-sm font-medium text-primary/70">
+          <TagIcon className="h-4 w-4" aria-hidden />
+          Entidade
+        </div>
+
+        <h1 className="text-3xl font-bold text-primary">{displayName}</h1>
+
+        {/* Linha divisória SVG */}
+        <div className="mx-auto mt-3 w-40">
+          <img src="/underscore.svg" alt="" />
+        </div>
+
+        {resolved && found > 0 && (
+          <p className="mt-4 text-base text-primary/80">
+            {new Intl.NumberFormat('pt-BR').format(found)} notícia
+            {found === 1 ? '' : 's'} mencionam esta entidade.
+          </p>
+        )}
+      </div>
+
+      {/* Conteúdo */}
+      <div className="container mx-auto px-4">
+        {articlesQ.isError ? (
+          <p className="text-center text-red-500">
+            Ocorreu um erro ao carregar as notícias.
+          </p>
+        ) : (
+          <main className="min-w-0">
+            <motion.div
+              className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-6"
+              initial={{ opacity: 0, y: 40 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ duration: 0.6, ease: 'easeOut' }}
+            >
+              {articles.map((article, index) => (
+                <NewsCard
+                  key={article.unique_id}
+                  internalUrl={`/artigos/${article.unique_id}`}
+                  theme={article.theme_1_level_3_label || ''}
+                  date={article.published_at}
+                  ref={index === articles.length - 1 ? ref : undefined}
+                  summary={article.summary || ''}
+                  title={article.title || ''}
+                  imageUrl={article.image || ''}
+                  trackingOrigin="search"
+                />
+              ))}
+            </motion.div>
+
+            {!articlesQ.isLoading && articles.length === 0 && (
+              <div className="mx-auto mt-8 max-w-xl text-center">
+                <p className="text-primary/70">
+                  Ainda não há notícias indexadas para esta entidade.
+                </p>
+                <p className="mt-2 text-sm text-primary/50">
+                  As menções a entidades estão sendo processadas e ficarão
+                  disponíveis em breve.
+                </p>
+              </div>
+            )}
+          </main>
+        )}
+      </div>
+    </section>
+  )
+}

--- a/src/app/(public)/entidades/[slug]/EntityPageClient.tsx
+++ b/src/app/(public)/entidades/[slug]/EntityPageClient.tsx
@@ -1,14 +1,20 @@
 'use client'
 
-import { useInfiniteQuery } from '@tanstack/react-query'
+import { useInfiniteQuery, useQuery } from '@tanstack/react-query'
 import { motion } from 'framer-motion'
 import { ExternalLink, Tag as TagIcon } from 'lucide-react'
 import { useInView } from 'react-intersection-observer'
 import NewsCard from '@/components/articles/NewsCard'
+import EntityNetwork from '@/components/entities/EntityNetwork'
+import { RelatedEntities } from '@/components/entities/RelatedEntities'
 import { Badge } from '@/components/ui/badge'
 import { entityTypeStyle } from '@/lib/entity-types'
 import type { EntityNode } from '@/services/content/types'
-import { getEntityArticles } from './actions'
+import {
+  getEntityArticles,
+  getEntityNetwork,
+  getRelatedEntities,
+} from './actions'
 
 type EntityPageClientProps = {
   /** Id canônico (`Q…`/`dgb_…`) quando a página é canônica; senão `null`. */
@@ -48,6 +54,16 @@ export default function EntityPageClient({
     getNextPageParam: (lastPage) => lastPage.page ?? undefined,
     initialPageParam: 1,
     enabled: resolved,
+  })
+
+  // Entidades relacionadas (co-menção, 1-hop) — só no caminho canônico, onde há
+  // um id (`Q…`/`dgb_…`) para travessia no grafo. Degrada para [] enquanto o
+  // grafo não estiver populado; a seção então se esconde.
+  const relatedQ = useQuery({
+    queryKey: ['entity-related', canonicalId],
+    queryFn: () => getRelatedEntities(canonicalId as string),
+    enabled: canonicalId != null,
+    staleTime: 5 * 60 * 1000,
   })
 
   const { ref } = useInView({
@@ -120,6 +136,23 @@ export default function EntityPageClient({
           </div>
         )}
       </div>
+
+      {/* Grafo de entidades (só no caminho canônico, com id para travessia) */}
+      {canonicalId != null && (
+        <div className="container mx-auto px-4">
+          {/* Entidades relacionadas — esconde-se sozinha quando vazio */}
+          <RelatedEntities entities={relatedQ.data} />
+
+          {/* Rede ego-centrada (toggle default OFF) */}
+          <EntityNetwork
+            entityId={canonicalId}
+            depth={1}
+            fetchNetwork={(id, depth, limit) =>
+              getEntityNetwork(id, depth, limit)
+            }
+          />
+        </div>
+      )}
 
       {/* Conteúdo */}
       <div className="container mx-auto px-4">

--- a/src/app/(public)/entidades/[slug]/actions.ts
+++ b/src/app/(public)/entidades/[slug]/actions.ts
@@ -1,0 +1,90 @@
+'use server'
+
+import { deslugifyEntity, matchEntityBySlug } from '@/lib/entity-slug'
+import { createSSRClient } from '@/lib/graphql/client'
+import { createGraphQLContentService } from '@/services/content/graphql'
+import type { ArticleRow } from '@/types/article'
+
+/** Cliente GraphQL público (sem token) para as server actions de entidade. */
+function content() {
+  return createGraphQLContentService(createSSRClient(async () => null))
+}
+
+export type ResolvedEntity = {
+  /** Texto canônico exato da entidade (usado em `filter.entities`). */
+  text: string
+  /** Contagem de artigos associada ao facet (best-effort). */
+  count: number | null
+}
+
+/**
+ * Resolve o texto canônico de uma entidade a partir do slug da URL.
+ *
+ * Estratégia: consulta `entitySuggestions(query=<deslug>)` e escolhe o facet
+ * cujo slug bate com o slug-alvo. Retorna `null` quando nada casa — o que é o
+ * caso enquanto a Fase 0 (reindex Typesense) não tiver rodado (o resolver
+ * retorna vazio). A página trata `null` com um estado vazio amigável.
+ */
+export async function resolveEntity(
+  slug: string,
+): Promise<ResolvedEntity | null> {
+  const approxQuery = deslugifyEntity(slug)
+  const suggestions = await content().getEntitySuggestions(
+    approxQuery,
+    null,
+    20,
+  )
+  if (suggestions.length === 0) return null
+
+  const match = matchEntityBySlug(
+    slug,
+    suggestions.map((s) => s.value),
+  )
+  if (!match) return null
+
+  const facet = suggestions.find((s) => s.value === match)
+  return { text: match, count: facet?.count ?? null }
+}
+
+export type GetEntityArticlesArgs = {
+  /** Texto canônico exato da entidade. */
+  entity: string
+  page: number
+}
+
+export type GetEntityArticlesResult = {
+  articles: ArticleRow[]
+  page: number
+  found: number
+}
+
+/**
+ * Lista paginada de artigos que mencionam a entidade. Reutiliza a busca
+ * (`search`) com `filter.entities=[texto]`, espelhando o comportamento da
+ * página /busca (dedup por content_hash, sem busca semântica).
+ */
+export async function getEntityArticles(
+  args: GetEntityArticlesArgs,
+): Promise<GetEntityArticlesResult> {
+  const { entity, page } = args
+
+  const result = await content().searchArticles({
+    // Busca filter-only por entidade: o resolver `search` do graphql-api
+    // rejeita query vazia ("Query must not be empty"). `'*'` é o wildcard
+    // filter-only aceito (convenção já usada em outros call-sites).
+    query: '*',
+    page,
+    semantic: false,
+    dedup: true,
+    sort: 'DATE',
+    filter: {
+      entities: [entity],
+    },
+  })
+
+  return {
+    articles: result.articles,
+    page: page + 1,
+    found: result.found,
+  }
+}

--- a/src/app/(public)/entidades/[slug]/actions.ts
+++ b/src/app/(public)/entidades/[slug]/actions.ts
@@ -1,8 +1,13 @@
 'use server'
 
-import { deslugifyEntity, matchEntityBySlug } from '@/lib/entity-slug'
+import {
+  deslugifyEntity,
+  isCanonicalEntityId,
+  matchEntityBySlug,
+} from '@/lib/entity-slug'
 import { createSSRClient } from '@/lib/graphql/client'
 import { createGraphQLContentService } from '@/services/content/graphql'
+import type { EntityNode } from '@/services/content/types'
 import type { ArticleRow } from '@/types/article'
 
 /** Cliente GraphQL público (sem token) para as server actions de entidade. */
@@ -15,6 +20,18 @@ export type ResolvedEntity = {
   text: string
   /** Contagem de artigos associada ao facet (best-effort). */
   count: number | null
+}
+
+/**
+ * Cabeçalho de uma entidade canônica, resolvido por `entity(id)`. `null` quando
+ * o id não existe (ou o `entity(id)` ainda não está disponível) — a página
+ * então cai num cabeçalho mínimo a partir do próprio id.
+ */
+export async function resolveCanonicalEntity(
+  id: string,
+): Promise<EntityNode | null> {
+  if (!isCanonicalEntityId(id)) return null
+  return content().getEntity(id)
 }
 
 /**
@@ -47,8 +64,13 @@ export async function resolveEntity(
 }
 
 export type GetEntityArticlesArgs = {
-  /** Texto canônico exato da entidade. */
+  /**
+   * Texto canônico exato da entidade (caminho legado fuzzy-text). Ignorado
+   * quando `canonicalId` está presente.
+   */
   entity: string
+  /** Id canônico (`Q…`/`dgb_…`); quando presente, filtra por `entityCanonical`. */
+  canonicalId?: string | null
   page: number
 }
 
@@ -60,13 +82,16 @@ export type GetEntityArticlesResult = {
 
 /**
  * Lista paginada de artigos que mencionam a entidade. Reutiliza a busca
- * (`search`) com `filter.entities=[texto]`, espelhando o comportamento da
- * página /busca (dedup por content_hash, sem busca semântica).
+ * (`search`) filter-only (dedup por content_hash, sem busca semântica).
+ *
+ * - **Canônico** (`canonicalId`): filtra por `filter.entityCanonical=[id]` —
+ *   dedup'd por `entity_id`, robusto a variantes de texto.
+ * - **Legado** (texto): filtra por `filter.entities=[texto]` (migração graciosa).
  */
 export async function getEntityArticles(
   args: GetEntityArticlesArgs,
 ): Promise<GetEntityArticlesResult> {
-  const { entity, page } = args
+  const { entity, canonicalId, page } = args
 
   const result = await content().searchArticles({
     // Busca filter-only por entidade: o resolver `search` do graphql-api
@@ -77,9 +102,9 @@ export async function getEntityArticles(
     semantic: false,
     dedup: true,
     sort: 'DATE',
-    filter: {
-      entities: [entity],
-    },
+    filter: canonicalId
+      ? { entityCanonical: [canonicalId] }
+      : { entities: [entity] },
   })
 
   return {

--- a/src/app/(public)/entidades/[slug]/actions.ts
+++ b/src/app/(public)/entidades/[slug]/actions.ts
@@ -7,7 +7,11 @@ import {
 } from '@/lib/entity-slug'
 import { createSSRClient } from '@/lib/graphql/client'
 import { createGraphQLContentService } from '@/services/content/graphql'
-import type { EntityNode } from '@/services/content/types'
+import type {
+  EntityNetwork,
+  EntityNode,
+  RelatedEntity,
+} from '@/services/content/types'
 import type { ArticleRow } from '@/types/article'
 
 /** Cliente GraphQL público (sem token) para as server actions de entidade. */
@@ -112,4 +116,32 @@ export async function getEntityArticles(
     page: page + 1,
     found: result.found,
   }
+}
+
+/**
+ * Entidades relacionadas (co-menção, 1-hop) a uma entidade canônica, ordenadas
+ * por peso. Só faz sentido no caminho canônico (`id` = `Q…`/`dgb_…`); para
+ * qualquer outra entrada retorna `[]`. Degrada para `[]` enquanto o grafo
+ * (`entity_edges`) não estiver populado.
+ */
+export async function getRelatedEntities(
+  id: string,
+  limit = 12,
+): Promise<RelatedEntity[]> {
+  if (!isCanonicalEntityId(id)) return []
+  return content().getRelatedEntities(id, limit)
+}
+
+/**
+ * Rede ego-centrada (nós + arestas) de uma entidade canônica, para a
+ * visualização de rede. Retorna rede vazia para entradas não-canônicas ou
+ * enquanto o grafo não estiver disponível.
+ */
+export async function getEntityNetwork(
+  id: string,
+  depth = 1,
+  limit = 50,
+): Promise<EntityNetwork> {
+  if (!isCanonicalEntityId(id)) return { nodes: [], edges: [] }
+  return content().getEntityNetwork(id, depth, limit)
 }

--- a/src/app/(public)/entidades/[slug]/actions.ts
+++ b/src/app/(public)/entidades/[slug]/actions.ts
@@ -85,30 +85,33 @@ export type GetEntityArticlesResult = {
 }
 
 /**
- * Lista paginada de artigos que mencionam a entidade. Reutiliza a busca
- * (`search`) filter-only (dedup por content_hash, sem busca semântica).
+ * Lista paginada de artigos que mencionam a entidade.
  *
- * - **Canônico** (`canonicalId`): filtra por `filter.entityCanonical=[id]` —
- *   dedup'd por `entity_id`, robusto a variantes de texto.
- * - **Legado** (texto): filtra por `filter.entities=[texto]` (migração graciosa).
+ * - **Canônico** (`canonicalId`): usa `entityArticles` (Postgres direto via
+ *   `news_entities`) — não depende do campo `entityCanonical` no Typesense.
+ * - **Legado** (texto): filtra por `filter.entities=[texto]` via Typesense.
  */
 export async function getEntityArticles(
   args: GetEntityArticlesArgs,
 ): Promise<GetEntityArticlesResult> {
   const { entity, canonicalId, page } = args
 
+  if (canonicalId) {
+    const result = await content().getArticlesByEntity(canonicalId, page)
+    return {
+      articles: result.articles,
+      page: page + 1,
+      found: result.found,
+    }
+  }
+
   const result = await content().searchArticles({
-    // Busca filter-only por entidade: o resolver `search` do graphql-api
-    // rejeita query vazia ("Query must not be empty"). `'*'` é o wildcard
-    // filter-only aceito (convenção já usada em outros call-sites).
     query: '*',
     page,
     semantic: false,
     dedup: true,
     sort: 'DATE',
-    filter: canonicalId
-      ? { entityCanonical: [canonicalId] }
-      : { entities: [entity] },
+    filter: { entities: [entity] },
   })
 
   return {

--- a/src/app/(public)/entidades/[slug]/page.tsx
+++ b/src/app/(public)/entidades/[slug]/page.tsx
@@ -1,0 +1,52 @@
+import { deslugifyEntity } from '@/lib/entity-slug'
+import { resolveEntity } from './actions'
+import EntityPageClient from './EntityPageClient'
+
+type EntityPageProps = {
+  params: Promise<{
+    slug: string
+  }>
+}
+
+export async function generateMetadata({ params }: EntityPageProps) {
+  const { slug } = await params
+  const resolved = await resolveEntity(slug)
+  const name = resolved?.text ?? deslugifyEntity(slug)
+
+  const siteUrl = process.env.NEXT_PUBLIC_SITE_URL ?? ''
+  const pageUrl = `${siteUrl}/entidades/${slug}`
+  const title = `${name} — Notícias do Governo Federal | DestaquesGovBr`
+  const description = `Acompanhe as notícias e publicações oficiais do Governo Federal que mencionam ${name}.`
+
+  return {
+    title,
+    description,
+    alternates: { canonical: pageUrl },
+    openGraph: {
+      title,
+      description,
+      url: pageUrl,
+      type: 'website',
+      locale: 'pt_BR',
+      siteName: 'DestaquesGovBr',
+    },
+    twitter: {
+      card: 'summary',
+      title,
+      description,
+    },
+  }
+}
+
+export default async function EntityPage({ params }: EntityPageProps) {
+  const { slug } = await params
+  const resolved = await resolveEntity(slug)
+
+  return (
+    <EntityPageClient
+      entityText={resolved?.text ?? ''}
+      slugLabel={deslugifyEntity(slug)}
+      initialCount={resolved?.count ?? null}
+    />
+  )
+}

--- a/src/app/(public)/entidades/[slug]/page.tsx
+++ b/src/app/(public)/entidades/[slug]/page.tsx
@@ -1,5 +1,5 @@
-import { deslugifyEntity } from '@/lib/entity-slug'
-import { resolveEntity } from './actions'
+import { deslugifyEntity, isCanonicalEntityId } from '@/lib/entity-slug'
+import { resolveCanonicalEntity, resolveEntity } from './actions'
 import EntityPageClient from './EntityPageClient'
 
 type EntityPageProps = {
@@ -10,8 +10,17 @@ type EntityPageProps = {
 
 export async function generateMetadata({ params }: EntityPageProps) {
   const { slug } = await params
-  const resolved = await resolveEntity(slug)
-  const name = resolved?.text ?? deslugifyEntity(slug)
+
+  // Caminho canônico (id `Q…`/`dgb_…`): resolve o nome via entity(id).
+  // Caminho legado (texto): resolve o texto canônico via fuzzy-match.
+  let name: string
+  if (isCanonicalEntityId(slug)) {
+    const node = await resolveCanonicalEntity(slug)
+    name = node?.canonicalName ?? slug
+  } else {
+    const resolved = await resolveEntity(slug)
+    name = resolved?.text ?? deslugifyEntity(slug)
+  }
 
   const siteUrl = process.env.NEXT_PUBLIC_SITE_URL ?? ''
   const pageUrl = `${siteUrl}/entidades/${slug}`
@@ -40,12 +49,29 @@ export async function generateMetadata({ params }: EntityPageProps) {
 
 export default async function EntityPage({ params }: EntityPageProps) {
   const { slug } = await params
-  const resolved = await resolveEntity(slug)
 
+  // Slug canônico → resolve o nó do registry e filtra por id canônico.
+  if (isCanonicalEntityId(slug)) {
+    const node = await resolveCanonicalEntity(slug)
+    return (
+      <EntityPageClient
+        canonicalId={slug}
+        entityText=""
+        slugLabel={node?.canonicalName ?? slug}
+        entityNode={node}
+        initialCount={null}
+      />
+    )
+  }
+
+  // Slug legado (texto) → comportamento fuzzy-text preservado.
+  const resolved = await resolveEntity(slug)
   return (
     <EntityPageClient
+      canonicalId={null}
       entityText={resolved?.text ?? ''}
       slugLabel={deslugifyEntity(slug)}
+      entityNode={null}
       initialCount={resolved?.count ?? null}
     />
   )

--- a/src/app/(public)/noticias/page.tsx
+++ b/src/app/(public)/noticias/page.tsx
@@ -1,6 +1,7 @@
 import { ArrowRight } from 'lucide-react'
 import Link from 'next/link'
 import NewsCard from '@/components/articles/NewsCard'
+import { TrendingEntitiesSection } from '@/components/entities/TrendingEntitiesSection'
 import { Button } from '@/components/ui/button'
 import THEME_ICONS from '@/data/themes'
 import { formatDateTime } from '@/lib/utils'
@@ -11,6 +12,7 @@ import {
   getLatestArticles,
   getLatestByThemes,
   getThemes,
+  getTrendingEntities,
 } from '../actions'
 
 // Revalidate every 10 minutes (600 seconds)
@@ -18,13 +20,19 @@ export const revalidate = 600
 
 export default async function Home() {
   // ===== Fetch principal =====
-  const [latestNewsResult, themesResult, newsThisMonth, totalNews] =
-    await Promise.all([
-      getLatestArticles(),
-      getThemes(),
-      countMonthlyNews(),
-      countTotalNews(),
-    ])
+  const [
+    latestNewsResult,
+    themesResult,
+    _newsThisMonth,
+    _totalNews,
+    trendingEntitiesResult,
+  ] = await Promise.all([
+    getLatestArticles(),
+    getThemes(),
+    countMonthlyNews(),
+    countTotalNews(),
+    getTrendingEntities(6),
+  ])
 
   if (themesResult.type !== 'ok') return <div>Erro ao carregar os temas.</div>
   if (latestNewsResult.type !== 'ok')
@@ -111,7 +119,12 @@ export default async function Home() {
         </div>
       </section>
 
-      {/* 2️⃣ ÚLTIMAS NOTÍCIAS — grade */}
+      {/* 2️⃣ ENTIDADES EM ALTA — top NER trending */}
+      {trendingEntitiesResult.type === 'ok' && (
+        <TrendingEntitiesSection entities={trendingEntitiesResult.data} />
+      )}
+
+      {/* 3️⃣ ÚLTIMAS NOTÍCIAS — grade */}
       <section className="py-12">
         <div className="container mx-auto px-4">
           <div className="flex items-center justify-between mb-8">
@@ -153,7 +166,7 @@ export default async function Home() {
         </div>
       </section>
 
-      {/* 3️⃣ TEMAS EM FOCO — 3 blocos com 2 notícias cada */}
+      {/* 4️⃣ TEMAS EM FOCO — 3 blocos com 2 notícias cada */}
       <section className="py-12 bg-muted/50">
         <div className="container mx-auto px-4">
           <div className="flex items-center justify-between mb-8">
@@ -261,7 +274,7 @@ export default async function Home() {
         </div>
       </section>
 
-      {/* 4️⃣ TRANSPARÊNCIA / DADOS PÚBLICOS — 3 cards verticais com SVG de fundo */}
+      {/* 5️⃣ TRANSPARÊNCIA / DADOS PÚBLICOS — 3 cards verticais com SVG de fundo */}
       <section className="py-12">
         <div className="container mx-auto px-4">
           <div className="flex items-start mb-8">

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -138,6 +138,10 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
       // origens de script. Mitigação futura: proxy GraphQL server-side para
       // manter o Bearer fora do browser.
       session.accessToken = (token.accessToken as string) ?? undefined
+      // Propaga falha de refresh (token Keycloak morto e não renovável) para a
+      // guarda de `(logged-in)`, que força re-login em vez de deixar o usuário
+      // com sessão viva mas token inválido (toda chamada GraphQL → UNAUTHENTICATED).
+      session.error = (token.error as string) ?? undefined
       return session
     },
   },

--- a/src/components/articles/ArticleFeatures.tsx
+++ b/src/components/articles/ArticleFeatures.tsx
@@ -10,21 +10,18 @@
  * quando não há dado (o pipeline de features é parcial).
  */
 
-import {
-  Building2,
-  Clock,
-  Eye,
-  Flame,
-  Gauge,
-  type LucideIcon,
-  MapPin,
-  Tag as TagIcon,
-  User,
-} from 'lucide-react'
+import { Clock, Eye, Flame, Gauge, type LucideIcon } from 'lucide-react'
 import Link from 'next/link'
 import type { ReactNode } from 'react'
 import { Badge } from '@/components/ui/badge'
 import { slugifyEntity } from '@/lib/entity-slug'
+import {
+  ENTITY_TYPE_ORDER,
+  ENTITY_TYPE_STYLES,
+  type EntityTypeKey,
+  entityTypeStyle,
+  KNOWN_ENTITY_TYPES,
+} from '@/lib/entity-types'
 import type { ArticleEntity, ArticleFeatures } from '@/types/article'
 
 // trending_score = volume 24h / média 7d por tema (nível 1). >= 1.5 indica
@@ -95,47 +92,24 @@ export function ArticleFichaBar({
   )
 }
 
-type EntityGroup = {
-  key: string
-  label: string
-  types: string[]
-  icon: LucideIcon
-  dot: string
+/**
+ * Destino de navegação de um chip de entidade: a página canônica
+ * `/entidades/{canonicalId}` quando a menção já tem id canônico; senão o
+ * fallback de texto `/entidades/{slug}` (migração graciosa).
+ */
+function entityHref(entity: ArticleEntity): string {
+  return entity.canonical_id
+    ? `/entidades/${entity.canonical_id}`
+    : `/entidades/${slugifyEntity(entity.text)}`
 }
-
-const GROUPS: EntityGroup[] = [
-  {
-    key: 'org',
-    label: 'Instituições',
-    types: ['ORG'],
-    icon: Building2,
-    dot: 'bg-government-blue',
-  },
-  {
-    key: 'per',
-    label: 'Pessoas',
-    types: ['PER'],
-    icon: User,
-    dot: 'bg-government-green',
-  },
-  {
-    key: 'loc',
-    label: 'Locais',
-    types: ['LOC'],
-    icon: MapPin,
-    dot: 'bg-government-yellow',
-  },
-]
-
-const KNOWN_TYPES = new Set(GROUPS.flatMap((g) => g.types))
 
 function EntityChips({ items }: { items: ArticleEntity[] }) {
   return (
     <div className="flex flex-wrap gap-2">
       {items.map((entity) => (
         <Link
-          key={entity.text}
-          href={`/entidades/${slugifyEntity(entity.text)}`}
+          key={`${entity.type}:${entity.text}`}
+          href={entityHref(entity)}
           aria-label={`Ver notícias sobre ${entity.text}`}
         >
           <Badge className="bg-white text-primary font-medium hover:bg-primary/5 transition-colors cursor-pointer">
@@ -150,6 +124,52 @@ function EntityChips({ items }: { items: ArticleEntity[] }) {
   )
 }
 
+type ResolvedGroup = {
+  key: string
+  label: string
+  icon: LucideIcon
+  dot: string
+  items: ArticleEntity[]
+}
+
+/**
+ * Agrupa as menções por tipo na ordem canônica (ORG/PER/LOC/EVENT/POLICY),
+ * drenando o resíduo para o balde "Outros". Grupos vazios são omitidos.
+ */
+export function groupEntities(entities: ArticleEntity[]): ResolvedGroup[] {
+  const byCountDesc = (a: ArticleEntity, b: ArticleEntity) => b.count - a.count
+
+  const named: ResolvedGroup[] = ENTITY_TYPE_ORDER.map(
+    (type: EntityTypeKey) => {
+      const style = ENTITY_TYPE_STYLES[type]
+      return {
+        key: type.toLowerCase(),
+        label: style.label,
+        icon: style.icon,
+        dot: style.dot,
+        items: entities.filter((e) => e.type === type).sort(byCountDesc),
+      }
+    },
+  ).filter((group) => group.items.length > 0)
+
+  const others = entities
+    .filter((e) => !KNOWN_ENTITY_TYPES.has(e.type))
+    .sort(byCountDesc)
+
+  if (others.length > 0) {
+    const style = entityTypeStyle('OTHER')
+    named.push({
+      key: 'outros',
+      label: style.label,
+      icon: style.icon,
+      dot: style.dot,
+      items: others,
+    })
+  }
+
+  return named
+}
+
 export function ArticleEntities({
   entities,
 }: {
@@ -157,35 +177,7 @@ export function ArticleEntities({
 }) {
   if (!entities || entities.length === 0) return null
 
-  const byCountDesc = (a: ArticleEntity, b: ArticleEntity) => b.count - a.count
-
-  const named = GROUPS.map((group) => ({
-    ...group,
-    items: entities
-      .filter((e) => group.types.includes(e.type))
-      .sort(byCountDesc),
-  })).filter((group) => group.items.length > 0)
-
-  const others = entities
-    .filter((e) => !KNOWN_TYPES.has(e.type))
-    .sort(byCountDesc)
-
-  const groups: Array<EntityGroup & { items: ArticleEntity[] }> = [
-    ...named,
-    ...(others.length > 0
-      ? [
-          {
-            key: 'outros',
-            label: 'Outros',
-            types: [],
-            icon: TagIcon,
-            dot: 'bg-primary/40',
-            items: others,
-          },
-        ]
-      : []),
-  ]
-
+  const groups = groupEntities(entities)
   if (groups.length === 0) return null
 
   return (

--- a/src/components/articles/ArticleFeatures.tsx
+++ b/src/components/articles/ArticleFeatures.tsx
@@ -1,0 +1,216 @@
+/**
+ * Seções de features computadas (news_features) da tela de detalhe da notícia:
+ *   - `ArticleFichaBar`: faixa-resumo de leitura (tempo, legibilidade), selo
+ *     "Em alta" (trending) e visualizações (best-effort).
+ *   - `ArticleEntities`: entidades nomeadas agrupadas (Instituições/Pessoas/
+ *     Locais/Outros), cada chip linkando para a busca.
+ *
+ * Harmoniza com o design institucional do artigo: paleta government-*,
+ * componente Badge, ícones lucide, larguras max-w-3xl. Cada bloco se esconde
+ * quando não há dado (o pipeline de features é parcial).
+ */
+
+import {
+  Building2,
+  Clock,
+  Eye,
+  Flame,
+  Gauge,
+  type LucideIcon,
+  MapPin,
+  Tag as TagIcon,
+  User,
+} from 'lucide-react'
+import Link from 'next/link'
+import type { ReactNode } from 'react'
+import { Badge } from '@/components/ui/badge'
+import { slugifyEntity } from '@/lib/entity-slug'
+import type { ArticleEntity, ArticleFeatures } from '@/types/article'
+
+// trending_score = volume 24h / média 7d por tema (nível 1). >= 1.5 indica
+// volume claramente acima da média recente → digno do selo "Em alta".
+const TRENDING_THRESHOLD = 1.5
+const WORDS_PER_MINUTE = 200
+
+function readingMinutes(wordCount: number | null): number | null {
+  if (!wordCount || wordCount <= 0) return null
+  return Math.max(1, Math.round(wordCount / WORDS_PER_MINUTE))
+}
+
+function readabilityBand(flesch: number | null): string | null {
+  if (flesch == null) return null
+  if (flesch >= 70) return 'Leitura fácil'
+  if (flesch >= 50) return 'Leitura média'
+  return 'Leitura densa'
+}
+
+function Stat({
+  icon: Icon,
+  children,
+}: {
+  icon: LucideIcon
+  children: ReactNode
+}) {
+  return (
+    <span className="inline-flex items-center gap-1.5 text-sm text-primary/70">
+      <Icon className="w-4 h-4 text-primary/50" aria-hidden />
+      {children}
+    </span>
+  )
+}
+
+export function ArticleFichaBar({
+  features,
+}: {
+  features?: ArticleFeatures | null
+}) {
+  if (!features) return null
+
+  const minutes = readingMinutes(features.word_count)
+  const band = readabilityBand(features.readability_flesch)
+  const trending =
+    features.trending_score != null &&
+    features.trending_score >= TRENDING_THRESHOLD
+  const views =
+    features.view_count && features.view_count > 0 ? features.view_count : null
+
+  if (!minutes && !band && !trending && !views) return null
+
+  return (
+    <div className="mx-auto mb-12 flex max-w-3xl flex-wrap items-center justify-center gap-x-5 gap-y-2 rounded-lg border border-primary/10 bg-primary/[0.03] px-5 py-3">
+      {trending && (
+        <span className="inline-flex items-center gap-1.5 rounded-full bg-government-red/10 px-2.5 py-0.5 text-sm font-semibold text-government-red">
+          <Flame className="w-4 h-4" aria-hidden />
+          Em alta
+        </span>
+      )}
+      {minutes && <Stat icon={Clock}>{minutes} min de leitura</Stat>}
+      {band && <Stat icon={Gauge}>{band}</Stat>}
+      {views && (
+        <Stat icon={Eye}>
+          {new Intl.NumberFormat('pt-BR').format(views)} visualizações
+        </Stat>
+      )}
+    </div>
+  )
+}
+
+type EntityGroup = {
+  key: string
+  label: string
+  types: string[]
+  icon: LucideIcon
+  dot: string
+}
+
+const GROUPS: EntityGroup[] = [
+  {
+    key: 'org',
+    label: 'Instituições',
+    types: ['ORG'],
+    icon: Building2,
+    dot: 'bg-government-blue',
+  },
+  {
+    key: 'per',
+    label: 'Pessoas',
+    types: ['PER'],
+    icon: User,
+    dot: 'bg-government-green',
+  },
+  {
+    key: 'loc',
+    label: 'Locais',
+    types: ['LOC'],
+    icon: MapPin,
+    dot: 'bg-government-yellow',
+  },
+]
+
+const KNOWN_TYPES = new Set(GROUPS.flatMap((g) => g.types))
+
+function EntityChips({ items }: { items: ArticleEntity[] }) {
+  return (
+    <div className="flex flex-wrap gap-2">
+      {items.map((entity) => (
+        <Link
+          key={entity.text}
+          href={`/entidades/${slugifyEntity(entity.text)}`}
+          aria-label={`Ver notícias sobre ${entity.text}`}
+        >
+          <Badge className="bg-white text-primary font-medium hover:bg-primary/5 transition-colors cursor-pointer">
+            {entity.text}
+            {entity.count > 1 && (
+              <span className="ml-1.5 text-primary/40">{entity.count}</span>
+            )}
+          </Badge>
+        </Link>
+      ))}
+    </div>
+  )
+}
+
+export function ArticleEntities({
+  entities,
+}: {
+  entities?: ArticleEntity[] | null
+}) {
+  if (!entities || entities.length === 0) return null
+
+  const byCountDesc = (a: ArticleEntity, b: ArticleEntity) => b.count - a.count
+
+  const named = GROUPS.map((group) => ({
+    ...group,
+    items: entities
+      .filter((e) => group.types.includes(e.type))
+      .sort(byCountDesc),
+  })).filter((group) => group.items.length > 0)
+
+  const others = entities
+    .filter((e) => !KNOWN_TYPES.has(e.type))
+    .sort(byCountDesc)
+
+  const groups: Array<EntityGroup & { items: ArticleEntity[] }> = [
+    ...named,
+    ...(others.length > 0
+      ? [
+          {
+            key: 'outros',
+            label: 'Outros',
+            types: [],
+            icon: TagIcon,
+            dot: 'bg-primary/40',
+            items: others,
+          },
+        ]
+      : []),
+  ]
+
+  if (groups.length === 0) return null
+
+  return (
+    <section className="mt-12 mb-8 max-w-3xl mx-auto">
+      <h2 className="text-sm font-semibold text-primary/70 uppercase tracking-wide mb-4">
+        Entidades mencionadas
+      </h2>
+      <div className="space-y-4">
+        {groups.map((group) => {
+          const Icon = group.icon
+          return (
+            <div key={group.key}>
+              <div className="mb-2 flex items-center gap-1.5 text-xs font-medium uppercase tracking-wide text-primary/50">
+                <span
+                  className={`inline-block w-1.5 h-1.5 rounded-full ${group.dot}`}
+                  aria-hidden
+                />
+                <Icon className="w-3.5 h-3.5" aria-hidden />
+                {group.label}
+              </div>
+              <EntityChips items={group.items} />
+            </div>
+          )
+        })}
+      </div>
+    </section>
+  )
+}

--- a/src/components/articles/ArticleFilters.tsx
+++ b/src/components/articles/ArticleFilters.tsx
@@ -4,6 +4,7 @@ import { X } from 'lucide-react'
 import { useEffect, useRef, useState } from 'react'
 import { TagFilter } from '@/components/articles/TagFilter'
 import { AgencyMultiSelect } from '@/components/filters/AgencyMultiSelect'
+import { EntityMultiSelect } from '@/components/filters/EntityMultiSelect'
 import { ThemeMultiSelect } from '@/components/filters/ThemeMultiSelect'
 import { Portal } from '@/components/layout/Portal'
 import { Button } from '@/components/ui/button'
@@ -11,6 +12,13 @@ import { Input } from '@/components/ui/input'
 import type { AgencyOption } from '@/data/agencies-utils'
 import type { ThemeOption } from '@/data/themes-utils'
 import type { TagFacet } from '@/types/article'
+
+/** Opções de sentimento expostas no filtro (valor enviado ao filter.sentiment). */
+const SENTIMENT_OPTIONS: Array<{ value: string; label: string }> = [
+  { value: 'positive', label: 'Positivo' },
+  { value: 'neutral', label: 'Neutro' },
+  { value: 'negative', label: 'Negativo' },
+]
 
 type DateFilterProps = {
   label: string
@@ -112,17 +120,23 @@ type ArticleFiltersProps = {
   selectedAgencies?: string[]
   selectedThemes?: string[]
   selectedTags?: string[]
+  selectedSentiments?: string[]
+  selectedEntities?: string[]
   onStartDateChange: (date: Date | undefined) => void
   onEndDateChange: (date: Date | undefined) => void
   onAgenciesChange?: (agencies: string[]) => void
   onThemesChange?: (themes: string[]) => void
   onTagsChange?: (tags: string[]) => void
+  onSentimentsChange?: (sentiments: string[]) => void
+  onEntitiesChange?: (entities: string[]) => void
   getAgencyName?: (key: string) => string
   getThemeName?: (key: string) => string
   getThemeHierarchyPath?: (key: string) => string
   showAgencyFilter?: boolean
   showThemeFilter?: boolean
   showTagFilter?: boolean
+  showSentimentFilter?: boolean
+  showEntityFilter?: boolean
 }
 
 export function ArticleFilters({
@@ -134,18 +148,32 @@ export function ArticleFilters({
   selectedAgencies = [],
   selectedThemes = [],
   selectedTags = [],
+  selectedSentiments = [],
+  selectedEntities = [],
   onStartDateChange,
   onEndDateChange,
   onAgenciesChange,
   onThemesChange,
   onTagsChange,
+  onSentimentsChange,
+  onEntitiesChange,
   getAgencyName,
   getThemeName,
   getThemeHierarchyPath,
   showAgencyFilter = true,
   showThemeFilter = true,
   showTagFilter = true,
+  showSentimentFilter = false,
+  showEntityFilter = false,
 }: ArticleFiltersProps) {
+  const toggleSentiment = (value: string) => {
+    if (!onSentimentsChange) return
+    onSentimentsChange(
+      selectedSentiments.includes(value)
+        ? selectedSentiments.filter((s) => s !== value)
+        : [...selectedSentiments, value],
+    )
+  }
   return (
     <aside className="lg:w-80 flex-shrink-0 lg:border-r lg:border-border lg:pr-8 relative z-[98]">
       <div>
@@ -310,6 +338,93 @@ export function ArticleFilters({
                 onSelectedTagsChange={onTagsChange}
               />
             </div>
+          )}
+
+          {/* Sentiment Filter */}
+          {showSentimentFilter && onSentimentsChange && (
+            <div className="flex flex-col gap-2">
+              <span className="text-sm font-semibold text-primary">
+                Sentimento
+              </span>
+              <div className="flex flex-wrap gap-2">
+                {SENTIMENT_OPTIONS.map((option) => {
+                  const active = selectedSentiments.includes(option.value)
+                  return (
+                    <Button
+                      key={option.value}
+                      type="button"
+                      variant={active ? 'default' : 'outline'}
+                      size="sm"
+                      onClick={() => toggleSentiment(option.value)}
+                      className="rounded-full"
+                      aria-pressed={active}
+                    >
+                      {option.label}
+                    </Button>
+                  )
+                })}
+              </div>
+            </div>
+          )}
+
+          {/* Entity Filter (typeahead — depende da Fase 0 para retornar dados) */}
+          {showEntityFilter && onEntitiesChange && (
+            <>
+              <div className="flex flex-col gap-2">
+                <span className="text-sm font-semibold text-primary">
+                  Entidades
+                </span>
+                <EntityMultiSelect
+                  selectedEntities={selectedEntities}
+                  onSelectedEntitiesChange={onEntitiesChange}
+                />
+              </div>
+
+              {/* Selected Entities List */}
+              {selectedEntities.length > 0 && (
+                <div className="pt-4 border-t border-border">
+                  <div className="flex items-center justify-between mb-3">
+                    <span className="text-sm font-semibold text-primary">
+                      Entidades selecionadas ({selectedEntities.length})
+                    </span>
+                    <Button
+                      type="button"
+                      variant="link"
+                      onClick={() => onEntitiesChange([])}
+                      className="h-auto p-0 text-xs text-muted-foreground hover:text-primary"
+                    >
+                      Limpar todas
+                    </Button>
+                  </div>
+                  <div className="space-y-2 max-h-60 overflow-y-auto">
+                    {selectedEntities.map((value) => (
+                      <div
+                        key={value}
+                        className="flex items-center justify-between gap-2 px-3 py-2 bg-primary/5 border border-primary/10 rounded-md text-sm hover:bg-primary/10 transition-colors group"
+                      >
+                        <span className="truncate text-primary/90 flex-1 min-w-0">
+                          {value}
+                        </span>
+                        <Button
+                          type="button"
+                          variant="ghost"
+                          size="icon"
+                          onClick={() =>
+                            onEntitiesChange(
+                              selectedEntities.filter((v) => v !== value),
+                            )
+                          }
+                          className="h-6 w-6 p-0 text-primary/50 hover:text-primary opacity-0 group-hover:opacity-100 transition-opacity flex-shrink-0"
+                          aria-label={`Remover ${value}`}
+                        >
+                          <X className="h-4 w-4" />
+                        </Button>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              )}
+            </>
           )}
         </div>
       </div>

--- a/src/components/articles/ClientArticle.tsx
+++ b/src/components/articles/ClientArticle.tsx
@@ -5,22 +5,27 @@ import {
   Calendar,
   Check,
   ExternalLink,
+  Highlighter,
   Share2,
   Tag,
 } from 'lucide-react'
 import Link from 'next/link'
-import { useMemo, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import {
   ArticleEntities,
   ArticleFichaBar,
 } from '@/components/articles/ArticleFeatures'
 import NewsCard from '@/components/articles/NewsCard'
+import { SemanticLens } from '@/components/articles/SemanticLens'
 import { VideoPlayer } from '@/components/articles/VideoPlayer'
 import { MarkdownRenderer } from '@/components/common/MarkdownRenderer'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { formatDateTime } from '@/lib/utils'
 import type { ArticleRow } from '@/types/article'
+
+/** Chave de persistência da preferência de exibir a lente semântica. */
+const LENS_STORAGE_KEY = 'dgb:semantic-lens'
 
 export default function ClientArticle({
   article,
@@ -35,6 +40,24 @@ export default function ClientArticle({
 }) {
   const [copied, setCopied] = useState(false)
   const [coverImageBroken, setCoverImageBroken] = useState(false)
+
+  // Lente semântica: default OFF, escolha persistida em localStorage.
+  const [lensOn, setLensOn] = useState(false)
+  useEffect(() => {
+    setLensOn(localStorage.getItem(LENS_STORAGE_KEY) === '1')
+  }, [])
+
+  function toggleLens() {
+    setLensOn((prev) => {
+      const next = !prev
+      localStorage.setItem(LENS_STORAGE_KEY, next ? '1' : '0')
+      return next
+    })
+  }
+
+  // A lente só faz sentido quando há anotações de span derivadas para o corpo.
+  const annotations = article.features?.content_annotations ?? []
+  const lensAvailable = annotations.length > 0 && !!article.content
 
   // Check if the cover image appears in the article body
   const isImageInBody = useMemo(() => {
@@ -111,6 +134,24 @@ export default function ClientArticle({
                 </>
               )}
             </Button>
+
+            {/* Lente semântica: liga/desliga o destaque de entidades no corpo */}
+            {lensAvailable && (
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={toggleLens}
+                aria-pressed={lensOn}
+                className={
+                  lensOn
+                    ? 'text-government-blue hover:text-government-blue transition-colors'
+                    : 'text-primary/70 hover:text-primary transition-colors'
+                }
+              >
+                <Highlighter className="w-4 h-4 mr-1" />
+                {lensOn ? 'Lente ativa' : 'Lente semântica'}
+              </Button>
+            )}
           </div>
 
           {/* Editorial Lead - aparece como tag acima do título */}
@@ -175,9 +216,17 @@ export default function ClientArticle({
           )
         )}
 
-        {/* Corpo do artigo */}
+        {/* Corpo do artigo — lente ON destaca entidades sobre o texto plano;
+            lente OFF mantém o Markdown renderizado normalmente. */}
         <article className="prose prose-lg mx-auto max-w-3xl text-primary/90 leading-relaxed article-content">
-          <MarkdownRenderer content={article.content ?? ''} />
+          {lensOn && lensAvailable ? (
+            <SemanticLens
+              content={article.content ?? ''}
+              annotations={annotations}
+            />
+          ) : (
+            <MarkdownRenderer content={article.content ?? ''} />
+          )}
         </article>
 
         {/* Botão CTA para notícia original */}

--- a/src/components/articles/ClientArticle.tsx
+++ b/src/components/articles/ClientArticle.tsx
@@ -10,6 +10,10 @@ import {
 } from 'lucide-react'
 import Link from 'next/link'
 import { useMemo, useState } from 'react'
+import {
+  ArticleEntities,
+  ArticleFichaBar,
+} from '@/components/articles/ArticleFeatures'
 import NewsCard from '@/components/articles/NewsCard'
 import { VideoPlayer } from '@/components/articles/VideoPlayer'
 import { MarkdownRenderer } from '@/components/common/MarkdownRenderer'
@@ -147,6 +151,9 @@ export default function ClientArticle({
           </div>
         </header>
 
+        {/* Faixa de leitura/trending (features computadas) */}
+        <ArticleFichaBar features={article.features} />
+
         {/* Video takes priority over cover image */}
         {article.video_url ? (
           <VideoPlayer videoUrl={article.video_url} title={article.title} />
@@ -206,6 +213,9 @@ export default function ClientArticle({
             </div>
           </section>
         )}
+
+        {/* Entidades mencionadas (features computadas) */}
+        <ArticleEntities entities={article.features?.entities} />
 
         {/* Notícias similares */}
         {similarArticles.length > 0 && (

--- a/src/components/articles/SemanticLens.tsx
+++ b/src/components/articles/SemanticLens.tsx
@@ -1,0 +1,151 @@
+'use client'
+
+/**
+ * Lente semântica — renderiza o corpo da notícia (texto plano) com as entidades
+ * destacadas inline e ligáveis às respectivas páginas de entidade.
+ *
+ * Contrato de robustez (validate-then-split): o NER rodou sobre o texto plano,
+ * enquanto o corpo servido pode divergir (Markdown ↔ plain-text, drift
+ * Typesense ↔ Postgres). Portanto cada span é **validado** antes de destacar:
+ * descartamos qualquer anotação cujo `content.slice(start,end)` foldado (NFC +
+ * casefold + sem acento) não bata com `annotation.text` foldado. Span inválido
+ * simplesmente não é destacado (cobertura parcial aceitável; nunca destaca
+ * errado).
+ *
+ * O destaque é um tint de fundo sutil + borda inferior (não um chip cheio) para
+ * preservar o fluxo de leitura. Cada destaque é um `next/link` inline.
+ */
+
+import Link from 'next/link'
+import { slugifyEntity } from '@/lib/entity-slug'
+import { entityTypeStyle } from '@/lib/entity-types'
+import type { ContentAnnotation } from '@/types/article'
+
+/**
+ * Dobra (fold) uma string para comparação tolerante: NFC, casefold
+ * (lowercase) e remoção de acentos. Espelha a derivação determinística de
+ * offsets do feature-worker, defendendo contra drift de conteúdo no render.
+ */
+export function foldForMatch(s: string): string {
+  return s
+    .normalize('NFC')
+    .toLowerCase()
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+}
+
+/** Um segmento plano do texto: texto puro, ou uma entidade destacável. */
+export type LensSegment =
+  | { kind: 'text'; text: string; start: number }
+  | {
+      kind: 'entity'
+      text: string
+      start: number
+      end: number
+      type: string
+      canonicalId: string | null
+    }
+
+/**
+ * Constrói os segmentos planos do texto a partir das anotações.
+ *
+ * Passos:
+ *  1. **validate**: mantém só spans cujo `content.slice` foldado == `text` foldado.
+ *  2. **sort + dedupe overlap**: ordena por `start asc`; descarta qualquer span
+ *     que comece antes do fim do anterior aceito (overlaps já são resolvidos
+ *     upstream por longest-match-wins, mas defendemos aqui por garantia).
+ *  3. **split**: caminha o cursor emitindo texto puro entre spans + os spans.
+ */
+export function buildSegments(
+  content: string,
+  annotations: ContentAnnotation[],
+): LensSegment[] {
+  const valid = annotations
+    .filter((a) => {
+      if (
+        !Number.isInteger(a.start) ||
+        !Number.isInteger(a.end) ||
+        a.start < 0 ||
+        a.end > content.length ||
+        a.start >= a.end
+      ) {
+        return false
+      }
+      return (
+        foldForMatch(content.slice(a.start, a.end)) === foldForMatch(a.text)
+      )
+    })
+    .sort((a, b) => a.start - b.start || b.end - a.end)
+
+  const segments: LensSegment[] = []
+  let cursor = 0
+
+  for (const a of valid) {
+    // Pula spans que se sobrepõem a um já emitido (non-overlapping).
+    if (a.start < cursor) continue
+
+    if (a.start > cursor) {
+      segments.push({
+        kind: 'text',
+        text: content.slice(cursor, a.start),
+        start: cursor,
+      })
+    }
+
+    segments.push({
+      kind: 'entity',
+      text: content.slice(a.start, a.end),
+      start: a.start,
+      end: a.end,
+      type: a.type,
+      canonicalId: a.canonical_id ?? null,
+    })
+    cursor = a.end
+  }
+
+  if (cursor < content.length) {
+    segments.push({ kind: 'text', text: content.slice(cursor), start: cursor })
+  }
+
+  return segments
+}
+
+/** Destino da entidade: página canônica quando há id; senão fallback de texto. */
+function entityHref(text: string, canonicalId: string | null): string {
+  return canonicalId
+    ? `/entidades/${canonicalId}`
+    : `/entidades/${slugifyEntity(text)}`
+}
+
+export function SemanticLens({
+  content,
+  annotations,
+}: {
+  content: string
+  annotations: ContentAnnotation[]
+}) {
+  const segments = buildSegments(content, annotations)
+
+  return (
+    <p className="whitespace-pre-wrap">
+      {segments.map((segment) => {
+        if (segment.kind === 'text') {
+          // Key estável pelo offset de início (único e nunca o índice do array).
+          return <span key={`t-${segment.start}`}>{segment.text}</span>
+        }
+        const style = entityTypeStyle(segment.type)
+        return (
+          <Link
+            key={`${segment.start}-${segment.end}`}
+            href={entityHref(segment.text, segment.canonicalId)}
+            title={`Ver notícias sobre ${segment.text}`}
+            aria-label={`Ver notícias sobre ${segment.text}`}
+            className={`rounded-sm px-0.5 transition-colors ${style.lens}`}
+          >
+            {segment.text}
+          </Link>
+        )
+      })}
+    </p>
+  )
+}

--- a/src/components/articles/__tests__/ArticleFeatures.test.tsx
+++ b/src/components/articles/__tests__/ArticleFeatures.test.tsx
@@ -1,0 +1,107 @@
+import { screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import { render } from '@/__tests__/test-utils'
+import type { ArticleEntity } from '@/types/article'
+import { ArticleEntities, groupEntities } from '../ArticleFeatures'
+
+function ent(
+  text: string,
+  type: string,
+  count = 1,
+  canonical_id: string | null = null,
+): ArticleEntity {
+  return { text, type, count, canonical_id }
+}
+
+describe('groupEntities', () => {
+  it('agrupa por tipo na ordem ORG/PER/LOC/EVENT/POLICY', () => {
+    const groups = groupEntities([
+      ent('Bolsa Família', 'POLICY'),
+      ent('Copa do Mundo', 'EVENT'),
+      ent('Brasília', 'LOC'),
+      ent('Lula', 'PER'),
+      ent('MEC', 'ORG'),
+    ])
+    expect(groups.map((g) => g.label)).toEqual([
+      'Instituições',
+      'Pessoas',
+      'Locais',
+      'Eventos',
+      'Políticas Públicas',
+    ])
+  })
+
+  it('inclui grupos EVENT e POLICY (antes escondidos no balde MISC)', () => {
+    const groups = groupEntities([
+      ent('Enem 2026', 'EVENT'),
+      ent('Pé-de-Meia', 'POLICY'),
+    ])
+    expect(groups.map((g) => g.label)).toEqual([
+      'Eventos',
+      'Políticas Públicas',
+    ])
+  })
+
+  it('omite grupos vazios', () => {
+    const groups = groupEntities([ent('MEC', 'ORG')])
+    expect(groups).toHaveLength(1)
+    expect(groups[0].label).toBe('Instituições')
+  })
+
+  it('drena tipos desconhecidos para o balde "Outros"', () => {
+    const groups = groupEntities([ent('algo', 'LAW'), ent('MEC', 'ORG')])
+    const labels = groups.map((g) => g.label)
+    expect(labels).toContain('Instituições')
+    expect(labels).toContain('Outros')
+    // "Outros" sempre por último.
+    expect(labels[labels.length - 1]).toBe('Outros')
+  })
+
+  it('ordena os itens de cada grupo por contagem desc', () => {
+    const groups = groupEntities([
+      ent('Pouco', 'ORG', 2),
+      ent('Muito', 'ORG', 9),
+    ])
+    expect(groups[0].items.map((e) => e.text)).toEqual(['Muito', 'Pouco'])
+  })
+})
+
+describe('ArticleEntities render', () => {
+  it('não renderiza nada quando não há entidades', () => {
+    const { container } = render(<ArticleEntities entities={[]} />)
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('linka chip canônico para /entidades/{canonicalId}', () => {
+    render(
+      <ArticleEntities
+        entities={[ent('Ministério da Saúde', 'ORG', 3, 'Q216330')]}
+      />,
+    )
+    const link = screen.getByRole('link', {
+      name: /Ver notícias sobre Ministério da Saúde/i,
+    })
+    expect(link).toHaveAttribute('href', '/entidades/Q216330')
+  })
+
+  it('faz fallback para slug de texto quando a menção não tem id canônico', () => {
+    render(<ArticleEntities entities={[ent('Lula', 'PER', 5, null)]} />)
+    const link = screen.getByRole('link', {
+      name: /Ver notícias sobre Lula/i,
+    })
+    expect(link).toHaveAttribute('href', '/entidades/lula')
+  })
+
+  it('renderiza as seções Eventos e Políticas Públicas', () => {
+    render(
+      <ArticleEntities
+        entities={[
+          ent('Copa do Mundo', 'EVENT'),
+          ent('Bolsa Família', 'POLICY'),
+        ]}
+      />,
+    )
+    expect(screen.getByText('Eventos')).toBeInTheDocument()
+    expect(screen.getByText('Políticas Públicas')).toBeInTheDocument()
+  })
+})

--- a/src/components/articles/__tests__/SemanticLens.test.tsx
+++ b/src/components/articles/__tests__/SemanticLens.test.tsx
@@ -1,0 +1,143 @@
+import { screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import { render } from '@/__tests__/test-utils'
+import type { ContentAnnotation } from '@/types/article'
+import { buildSegments, foldForMatch, SemanticLens } from '../SemanticLens'
+
+function ann(
+  start: number,
+  end: number,
+  text: string,
+  type = 'ORG',
+  canonical_id: string | null = null,
+): ContentAnnotation {
+  return { start, end, type, text, canonical_id }
+}
+
+describe('foldForMatch', () => {
+  it('dobra caixa e acentos (NFC + casefold + sem acento)', () => {
+    expect(foldForMatch('Ministério')).toBe('ministerio')
+    expect(foldForMatch('SAÚDE')).toBe(foldForMatch('saúde'))
+  })
+})
+
+describe('buildSegments — validate-then-split', () => {
+  it('destaca um span válido e mantém o texto ao redor', () => {
+    const content = 'Visita ao Ministério da Saúde hoje.'
+    const start = content.indexOf('Ministério da Saúde')
+    const end = start + 'Ministério da Saúde'.length
+    const segments = buildSegments(content, [
+      ann(start, end, 'Ministério da Saúde', 'ORG', 'Q216330'),
+    ])
+
+    const entity = segments.filter((s) => s.kind === 'entity')
+    expect(entity).toHaveLength(1)
+    expect(entity[0]).toMatchObject({
+      text: 'Ministério da Saúde',
+      type: 'ORG',
+      canonicalId: 'Q216330',
+    })
+    // Texto: prefixo + sufixo (dois segmentos de texto envolvendo o destaque).
+    const text = segments.filter((s) => s.kind === 'text')
+    expect(text.map((s) => s.text).join('')).toContain('Visita ao ')
+  })
+
+  it('valida insensível a acento/caixa (drift Markdown↔plain tolerado)', () => {
+    const content = 'O ministério da saude agiu.'
+    const start = content.indexOf('ministério da saude')
+    const end = start + 'ministério da saude'.length
+    const segments = buildSegments(content, [
+      // surface da anotação difere em caixa/acento do slice, mas folda igual.
+      ann(start, end, 'Ministério da Saúde', 'ORG'),
+    ])
+    expect(segments.some((s) => s.kind === 'entity')).toBe(true)
+  })
+
+  it('descarta span "driftado" (slice foldado ≠ text foldado)', () => {
+    const content = 'Texto totalmente diferente aqui.'
+    const segments = buildSegments(content, [
+      // offsets apontam para "Texto tota" que não folda para "Bolsa Família".
+      ann(0, 10, 'Bolsa Família', 'POLICY'),
+    ])
+    expect(segments.every((s) => s.kind === 'text')).toBe(true)
+    expect(segments.map((s) => s.text).join('')).toBe(content)
+  })
+
+  it('descarta offsets fora dos limites ou degenerados', () => {
+    const content = 'curto'
+    expect(
+      buildSegments(content, [ann(0, 999, 'curto')]).every(
+        (s) => s.kind === 'text',
+      ),
+    ).toBe(true)
+    expect(
+      buildSegments(content, [ann(3, 3, '')]).every((s) => s.kind === 'text'),
+    ).toBe(true)
+  })
+
+  it('não destaca nada quando não há anotações (texto puro)', () => {
+    const content = 'Sem entidades.'
+    const segments = buildSegments(content, [])
+    expect(segments).toEqual([{ kind: 'text', text: content, start: 0 }])
+  })
+
+  it('resolve overlap mantendo o primeiro/maior e pulando o aninhado', () => {
+    // "Ministério da Educação (MEC)" engloba "MEC" — varredura start asc, len
+    // desc: o maior vence, o aninhado é pulado (non-overlapping).
+    const content = 'Ministério da Educação (MEC) anunciou.'
+    const outerStart = 0
+    const outerEnd = 'Ministério da Educação (MEC)'.length
+    const mecStart = content.indexOf('MEC')
+    const segments = buildSegments(content, [
+      ann(mecStart, mecStart + 3, 'MEC', 'ORG'),
+      ann(outerStart, outerEnd, 'Ministério da Educação (MEC)', 'ORG'),
+    ])
+    const entities = segments.filter((s) => s.kind === 'entity')
+    expect(entities).toHaveLength(1)
+    expect(entities[0].text).toBe('Ministério da Educação (MEC)')
+  })
+
+  it('destaca múltiplas entidades distintas em ordem', () => {
+    const content = 'Lula e Haddad reuniram-se.'
+    const segments = buildSegments(content, [
+      ann(0, 4, 'Lula', 'PER', 'Q8412'),
+      ann(7, 13, 'Haddad', 'PER'),
+    ])
+    const entities = segments.filter((s) => s.kind === 'entity')
+    expect(entities.map((e) => e.text)).toEqual(['Lula', 'Haddad'])
+  })
+})
+
+describe('SemanticLens render', () => {
+  it('renderiza o destaque como link para a entidade canônica', () => {
+    const content = 'Sobre o Pé-de-Meia.'
+    const start = content.indexOf('Pé-de-Meia')
+    const end = start + 'Pé-de-Meia'.length
+    render(
+      <SemanticLens
+        content={content}
+        annotations={[ann(start, end, 'Pé-de-Meia', 'POLICY', 'dgb_xyz')]}
+      />,
+    )
+    const link = screen.getByRole('link', {
+      name: /Ver notícias sobre Pé-de-Meia/i,
+    })
+    expect(link).toHaveAttribute('href', '/entidades/dgb_xyz')
+  })
+
+  it('faz fallback para slug de texto quando não há id canônico', () => {
+    const content = 'Sobre o Pé-de-Meia.'
+    const start = content.indexOf('Pé-de-Meia')
+    const end = start + 'Pé-de-Meia'.length
+    render(
+      <SemanticLens
+        content={content}
+        annotations={[ann(start, end, 'Pé-de-Meia', 'POLICY', null)]}
+      />,
+    )
+    const link = screen.getByRole('link', {
+      name: /Ver notícias sobre Pé-de-Meia/i,
+    })
+    expect(link).toHaveAttribute('href', '/entidades/pe-de-meia')
+  })
+})

--- a/src/components/entities/EntityNetwork.tsx
+++ b/src/components/entities/EntityNetwork.tsx
@@ -14,12 +14,11 @@
  */
 
 import { useQuery } from '@tanstack/react-query'
-import { Network } from 'lucide-react'
+import { Maximize2, Minimize2, Network, X } from 'lucide-react'
 import dynamic from 'next/dynamic'
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { Button } from '@/components/ui/button'
 
-// Client-only: depende de window/canvas. ssr:false evita quebrar o SSR da página.
 const EntityNetworkGraph = dynamic(() => import('./EntityNetworkGraph'), {
   ssr: false,
   loading: () => (
@@ -55,11 +54,34 @@ export default function EntityNetwork({
   fetchNetwork,
 }: EntityNetworkProps) {
   const [open, setOpen] = useState(false)
+  const [expanded, setExpanded] = useState(false)
+
+  // Altura da viewport para o canvas maximizado.
+  const [viewportHeight, setViewportHeight] = useState(600)
+  useEffect(() => {
+    setViewportHeight(window.innerHeight)
+    const handler = () => setViewportHeight(window.innerHeight)
+    window.addEventListener('resize', handler)
+    return () => window.removeEventListener('resize', handler)
+  }, [])
+
+  // Bloqueia scroll e habilita Esc para fechar o overlay.
+  useEffect(() => {
+    if (!expanded) return
+    document.body.style.overflow = 'hidden'
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setExpanded(false)
+    }
+    document.addEventListener('keydown', onKey)
+    return () => {
+      document.body.style.overflow = ''
+      document.removeEventListener('keydown', onKey)
+    }
+  }, [expanded])
 
   const networkQ = useQuery({
     queryKey: ['entity-network', entityId, depth, limit],
     queryFn: () => fetchNetwork(entityId, depth, limit),
-    // Só dispara a query depois que o usuário liga o toggle.
     enabled: open,
     staleTime: 5 * 60 * 1000,
   })
@@ -67,21 +89,56 @@ export default function EntityNetwork({
   const network = networkQ.data
   const hasGraph = (network?.nodes.length ?? 0) > 0
 
+  function handleToggle() {
+    const next = !open
+    setOpen(next)
+    if (!next) setExpanded(false)
+  }
+
+  const graphContent =
+    !networkQ.isLoading && !networkQ.isError && hasGraph && network ? (
+      <EntityNetworkGraph network={network} egoId={entityId} />
+    ) : null
+
+  const hint = (
+    <p className="mt-2 text-center text-xs text-primary/40">
+      Clique em uma entidade para navegar. A espessura da linha indica quantas
+      notícias mencionam o par.
+    </p>
+  )
+
   return (
     <section className="mx-auto mb-12 max-w-3xl">
       <div className="mb-4 flex items-center justify-between gap-3">
         <h2 className="text-sm font-semibold uppercase tracking-wide text-primary/70">
           Rede de entidades
         </h2>
-        <Button
-          variant="ghost"
-          size="sm"
-          aria-pressed={open}
-          onClick={() => setOpen((v) => !v)}
-        >
-          <Network className="h-4 w-4" aria-hidden />
-          {open ? 'Ocultar rede' : 'Ver rede'}
-        </Button>
+        <div className="flex items-center gap-1">
+          {open && !networkQ.isError && (
+            <Button
+              variant="ghost"
+              size="sm"
+              aria-label={expanded ? 'Minimizar rede' : 'Maximizar rede'}
+              onClick={() => setExpanded((v) => !v)}
+            >
+              {expanded ? (
+                <Minimize2 className="h-4 w-4" aria-hidden />
+              ) : (
+                <Maximize2 className="h-4 w-4" aria-hidden />
+              )}
+              {expanded ? 'Minimizar' : 'Maximizar'}
+            </Button>
+          )}
+          <Button
+            variant="ghost"
+            size="sm"
+            aria-pressed={open}
+            onClick={handleToggle}
+          >
+            <Network className="h-4 w-4" aria-hidden />
+            {open ? 'Ocultar rede' : 'Ver rede'}
+          </Button>
+        </div>
       </div>
 
       {open && (
@@ -105,16 +162,57 @@ export default function EntityNetwork({
             </p>
           )}
 
-          {!networkQ.isLoading && !networkQ.isError && hasGraph && network && (
+          {graphContent && (
             <>
-              <EntityNetworkGraph network={network} egoId={entityId} />
-              <p className="mt-2 text-center text-xs text-primary/40">
-                Clique em uma entidade para navegar. A espessura da linha indica
-                quantas notícias mencionam o par.
-              </p>
+              {graphContent}
+              {hint}
             </>
           )}
         </div>
+      )}
+
+      {/* Overlay maximizado: canvas ocupa toda a viewport (z-50) e o botão
+          de fechar é fixed z-[60] — acima da stacking context do force-graph */}
+      {expanded && (
+        <>
+          {/* Canvas em tela cheia (ou estado de loading/vazio/erro) */}
+          <div className="fixed inset-0 z-[100] bg-background">
+            {networkQ.isLoading && (
+              <div className="flex h-full items-center justify-center text-sm text-primary/50">
+                Carregando rede…
+              </div>
+            )}
+            {!networkQ.isLoading && networkQ.isError && (
+              <div className="flex h-full items-center justify-center text-sm text-red-500">
+                Não foi possível carregar a rede de entidades.
+              </div>
+            )}
+            {!networkQ.isLoading && !networkQ.isError && !hasGraph && (
+              <div className="flex h-full items-center justify-center text-sm text-primary/50">
+                Ainda não há conexões suficientes para montar a rede desta
+                entidade.
+              </div>
+            )}
+            {hasGraph && network && (
+              <EntityNetworkGraph
+                network={network}
+                egoId={entityId}
+                height={viewportHeight}
+              />
+            )}
+          </div>
+
+          {/* Botão de fechar: z-[60] garante que fica acima do canvas */}
+          <button
+            type="button"
+            onClick={() => setExpanded(false)}
+            aria-label="Fechar visualização expandida (Esc)"
+            className="fixed right-4 top-4 z-[110] flex items-center gap-1.5 rounded-md border border-primary/20 bg-background/95 px-3 py-1.5 text-sm font-medium text-primary shadow-md backdrop-blur-sm transition-colors hover:bg-background"
+          >
+            <X className="h-4 w-4" aria-hidden />
+            Fechar
+          </button>
+        </>
       )}
     </section>
   )

--- a/src/components/entities/EntityNetwork.tsx
+++ b/src/components/entities/EntityNetwork.tsx
@@ -1,0 +1,121 @@
+'use client'
+
+/**
+ * Visualização de rede ego-centrada de uma entidade (Fase 6d).
+ *
+ * Wrapper client com toggle (default OFF): o grafo só carrega/renderiza quando
+ * o usuário liga — economiza a query e o canvas pesado para quem só quer ler as
+ * notícias. O canvas (`EntityNetworkGraph`) é importado dinamicamente com
+ * `ssr:false` porque `react-force-graph-2d` depende de `window`.
+ *
+ * A query (`entityNetwork`) roda via react-query através da server action
+ * `getEntityNetwork`. Toda a rede (nós + arestas) já vem capada pelo backend
+ * (`limit` + threshold de peso) para evitar hairball.
+ */
+
+import { useQuery } from '@tanstack/react-query'
+import { Network } from 'lucide-react'
+import dynamic from 'next/dynamic'
+import { useState } from 'react'
+import { Button } from '@/components/ui/button'
+
+// Client-only: depende de window/canvas. ssr:false evita quebrar o SSR da página.
+const EntityNetworkGraph = dynamic(() => import('./EntityNetworkGraph'), {
+  ssr: false,
+  loading: () => (
+    <div className="flex h-[420px] items-center justify-center rounded-lg border border-primary/10 bg-primary/[0.02] text-sm text-primary/50">
+      Carregando rede…
+    </div>
+  ),
+})
+
+export type EntityNetworkProps = {
+  /** Id canônico da entidade-foco (`Q…`/`dgb_…`). */
+  entityId: string
+  /** Profundidade da rede (saltos). Default 1 (vizinhos imediatos). */
+  depth?: number
+  /** Limite de nós retornados pelo backend. Default 50. */
+  limit?: number
+  /**
+   * Busca a rede. Injetável para testes; default usa a server action
+   * `getEntityNetwork` (resolvida no consumidor para evitar acoplar este
+   * componente client à action diretamente nos testes).
+   */
+  fetchNetwork: (
+    id: string,
+    depth: number,
+    limit: number,
+  ) => Promise<import('@/services/content/types').EntityNetwork>
+}
+
+export default function EntityNetwork({
+  entityId,
+  depth = 1,
+  limit = 50,
+  fetchNetwork,
+}: EntityNetworkProps) {
+  const [open, setOpen] = useState(false)
+
+  const networkQ = useQuery({
+    queryKey: ['entity-network', entityId, depth, limit],
+    queryFn: () => fetchNetwork(entityId, depth, limit),
+    // Só dispara a query depois que o usuário liga o toggle.
+    enabled: open,
+    staleTime: 5 * 60 * 1000,
+  })
+
+  const network = networkQ.data
+  const hasGraph = (network?.nodes.length ?? 0) > 0
+
+  return (
+    <section className="mx-auto mb-12 max-w-3xl">
+      <div className="mb-4 flex items-center justify-between gap-3">
+        <h2 className="text-sm font-semibold uppercase tracking-wide text-primary/70">
+          Rede de entidades
+        </h2>
+        <Button
+          variant="ghost"
+          size="sm"
+          aria-pressed={open}
+          onClick={() => setOpen((v) => !v)}
+        >
+          <Network className="h-4 w-4" aria-hidden />
+          {open ? 'Ocultar rede' : 'Ver rede'}
+        </Button>
+      </div>
+
+      {open && (
+        <div>
+          {networkQ.isLoading && (
+            <div className="flex h-[420px] items-center justify-center rounded-lg border border-primary/10 bg-primary/[0.02] text-sm text-primary/50">
+              Carregando rede…
+            </div>
+          )}
+
+          {!networkQ.isLoading && networkQ.isError && (
+            <p className="text-center text-sm text-red-500">
+              Não foi possível carregar a rede de entidades.
+            </p>
+          )}
+
+          {!networkQ.isLoading && !networkQ.isError && !hasGraph && (
+            <p className="text-center text-sm text-primary/50">
+              Ainda não há conexões suficientes para montar a rede desta
+              entidade.
+            </p>
+          )}
+
+          {!networkQ.isLoading && !networkQ.isError && hasGraph && network && (
+            <>
+              <EntityNetworkGraph network={network} egoId={entityId} />
+              <p className="mt-2 text-center text-xs text-primary/40">
+                Clique em uma entidade para navegar. A espessura da linha indica
+                quantas notícias mencionam o par.
+              </p>
+            </>
+          )}
+        </div>
+      )}
+    </section>
+  )
+}

--- a/src/components/entities/EntityNetworkGraph.tsx
+++ b/src/components/entities/EntityNetworkGraph.tsx
@@ -1,0 +1,99 @@
+'use client'
+
+/**
+ * Renderização da rede de entidades em canvas (force-directed), Fase 6d.
+ *
+ * Componente client-only: `react-force-graph-2d` depende de `window`/canvas e
+ * NÃO pode rodar em SSR — por isso é importado dinamicamente (ssr:false) pelo
+ * `EntityNetwork.tsx`. Aqui só assumimos que estamos no browser.
+ *
+ * Estética (frontend-design):
+ *   - cor do nó por tipo (reusa `entity-types.ts`, fonte única de verdade);
+ *   - a entidade-foco (ego) recebe anel destacado e raio maior;
+ *   - espessura da aresta ∝ peso (co-menção); grafo já vem capado pelo backend
+ *     (`limit`/threshold) — aqui só ajustamos legibilidade;
+ *   - clique no nó navega para a página da entidade.
+ */
+
+import { useRouter } from 'next/navigation'
+import { useMemo, useRef } from 'react'
+import ForceGraph2D from 'react-force-graph-2d'
+import type { EntityNetwork } from '@/services/content/types'
+import {
+  type GraphLink,
+  type GraphNode,
+  maxEdgeWeight,
+  toGraphData,
+} from './entity-network-data'
+
+export type EntityNetworkGraphProps = {
+  /** Rede a desenhar (nós + arestas). */
+  network: EntityNetwork
+  /** Id canônico da entidade-foco (ego). */
+  egoId: string
+  /** Altura do canvas (px). Default 420. */
+  height?: number
+}
+
+export default function EntityNetworkGraph({
+  network,
+  egoId,
+  height = 420,
+}: EntityNetworkGraphProps) {
+  const router = useRouter()
+  const containerRef = useRef<HTMLDivElement>(null)
+
+  const data = useMemo(() => toGraphData(network, egoId), [network, egoId])
+
+  // Peso máximo p/ normalizar a espessura das arestas (evita divisão por zero).
+  const maxWeight = useMemo(() => maxEdgeWeight(data.links), [data.links])
+
+  return (
+    <div
+      ref={containerRef}
+      className="w-full overflow-hidden rounded-lg border border-primary/10 bg-primary/[0.02]"
+      style={{ height }}
+    >
+      <ForceGraph2D
+        graphData={data}
+        height={height}
+        nodeRelSize={4}
+        nodeColor={(node) => (node as GraphNode).color}
+        nodeVal={(node) => (node as GraphNode).val}
+        cooldownTicks={80}
+        linkColor={() => 'rgba(15, 23, 42, 0.12)'}
+        linkWidth={(link) =>
+          0.5 + ((link as unknown as GraphLink).weight / maxWeight) * 3
+        }
+        onNodeClick={(node) => {
+          const id = (node as GraphNode).id
+          if (id) router.push(`/entidades/${id}`)
+        }}
+        nodeCanvasObjectMode={() => 'after'}
+        nodeCanvasObject={(node, ctx, globalScale) => {
+          const n = node as GraphNode & { x?: number; y?: number }
+          if (n.x == null || n.y == null) return
+
+          // Anel destacado para a entidade-foco (ego).
+          if (n.isEgo) {
+            ctx.beginPath()
+            ctx.arc(n.x, n.y, n.val + 2, 0, 2 * Math.PI)
+            ctx.strokeStyle = n.color
+            ctx.lineWidth = 1.5 / globalScale
+            ctx.stroke()
+          }
+
+          // Rótulo só quando há zoom suficiente — evita poluição no overview.
+          if (globalScale >= 1.2) {
+            const fontSize = 11 / globalScale
+            ctx.font = `${fontSize}px sans-serif`
+            ctx.textAlign = 'center'
+            ctx.textBaseline = 'top'
+            ctx.fillStyle = 'rgba(15, 23, 42, 0.75)'
+            ctx.fillText(n.name, n.x, n.y + n.val + 1)
+          }
+        }}
+      />
+    </div>
+  )
+}

--- a/src/components/entities/EntityNetworkGraph.tsx
+++ b/src/components/entities/EntityNetworkGraph.tsx
@@ -6,18 +6,11 @@
  * Componente client-only: `react-force-graph-2d` depende de `window`/canvas e
  * NÃO pode rodar em SSR — por isso é importado dinamicamente (ssr:false) pelo
  * `EntityNetwork.tsx`. Aqui só assumimos que estamos no browser.
- *
- * Estética (frontend-design):
- *   - cor do nó por tipo (reusa `entity-types.ts`, fonte única de verdade);
- *   - a entidade-foco (ego) recebe anel destacado e raio maior;
- *   - espessura da aresta ∝ peso (co-menção); grafo já vem capado pelo backend
- *     (`limit`/threshold) — aqui só ajustamos legibilidade;
- *   - clique no nó navega para a página da entidade.
  */
 
 import { useRouter } from 'next/navigation'
-import { useMemo, useRef } from 'react'
-import ForceGraph2D from 'react-force-graph-2d'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import ForceGraph2D, { type ForceGraphMethods } from 'react-force-graph-2d'
 import type { EntityNetwork } from '@/services/content/types'
 import {
   type GraphLink,
@@ -42,10 +35,37 @@ export default function EntityNetworkGraph({
 }: EntityNetworkGraphProps) {
   const router = useRouter()
   const containerRef = useRef<HTMLDivElement>(null)
+  const graphRef = useRef<ForceGraphMethods | undefined>(undefined)
+  const fitted = useRef(false)
+
+  // Mede a largura real do container para o canvas — sem isso o grafo fica
+  // descentralizado quando o container é menor que o default interno do ForceGraph.
+  const [canvasWidth, setCanvasWidth] = useState(800)
+
+  useEffect(() => {
+    const el = containerRef.current
+    if (!el) return
+    const ro = new ResizeObserver((entries) => {
+      const w = entries[0]?.contentRect.width
+      if (w && w > 0) {
+        setCanvasWidth(w)
+        // Re-fit ao mudar dimensão (ex.: toggle maximizar).
+        fitted.current = false
+      }
+    })
+    ro.observe(el)
+    return () => ro.disconnect()
+  }, [])
+
+  // Centraliza o grafo assim que a simulação estabiliza.
+  const handleEngineStop = useCallback(() => {
+    if (!fitted.current) {
+      graphRef.current?.zoomToFit(400, 24)
+      fitted.current = true
+    }
+  }, [])
 
   const data = useMemo(() => toGraphData(network, egoId), [network, egoId])
-
-  // Peso máximo p/ normalizar a espessura das arestas (evita divisão por zero).
   const maxWeight = useMemo(() => maxEdgeWeight(data.links), [data.links])
 
   return (
@@ -55,8 +75,11 @@ export default function EntityNetworkGraph({
       style={{ height }}
     >
       <ForceGraph2D
+        ref={graphRef}
         graphData={data}
         height={height}
+        width={canvasWidth}
+        onEngineStop={handleEngineStop}
         nodeRelSize={4}
         nodeColor={(node) => (node as GraphNode).color}
         nodeVal={(node) => (node as GraphNode).val}
@@ -74,7 +97,6 @@ export default function EntityNetworkGraph({
           const n = node as GraphNode & { x?: number; y?: number }
           if (n.x == null || n.y == null) return
 
-          // Anel destacado para a entidade-foco (ego).
           if (n.isEgo) {
             ctx.beginPath()
             ctx.arc(n.x, n.y, n.val + 2, 0, 2 * Math.PI)
@@ -83,7 +105,6 @@ export default function EntityNetworkGraph({
             ctx.stroke()
           }
 
-          // Rótulo só quando há zoom suficiente — evita poluição no overview.
           if (globalScale >= 1.2) {
             const fontSize = 11 / globalScale
             ctx.font = `${fontSize}px sans-serif`

--- a/src/components/entities/RelatedEntities.tsx
+++ b/src/components/entities/RelatedEntities.tsx
@@ -1,0 +1,66 @@
+/**
+ * Seção "Entidades relacionadas" da página `/entidades/[id]` (Fase 6d).
+ *
+ * Renderiza chips a partir de `relatedEntities` (co-menção, 1-hop): cada chip é
+ * um Link para a página da entidade vizinha (`/entidades/{canonicalId}`), com
+ * cor/ícone por tipo (reusando `lib/entity-types.ts`) e o peso da aresta
+ * ("N notícias juntas"). A seção se esconde quando não há vizinhos — o grafo é
+ * parcial (cresce conforme o backfill de canonicalização avança).
+ *
+ * Componente puro/presentacional (recebe os dados prontos) — testável sem rede.
+ */
+
+import Link from 'next/link'
+import { Badge } from '@/components/ui/badge'
+import { entityTypeStyle } from '@/lib/entity-types'
+import type { RelatedEntity } from '@/services/content/types'
+
+/** Rótulo do peso da aresta, em PT-BR ("3 notícias juntas"). */
+function weightLabel(weight: number): string {
+  const n = new Intl.NumberFormat('pt-BR').format(weight)
+  return `${n} notícia${weight === 1 ? '' : 's'} juntas`
+}
+
+function RelatedEntityChip({ entity }: { entity: RelatedEntity }) {
+  const style = entityTypeStyle(entity.type ?? 'OTHER')
+  const Icon = style.icon
+  const name = entity.canonicalName ?? entity.canonicalId
+
+  return (
+    <Link
+      href={`/entidades/${entity.canonicalId}`}
+      aria-label={`Ver a entidade ${name} (${weightLabel(entity.weight)})`}
+    >
+      <Badge className="gap-1.5 bg-white py-1 pr-2.5 pl-2 font-medium text-primary transition-colors hover:bg-primary/5 cursor-pointer">
+        <span
+          className={`inline-block h-1.5 w-1.5 rounded-full ${style.dot}`}
+          aria-hidden
+        />
+        <Icon className="h-3.5 w-3.5 text-primary/50" aria-hidden />
+        {name}
+        <span className="ml-0.5 text-primary/40">{entity.weight}</span>
+      </Badge>
+    </Link>
+  )
+}
+
+export function RelatedEntities({
+  entities,
+}: {
+  entities?: RelatedEntity[] | null
+}) {
+  if (!entities || entities.length === 0) return null
+
+  return (
+    <section className="mx-auto mb-12 max-w-3xl">
+      <h2 className="mb-4 text-sm font-semibold uppercase tracking-wide text-primary/70">
+        Entidades relacionadas
+      </h2>
+      <div className="flex flex-wrap gap-2">
+        {entities.map((entity) => (
+          <RelatedEntityChip key={entity.canonicalId} entity={entity} />
+        ))}
+      </div>
+    </section>
+  )
+}

--- a/src/components/entities/TrendingEntitiesSection.tsx
+++ b/src/components/entities/TrendingEntitiesSection.tsx
@@ -1,0 +1,98 @@
+import Link from 'next/link'
+import { entityTypeStyle } from '@/lib/entity-types'
+import type { TrendingEntity } from '@/services/content/types'
+
+function GrowthBadge({ volumeRatio }: { volumeRatio: number }) {
+  const label = `↑${volumeRatio.toFixed(1)}×`
+  return (
+    <span className="inline-flex items-center rounded-full bg-green-100 px-2 py-0.5 text-xs font-semibold text-green-800">
+      {label}
+    </span>
+  )
+}
+
+function TrendingEntityCard({ entity }: { entity: TrendingEntity }) {
+  const style = entityTypeStyle(entity.type)
+  const Icon = style.icon
+
+  return (
+    <Link
+      href={`/entidades/${entity.entityId}`}
+      className="
+        group relative rounded-xl border bg-card p-5 flex flex-col gap-3
+        overflow-hidden transition-all duration-300 hover:shadow-lg hover:-translate-y-[2px]
+      "
+      data-testid="trending-entity-card"
+    >
+      <div className="flex items-start justify-between gap-2">
+        <div className="flex items-center gap-2 min-w-0">
+          <span
+            className="flex-shrink-0 flex h-7 w-7 items-center justify-center rounded-md"
+            style={{ backgroundColor: `${style.color}20`, color: style.color }}
+          >
+            <Icon className="h-4 w-4" />
+          </span>
+          <span className="text-xs font-medium text-muted-foreground truncate">
+            {style.label}
+          </span>
+        </div>
+        <GrowthBadge volumeRatio={entity.volumeRatio} />
+      </div>
+
+      <p className="font-semibold text-sm leading-snug text-foreground group-hover:text-primary transition-colors line-clamp-2">
+        {entity.canonicalName}
+      </p>
+
+      <p className="text-xs text-muted-foreground mt-auto">
+        {entity.windowCount} {entity.windowCount === 1 ? 'artigo' : 'artigos'}{' '}
+        esta semana
+      </p>
+    </Link>
+  )
+}
+
+export function TrendingEntitiesSection({
+  entities,
+}: {
+  entities: TrendingEntity[]
+}) {
+  if (entities.length === 0) return null
+
+  return (
+    <section
+      className="py-12 bg-muted/30"
+      data-testid="trending-entities-section"
+    >
+      <div className="container mx-auto px-4">
+        <div className="flex items-center justify-between mb-8">
+          <div className="flex items-start">
+            <img
+              src="/vertical-ribbon.svg"
+              alt="decorativo"
+              className="w-2 h-14 mr-4 mt-1"
+            />
+            <div>
+              <h2 className="text-2xl font-bold">Entidades em Alta</h2>
+              <p className="text-sm text-muted-foreground mt-1">
+                Organizações e pessoas com maior crescimento de cobertura nos
+                últimos 7 dias.
+              </p>
+            </div>
+          </div>
+          <Link
+            href="/entidades"
+            className="text-sm text-primary hover:underline whitespace-nowrap"
+          >
+            Ver todas
+          </Link>
+        </div>
+
+        <div className="grid grid-cols-2 md:grid-cols-3 gap-4">
+          {entities.map((entity) => (
+            <TrendingEntityCard key={entity.entityId} entity={entity} />
+          ))}
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/src/components/entities/__tests__/EntityNetwork.test.tsx
+++ b/src/components/entities/__tests__/EntityNetwork.test.tsx
@@ -1,0 +1,104 @@
+import { screen, waitFor } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import { render } from '@/__tests__/test-utils'
+import type { EntityNetwork as EntityNetworkData } from '@/services/content/types'
+import EntityNetwork from '../EntityNetwork'
+
+// Mock do canvas (client-only, depende de window): substituímos por um marcador
+// simples para validar a orquestração (toggle/fetch/estados) sem renderizar o
+// force-graph de verdade.
+vi.mock('../EntityNetworkGraph', () => ({
+  default: ({ egoId }: { egoId: string }) => (
+    <div data-testid="network-graph">graph:{egoId}</div>
+  ),
+}))
+
+const NETWORK: EntityNetworkData = {
+  nodes: [
+    { entityId: 'Q1', canonicalName: 'Finep', type: 'ORG', wikidataId: 'Q1' },
+    { entityId: 'Q2', canonicalName: 'MCTI', type: 'ORG', wikidataId: 'Q2' },
+  ],
+  edges: [{ src: 'Q1', dst: 'Q2', weight: 5, kind: 'co_mention' }],
+}
+
+const EMPTY: EntityNetworkData = { nodes: [], edges: [] }
+
+describe('EntityNetwork', () => {
+  it('começa com o toggle desligado (rede não carregada)', () => {
+    const fetchNetwork = vi.fn().mockResolvedValue(NETWORK)
+    render(<EntityNetwork entityId="Q1" fetchNetwork={fetchNetwork} />)
+
+    // Toggle visível, mas a query NÃO dispara enquanto OFF.
+    expect(
+      screen.getByRole('button', { name: /Ver rede/i }),
+    ).toBeInTheDocument()
+    expect(fetchNetwork).not.toHaveBeenCalled()
+    expect(screen.queryByTestId('network-graph')).not.toBeInTheDocument()
+  })
+
+  it('liga o toggle, busca e renderiza o grafo', async () => {
+    const fetchNetwork = vi.fn().mockResolvedValue(NETWORK)
+    const { user } = render(
+      <EntityNetwork entityId="Q1" fetchNetwork={fetchNetwork} />,
+    )
+
+    await user.click(screen.getByRole('button', { name: /Ver rede/i }))
+
+    await waitFor(() =>
+      expect(screen.getByTestId('network-graph')).toBeInTheDocument(),
+    )
+    expect(fetchNetwork).toHaveBeenCalledWith('Q1', 1, 50)
+    expect(screen.getByTestId('network-graph')).toHaveTextContent('graph:Q1')
+    // O botão passa a oferecer ocultar.
+    expect(
+      screen.getByRole('button', { name: /Ocultar rede/i }),
+    ).toBeInTheDocument()
+  })
+
+  it('mostra estado vazio quando a rede não tem nós', async () => {
+    const fetchNetwork = vi.fn().mockResolvedValue(EMPTY)
+    const { user } = render(
+      <EntityNetwork entityId="Q1" fetchNetwork={fetchNetwork} />,
+    )
+
+    await user.click(screen.getByRole('button', { name: /Ver rede/i }))
+
+    await waitFor(() =>
+      expect(
+        screen.getByText(/Ainda não há conexões suficientes/i),
+      ).toBeInTheDocument(),
+    )
+    expect(screen.queryByTestId('network-graph')).not.toBeInTheDocument()
+  })
+
+  it('mostra estado de erro quando a busca falha', async () => {
+    const fetchNetwork = vi.fn().mockRejectedValue(new Error('boom'))
+    const { user } = render(
+      <EntityNetwork entityId="Q1" fetchNetwork={fetchNetwork} />,
+    )
+
+    await user.click(screen.getByRole('button', { name: /Ver rede/i }))
+
+    await waitFor(() =>
+      expect(
+        screen.getByText(/Não foi possível carregar a rede/i),
+      ).toBeInTheDocument(),
+    )
+  })
+
+  it('repassa depth/limit customizados para o fetch', async () => {
+    const fetchNetwork = vi.fn().mockResolvedValue(NETWORK)
+    const { user } = render(
+      <EntityNetwork
+        entityId="Q9"
+        depth={2}
+        limit={30}
+        fetchNetwork={fetchNetwork}
+      />,
+    )
+
+    await user.click(screen.getByRole('button', { name: /Ver rede/i }))
+
+    await waitFor(() => expect(fetchNetwork).toHaveBeenCalledWith('Q9', 2, 30))
+  })
+})

--- a/src/components/entities/__tests__/RelatedEntities.test.tsx
+++ b/src/components/entities/__tests__/RelatedEntities.test.tsx
@@ -1,0 +1,71 @@
+import { screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import { render } from '@/__tests__/test-utils'
+import type { RelatedEntity } from '@/services/content/types'
+import { RelatedEntities } from '../RelatedEntities'
+
+function rel(
+  canonicalId: string,
+  canonicalName: string | null,
+  type: string | null,
+  weight: number,
+  kind = 'co_mention',
+): RelatedEntity {
+  return { canonicalId, canonicalName, type, wikidataId: null, weight, kind }
+}
+
+describe('RelatedEntities', () => {
+  it('não renderiza nada quando não há entidades', () => {
+    const { container } = render(<RelatedEntities entities={[]} />)
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('não renderiza nada quando entities é null/undefined', () => {
+    const { container } = render(<RelatedEntities entities={null} />)
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('renderiza o cabeçalho e um chip por entidade', () => {
+    render(
+      <RelatedEntities
+        entities={[
+          rel('Q216330', 'Ministério da Saúde', 'ORG', 12),
+          rel('Q12345', 'Lula', 'PER', 8),
+        ]}
+      />,
+    )
+    expect(screen.getByText('Entidades relacionadas')).toBeInTheDocument()
+    expect(screen.getAllByRole('link')).toHaveLength(2)
+  })
+
+  it('linka cada chip para a página canônica da entidade vizinha', () => {
+    render(
+      <RelatedEntities
+        entities={[rel('Q216330', 'Ministério da Saúde', 'ORG', 5)]}
+      />,
+    )
+    const link = screen.getByRole('link', {
+      name: /Ver a entidade Ministério da Saúde/i,
+    })
+    expect(link).toHaveAttribute('href', '/entidades/Q216330')
+  })
+
+  it('exibe o peso da aresta no aria-label ("N notícias juntas")', () => {
+    render(<RelatedEntities entities={[rel('Q1', 'Finep', 'ORG', 3)]} />)
+    expect(
+      screen.getByRole('link', { name: /3 notícias juntas/i }),
+    ).toBeInTheDocument()
+  })
+
+  it('singulariza o peso quando é 1 notícia', () => {
+    render(<RelatedEntities entities={[rel('Q1', 'Finep', 'ORG', 1)]} />)
+    expect(
+      screen.getByRole('link', { name: /1 notícia juntas/i }),
+    ).toBeInTheDocument()
+  })
+
+  it('cai no id canônico como rótulo quando não há canonicalName', () => {
+    render(<RelatedEntities entities={[rel('dgb_abc', null, 'ORG', 2)]} />)
+    expect(screen.getByText('dgb_abc')).toBeInTheDocument()
+  })
+})

--- a/src/components/entities/__tests__/entity-network-data.test.ts
+++ b/src/components/entities/__tests__/entity-network-data.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from 'vitest'
+import { entityTypeStyle } from '@/lib/entity-types'
+import type { EntityNetwork } from '@/services/content/types'
+import { maxEdgeWeight, toGraphData } from '../entity-network-data'
+
+const NETWORK: EntityNetwork = {
+  nodes: [
+    { entityId: 'Q1', canonicalName: 'Finep', type: 'ORG', wikidataId: 'Q1' },
+    { entityId: 'Q2', canonicalName: 'MCTI', type: 'ORG', wikidataId: 'Q2' },
+    { entityId: 'Q3', canonicalName: 'Lula', type: 'PER', wikidataId: 'Q3' },
+  ],
+  edges: [
+    { src: 'Q1', dst: 'Q2', weight: 7, kind: 'co_mention' },
+    { src: 'Q1', dst: 'Q3', weight: 3, kind: 'co_mention' },
+  ],
+}
+
+describe('toGraphData', () => {
+  it('mapeia nós e links 1:1', () => {
+    const data = toGraphData(NETWORK, 'Q1')
+    expect(data.nodes).toHaveLength(3)
+    expect(data.links).toHaveLength(2)
+    expect(data.links[0]).toMatchObject({
+      source: 'Q1',
+      target: 'Q2',
+      weight: 7,
+    })
+  })
+
+  it('marca a entidade-foco como ego com raio maior', () => {
+    const data = toGraphData(NETWORK, 'Q1')
+    const ego = data.nodes.find((n) => n.id === 'Q1')
+    const other = data.nodes.find((n) => n.id === 'Q3')
+    expect(ego?.isEgo).toBe(true)
+    expect(other?.isEgo).toBe(false)
+    // Ego (grau 2, piso 6) > nó folha (grau 1, piso 2).
+    expect(ego?.val).toBeGreaterThan(other?.val ?? 0)
+  })
+
+  it('atribui cor por tipo (fonte única: entity-types)', () => {
+    const data = toGraphData(NETWORK, 'Q1')
+    const org = data.nodes.find((n) => n.id === 'Q1')
+    const per = data.nodes.find((n) => n.id === 'Q3')
+    expect(org?.color).toBe(entityTypeStyle('ORG').color)
+    expect(per?.color).toBe(entityTypeStyle('PER').color)
+  })
+
+  it('usa o id como nome quando canonicalName é nulo', () => {
+    const data = toGraphData(
+      {
+        nodes: [
+          {
+            entityId: 'dgb_x',
+            canonicalName: null,
+            type: null,
+            wikidataId: null,
+          },
+        ],
+        edges: [],
+      },
+      'dgb_x',
+    )
+    expect(data.nodes[0].name).toBe('dgb_x')
+    // Tipo nulo cai no estilo OTHER.
+    expect(data.nodes[0].color).toBe(entityTypeStyle('OTHER').color)
+  })
+})
+
+describe('maxEdgeWeight', () => {
+  it('retorna o maior peso', () => {
+    expect(
+      maxEdgeWeight([
+        { source: 'a', target: 'b', weight: 2 },
+        { source: 'a', target: 'c', weight: 9 },
+      ]),
+    ).toBe(9)
+  })
+
+  it('retorna 1 (piso) quando não há arestas — evita divisão por zero', () => {
+    expect(maxEdgeWeight([])).toBe(1)
+  })
+})

--- a/src/components/entities/entity-network-data.ts
+++ b/src/components/entities/entity-network-data.ts
@@ -1,0 +1,68 @@
+/**
+ * Transformação pura rede → dados do force-graph (Fase 6d).
+ *
+ * Isolada do componente de canvas (`EntityNetworkGraph.tsx`) para ser testável
+ * sem importar `react-force-graph-2d` (client-only, depende de `window`).
+ *
+ * Deduz cor por tipo (reusa `entity-types.ts`) e o raio (`val`) a partir do grau
+ * (nº de arestas incidentes); a entidade-foco (ego) ganha um piso de raio maior.
+ */
+
+import { entityTypeStyle } from '@/lib/entity-types'
+import type { EntityNetwork } from '@/services/content/types'
+
+export type GraphNode = {
+  id: string
+  name: string
+  type: string | null
+  color: string
+  isEgo: boolean
+  val: number
+}
+
+export type GraphLink = {
+  source: string
+  target: string
+  weight: number
+}
+
+export type GraphData = {
+  nodes: GraphNode[]
+  links: GraphLink[]
+}
+
+/** Converte a rede do facade em nós/links do force-graph. */
+export function toGraphData(network: EntityNetwork, egoId: string): GraphData {
+  const degree = new Map<string, number>()
+  for (const edge of network.edges) {
+    degree.set(edge.src, (degree.get(edge.src) ?? 0) + 1)
+    degree.set(edge.dst, (degree.get(edge.dst) ?? 0) + 1)
+  }
+
+  const nodes: GraphNode[] = network.nodes.map((n) => {
+    const isEgo = n.entityId === egoId
+    const deg = degree.get(n.entityId) ?? 0
+    return {
+      id: n.entityId,
+      name: n.canonicalName ?? n.entityId,
+      type: n.type,
+      color: entityTypeStyle(n.type ?? 'OTHER').color,
+      isEgo,
+      // Raio cresce com o grau (suave), com piso maior para o ego.
+      val: (isEgo ? 6 : 2) + Math.sqrt(deg),
+    }
+  })
+
+  const links: GraphLink[] = network.edges.map((e) => ({
+    source: e.src,
+    target: e.dst,
+    weight: e.weight,
+  }))
+
+  return { nodes, links }
+}
+
+/** Maior peso entre as arestas (>= 1), p/ normalizar a espessura das linhas. */
+export function maxEdgeWeight(links: GraphLink[]): number {
+  return Math.max(1, ...links.map((l) => l.weight))
+}

--- a/src/components/filters/EntityMultiSelect.tsx
+++ b/src/components/filters/EntityMultiSelect.tsx
@@ -1,0 +1,118 @@
+'use client'
+
+import { useQuery } from '@tanstack/react-query'
+import { Check, Loader2 } from 'lucide-react'
+import * as React from 'react'
+import { getEntitySuggestions } from '@/app/(public)/busca/actions'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+
+type EntityMultiSelectProps = {
+  /** Textos canônicos de entidades já selecionados. */
+  selectedEntities: string[]
+  onSelectedEntitiesChange: (entities: string[]) => void
+  /** Restringe as sugestões a um tipo (ORG/PER/LOC). Ausente = campo combinado. */
+  type?: string | null
+}
+
+const DEBOUNCE_MS = 300
+const MIN_QUERY_LENGTH = 2
+
+export function EntityMultiSelect({
+  selectedEntities,
+  onSelectedEntitiesChange,
+  type = null,
+}: EntityMultiSelectProps) {
+  const [searchTerm, setSearchTerm] = React.useState('')
+  const [debouncedTerm, setDebouncedTerm] = React.useState('')
+  const debounceRef = React.useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  // Debounce do termo digitado antes de consultar as sugestões.
+  React.useEffect(() => {
+    if (debounceRef.current) clearTimeout(debounceRef.current)
+    debounceRef.current = setTimeout(() => {
+      setDebouncedTerm(searchTerm.trim())
+    }, DEBOUNCE_MS)
+    return () => {
+      if (debounceRef.current) clearTimeout(debounceRef.current)
+    }
+  }, [searchTerm])
+
+  const suggestionsQ = useQuery({
+    queryKey: ['entitySuggestions', debouncedTerm, type],
+    queryFn: () => getEntitySuggestions(debouncedTerm, type, 10),
+    enabled: debouncedTerm.length >= MIN_QUERY_LENGTH,
+    staleTime: 60_000,
+  })
+
+  const suggestions = suggestionsQ.data ?? []
+  const isLoading =
+    debouncedTerm.length >= MIN_QUERY_LENGTH &&
+    (suggestionsQ.isLoading || suggestionsQ.isFetching)
+
+  const toggleEntity = React.useCallback(
+    (value: string) => {
+      onSelectedEntitiesChange(
+        selectedEntities.includes(value)
+          ? selectedEntities.filter((v) => v !== value)
+          : [...selectedEntities, value],
+      )
+    },
+    [selectedEntities, onSelectedEntitiesChange],
+  )
+
+  return (
+    <div className="relative w-full">
+      <Input
+        type="text"
+        placeholder="Buscar entidades..."
+        value={searchTerm}
+        onChange={(e) => setSearchTerm(e.target.value)}
+        className="bg-white"
+        aria-label="Buscar entidades"
+      />
+
+      {debouncedTerm.length >= MIN_QUERY_LENGTH && (
+        <div className="mt-2 max-h-60 overflow-y-auto rounded-md border border-border bg-white">
+          {isLoading ? (
+            <div className="flex items-center justify-center gap-2 py-4 text-sm text-muted-foreground">
+              <Loader2 className="h-4 w-4 animate-spin" />
+              Buscando...
+            </div>
+          ) : suggestions.length === 0 ? (
+            <div className="py-4 text-center text-sm text-muted-foreground">
+              Nenhuma entidade encontrada
+            </div>
+          ) : (
+            <div className="p-1">
+              {suggestions.map((s) => {
+                const isSelected = selectedEntities.includes(s.value)
+                return (
+                  <Button
+                    key={s.value}
+                    type="button"
+                    variant="ghost"
+                    onClick={() => toggleEntity(s.value)}
+                    className="h-auto w-full justify-between gap-2 px-3 py-2 text-left font-normal"
+                    aria-pressed={isSelected}
+                  >
+                    <span className="flex min-w-0 items-center gap-2">
+                      <Check
+                        className={`h-4 w-4 flex-shrink-0 ${isSelected ? 'opacity-100 text-primary' : 'opacity-0'}`}
+                        aria-hidden
+                      />
+                      <span className="truncate">{s.value}</span>
+                    </span>
+                    <span className="flex-shrink-0 text-xs text-muted-foreground">
+                      {s.count}
+                    </span>
+                  </Button>
+                )
+              })}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/lib/__tests__/entity-slug.test.ts
+++ b/src/lib/__tests__/entity-slug.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest'
+import {
+  deslugifyEntity,
+  isCanonicalEntityId,
+  matchEntityBySlug,
+  slugifyEntity,
+} from '@/lib/entity-slug'
+
+describe('slugifyEntity', () => {
+  it('converte texto acentuado em kebab-case sem acentos', () => {
+    expect(slugifyEntity('Ministério da Saúde')).toBe('ministerio-da-saude')
+    expect(slugifyEntity('Lula')).toBe('lula')
+  })
+
+  it('remove pontuação e hífens nas pontas', () => {
+    expect(slugifyEntity('Minha Casa, Minha Vida')).toBe(
+      'minha-casa-minha-vida',
+    )
+    expect(slugifyEntity('  (FINEP)  ')).toBe('finep')
+  })
+})
+
+describe('isCanonicalEntityId', () => {
+  it('reconhece QIDs do Wikidata', () => {
+    expect(isCanonicalEntityId('Q216330')).toBe(true)
+    expect(isCanonicalEntityId('Q1')).toBe(true)
+  })
+
+  it('reconhece ids internos dgb_', () => {
+    expect(isCanonicalEntityId('dgb_01h8xyz')).toBe(true)
+    expect(isCanonicalEntityId('dgb_')).toBe(true)
+  })
+
+  it('trata texto legado (kebab-case) como NÃO canônico', () => {
+    expect(isCanonicalEntityId('ministerio-da-saude')).toBe(false)
+    expect(isCanonicalEntityId('lula')).toBe(false)
+    expect(isCanonicalEntityId('bolsa-familia')).toBe(false)
+  })
+
+  it('não confunde QID parcial/inválido com canônico', () => {
+    // 'Q' sem dígitos, ou 'Q' seguido de não-dígitos → legado.
+    expect(isCanonicalEntityId('Q')).toBe(false)
+    expect(isCanonicalEntityId('Qabc')).toBe(false)
+    expect(isCanonicalEntityId('Q216330-extra')).toBe(false)
+  })
+})
+
+describe('matchEntityBySlug', () => {
+  it('prefere match exato de slug', () => {
+    const candidates = ['Ministério da Saúde', 'Ministério da Saúde do Líbano']
+    expect(matchEntityBySlug('ministerio-da-saude', candidates)).toBe(
+      'Ministério da Saúde',
+    )
+  })
+
+  it('cai em match por prefixo quando não há exato', () => {
+    const candidates = ['Ministério da Saúde do Líbano']
+    expect(matchEntityBySlug('ministerio-da-saude', candidates)).toBe(
+      'Ministério da Saúde do Líbano',
+    )
+  })
+
+  it('retorna null quando nada casa', () => {
+    expect(matchEntityBySlug('inexistente', ['Lula'])).toBeNull()
+  })
+})
+
+describe('deslugifyEntity', () => {
+  it('reconstrói uma string de busca aproximada', () => {
+    expect(deslugifyEntity('ministerio-da-saude')).toBe('ministerio da saude')
+  })
+})

--- a/src/lib/entity-slug.ts
+++ b/src/lib/entity-slug.ts
@@ -12,6 +12,22 @@
 import { removeDiacritics } from '@/lib/utils'
 
 /**
+ * Um slug de entidade é um **id canônico** (chave do `entity_registry`) quando
+ * é um QID do Wikidata (`Q` seguido de dígitos, ex.: `Q216330`) ou um id interno
+ * `dgb_<ulid>`. Nesse caso a página resolve o cabeçalho via `entity(id)` e lista
+ * artigos por `filter.entityCanonical`. Caso contrário, o slug é texto legado
+ * (kebab-case) e mantém o comportamento fuzzy-text (`resolveEntity`).
+ *
+ * @example
+ * isCanonicalEntityId('Q216330') // true
+ * isCanonicalEntityId('dgb_01h8...') // true
+ * isCanonicalEntityId('ministerio-da-saude') // false
+ */
+export function isCanonicalEntityId(slug: string): boolean {
+  return /^Q\d+$/.test(slug) || /^dgb_/.test(slug)
+}
+
+/**
  * Converte o texto canônico de uma entidade em um slug URL-safe.
  *
  * @example

--- a/src/lib/entity-slug.ts
+++ b/src/lib/entity-slug.ts
@@ -1,0 +1,55 @@
+/**
+ * Helpers de slug para páginas de entidade (`/entidades/[slug]`).
+ *
+ * O slug é uma forma kebab-case sem acentos do texto canônico da entidade
+ * (ex.: "Ministério da Saúde" → "ministerio-da-saude"). Como o filtro de busca
+ * (`filter.entities`) precisa do TEXTO canônico exato (não do slug), a página
+ * resolve o texto via `entitySuggestions(query=<deslug aproximado>)` e escolhe
+ * o melhor match. `deslugifyEntity` produz uma string legível só para alimentar
+ * essa busca por prefixo — não é o texto canônico.
+ */
+
+import { removeDiacritics } from '@/lib/utils'
+
+/**
+ * Converte o texto canônico de uma entidade em um slug URL-safe.
+ *
+ * @example
+ * slugifyEntity('Ministério da Saúde') // 'ministerio-da-saude'
+ * slugifyEntity('Lula') // 'lula'
+ */
+export function slugifyEntity(text: string): string {
+  return removeDiacritics(text)
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9]+/g, '-') // não-alfanuméricos → hífen
+    .replace(/^-+|-+$/g, '') // remove hífens nas pontas
+}
+
+/**
+ * Converte um slug de volta para uma string de busca aproximada (legível),
+ * usada como `query` em `entitySuggestions` para reencontrar o texto canônico.
+ * NÃO produz o texto canônico exato (acentos/caixa se perdem no slug).
+ *
+ * @example
+ * deslugifyEntity('ministerio-da-saude') // 'ministerio da saude'
+ */
+export function deslugifyEntity(slug: string): string {
+  return slug.replace(/-+/g, ' ').trim()
+}
+
+/**
+ * Dado um slug e uma lista de candidatos (textos canônicos), escolhe o que
+ * melhor casa: primeiro um match exato de slug; senão, o primeiro candidato
+ * cujo slug começa com o slug-alvo; senão `null`.
+ */
+export function matchEntityBySlug(
+  slug: string,
+  candidates: string[],
+): string | null {
+  const target = slugifyEntity(deslugifyEntity(slug))
+  const exact = candidates.find((c) => slugifyEntity(c) === target)
+  if (exact) return exact
+  const prefix = candidates.find((c) => slugifyEntity(c).startsWith(target))
+  return prefix ?? null
+}

--- a/src/lib/entity-types.ts
+++ b/src/lib/entity-types.ts
@@ -1,0 +1,103 @@
+/**
+ * Fonte única de verdade do esquema visual de tipos de entidade (NER).
+ *
+ * Os mesmos tipos e cores são consumidos por:
+ *   - `ArticleFeatures.tsx` (chips agrupados "Entidades mencionadas")
+ *   - `EntityPageClient.tsx` (cabeçalho da página de entidade canônica)
+ *   - `SemanticLens.tsx` (destaque inline da lente semântica)
+ *
+ * A paleta segue o esquema institucional (government-blue/green/yellow já em uso)
+ * e atribui cores distintas a cada tipo, mantendo coesão com o design do artigo.
+ */
+
+import {
+  Building2,
+  CalendarDays,
+  Landmark,
+  type LucideIcon,
+  MapPin,
+  Tag as TagIcon,
+  User,
+} from 'lucide-react'
+
+/** Tipos de entidade sancionados pela taxonomia NER evoluída. */
+export type EntityTypeKey = 'ORG' | 'PER' | 'LOC' | 'EVENT' | 'POLICY' | 'OTHER'
+
+/** Estilo visual de um tipo de entidade. */
+export type EntityTypeStyle = {
+  /** Rótulo do grupo (plural), exibido no cabeçalho de seção dos chips. */
+  label: string
+  /** Ícone lucide representativo do tipo. */
+  icon: LucideIcon
+  /** Classe Tailwind de cor de fundo do "dot" (marcador do grupo). */
+  dot: string
+  /**
+   * Classes Tailwind do destaque inline da lente: tint de fundo sutil + borda
+   * inferior colorida. NÃO é um chip cheio — preserva o fluxo de leitura.
+   */
+  lens: string
+}
+
+/**
+ * Mapa tipo → estilo. As cores government-* já existem no tema (globals.css);
+ * EVENT/POLICY ganham tons coerentes (roxo/laranja) que se distinguem dos três
+ * tipos base sem destoar do esquema institucional.
+ */
+export const ENTITY_TYPE_STYLES: Record<EntityTypeKey, EntityTypeStyle> = {
+  ORG: {
+    label: 'Instituições',
+    icon: Building2,
+    dot: 'bg-government-blue',
+    lens: 'bg-government-blue/10 border-b-2 border-government-blue/50 hover:bg-government-blue/20',
+  },
+  PER: {
+    label: 'Pessoas',
+    icon: User,
+    dot: 'bg-government-green',
+    lens: 'bg-government-green/10 border-b-2 border-government-green/50 hover:bg-government-green/20',
+  },
+  LOC: {
+    label: 'Locais',
+    icon: MapPin,
+    dot: 'bg-government-yellow',
+    lens: 'bg-government-yellow/15 border-b-2 border-government-yellow/60 hover:bg-government-yellow/25',
+  },
+  EVENT: {
+    label: 'Eventos',
+    icon: CalendarDays,
+    dot: 'bg-purple-500',
+    lens: 'bg-purple-500/10 border-b-2 border-purple-500/50 hover:bg-purple-500/20',
+  },
+  POLICY: {
+    label: 'Políticas Públicas',
+    icon: Landmark,
+    dot: 'bg-orange-500',
+    lens: 'bg-orange-500/10 border-b-2 border-orange-500/50 hover:bg-orange-500/20',
+  },
+  OTHER: {
+    label: 'Outros',
+    icon: TagIcon,
+    dot: 'bg-primary/40',
+    lens: 'bg-primary/5 border-b-2 border-primary/30 hover:bg-primary/10',
+  },
+}
+
+/** Ordem canônica de exibição dos grupos de entidade. */
+export const ENTITY_TYPE_ORDER: EntityTypeKey[] = [
+  'ORG',
+  'PER',
+  'LOC',
+  'EVENT',
+  'POLICY',
+]
+
+/** Tipos com grupo/cor próprios (exclui o balde `OTHER`). */
+export const KNOWN_ENTITY_TYPES = new Set<string>(ENTITY_TYPE_ORDER)
+
+/**
+ * Resolve o estilo de um tipo de entidade (string crua do backend), caindo em
+ * `OTHER` para qualquer tipo fora da taxonomia conhecida.
+ */
+export function entityTypeStyle(type: string): EntityTypeStyle {
+  return ENTITY_TYPE_STYLES[type as EntityTypeKey] ?? ENTITY_TYPE_STYLES.OTHER
+}

--- a/src/lib/entity-types.ts
+++ b/src/lib/entity-types.ts
@@ -36,6 +36,11 @@ export type EntityTypeStyle = {
    * inferior colorida. NÃO é um chip cheio — preserva o fluxo de leitura.
    */
   lens: string
+  /**
+   * Cor sólida em CSS (hex/hsl) — espelha o `dot`. Usada onde Tailwind não se
+   * aplica (ex.: nós da visualização de rede desenhados em canvas).
+   */
+  color: string
 }
 
 /**
@@ -49,36 +54,48 @@ export const ENTITY_TYPE_STYLES: Record<EntityTypeKey, EntityTypeStyle> = {
     icon: Building2,
     dot: 'bg-government-blue',
     lens: 'bg-government-blue/10 border-b-2 border-government-blue/50 hover:bg-government-blue/20',
+    // hsl(211, 100%, 32%) — government-blue
+    color: 'hsl(211, 100%, 32%)',
   },
   PER: {
     label: 'Pessoas',
     icon: User,
     dot: 'bg-government-green',
     lens: 'bg-government-green/10 border-b-2 border-government-green/50 hover:bg-government-green/20',
+    // hsl(146, 100%, 24%) — government-green
+    color: 'hsl(146, 100%, 24%)',
   },
   LOC: {
     label: 'Locais',
     icon: MapPin,
     dot: 'bg-government-yellow',
     lens: 'bg-government-yellow/15 border-b-2 border-government-yellow/60 hover:bg-government-yellow/25',
+    // hsl(44, 100%, 57%) — government-yellow
+    color: 'hsl(44, 100%, 57%)',
   },
   EVENT: {
     label: 'Eventos',
     icon: CalendarDays,
     dot: 'bg-purple-500',
     lens: 'bg-purple-500/10 border-b-2 border-purple-500/50 hover:bg-purple-500/20',
+    // tailwind purple-500
+    color: '#a855f7',
   },
   POLICY: {
     label: 'Políticas Públicas',
     icon: Landmark,
     dot: 'bg-orange-500',
     lens: 'bg-orange-500/10 border-b-2 border-orange-500/50 hover:bg-orange-500/20',
+    // tailwind orange-500
+    color: '#f97316',
   },
   OTHER: {
     label: 'Outros',
     icon: TagIcon,
     dot: 'bg-primary/40',
     lens: 'bg-primary/5 border-b-2 border-primary/30 hover:bg-primary/10',
+    // primary institucional (azul escuro), atenuado
+    color: '#6b7a90',
   },
 }
 

--- a/src/lib/graphql/queries/articles.ts
+++ b/src/lib/graphql/queries/articles.ts
@@ -64,7 +64,7 @@ export const ARTICLES_QUERY = gql`
   }
 `
 
-/** Busca (keyword/semântica/híbrida) com filtro, paginação e dedup. */
+/** Busca (keyword/semântica/híbrida) com filtro, paginação, dedup e ordenação. */
 export const SEARCH_QUERY = gql`
   ${ARTICLE_FIELDS}
   query Search(
@@ -74,6 +74,7 @@ export const SEARCH_QUERY = gql`
     $semantic: Boolean!
     $alpha: Float
     $dedup: Boolean!
+    $sort: ArticleSort
   ) {
     search(
       query: $query
@@ -82,6 +83,7 @@ export const SEARCH_QUERY = gql`
       semantic: $semantic
       alpha: $alpha
       dedup: $dedup
+      sort: $sort
     ) {
       articles {
         ...ArticleFields
@@ -92,12 +94,46 @@ export const SEARCH_QUERY = gql`
   }
 `
 
-/** Carrega um único artigo pelo `uniqueId`. */
+/**
+ * Sugestões de entidades (facets) para o typeahead do filtro de busca e para
+ * resolver o texto canônico de uma entidade nas páginas `/entidades/[slug]`.
+ *
+ * ⚠️ Depende de campos Typesense (`entities`/`entity_org`/…) que só existem
+ * após a Fase 0 (reindex de produção). Até lá, retorna vazio/erro graciosamente
+ * — o facade `getEntitySuggestions` engole o erro e devolve `[]`.
+ */
+export const ENTITY_SUGGESTIONS_QUERY = gql`
+  query EntitySuggestions($query: String!, $type: String, $limit: Int!) {
+    entitySuggestions(query: $query, type: $type, limit: $limit) {
+      value
+      count
+    }
+  }
+`
+
+/**
+ * Carrega um único artigo pelo `uniqueId`, incluindo as features computadas
+ * (entidades, leitura/legibilidade, popularidade/trending). O bloco `features`
+ * fica SÓ aqui — não no fragment `ArticleFields` — para não onerar
+ * listas/busca/relacionadas, que não selecionam features.
+ */
 export const ARTICLE_QUERY = gql`
   ${ARTICLE_FIELDS}
   query Article($uniqueId: String!) {
     article(uniqueId: $uniqueId) {
       ...ArticleFields
+      features {
+        entities {
+          text
+          type
+          count
+        }
+        viewCount
+        uniqueSessions
+        trendingScore
+        wordCount
+        readabilityFlesch
+      }
     }
   }
 `
@@ -162,6 +198,29 @@ export const ESTIMATE_RECORTE_COUNT_QUERY = gql`
 
 // ---------- TypeScript shapes ----------
 
+/** Valores do enum `ArticleSort` do schema, usados na ordenação de busca. */
+export type ArticleSort = 'RELEVANCE' | 'DATE' | 'TRENDING' | 'VIEWS'
+
+/** Facet de entidade (texto canônico + contagem) do `entitySuggestions`. */
+export interface EntityFacetGraphQL {
+  value: string
+  count: number
+}
+
+export interface EntitySuggestionsQueryData {
+  entitySuggestions: EntityFacetGraphQL[]
+}
+
+/** Features computadas, como vêm do graphql-api (camelCase). Só no detalhe. */
+export interface ArticleFeaturesGraphQL {
+  entities: Array<{ text: string; type: string; count: number }>
+  viewCount: number | null
+  uniqueSessions: number | null
+  trendingScore: number | null
+  wordCount: number | null
+  readabilityFlesch: number | null
+}
+
 /** Artigo camelCase como vem do graphql-api (espelha o fragment acima). */
 export interface ArticleGraphQL {
   uniqueId: string
@@ -187,6 +246,8 @@ export interface ArticleGraphQL {
   theme1Level3Label: string | null
   mostSpecificThemeCode: string | null
   mostSpecificThemeLabel: string | null
+  // Presente apenas em ARTICLE_QUERY (detalhe do artigo).
+  features?: ArticleFeaturesGraphQL | null
 }
 
 export interface ArticlesResultGraphQL {

--- a/src/lib/graphql/queries/articles.ts
+++ b/src/lib/graphql/queries/articles.ts
@@ -127,6 +127,15 @@ export const ARTICLE_QUERY = gql`
           text
           type
           count
+          canonicalId
+          salience
+        }
+        contentAnnotations {
+          start
+          end
+          type
+          text
+          canonicalId
         }
         viewCount
         uniqueSessions
@@ -134,6 +143,26 @@ export const ARTICLE_QUERY = gql`
         wordCount
         readabilityFlesch
       }
+    }
+  }
+`
+
+/**
+ * Resolve uma entidade canônica pelo seu `entityId` (QID Wikidata `Q…` ou
+ * `dgb_<ulid>`) — usado no cabeçalho das páginas `/entidades/[id-canônico]`.
+ * Retorna `null` quando o id não existe no `entity_registry`.
+ */
+export const ENTITY_QUERY = gql`
+  query Entity($id: String!) {
+    entity(id: $id) {
+      entityId
+      canonicalName
+      type
+      aliases
+      wikidataId
+      wikidataUrl
+      description
+      agencyKey
     }
   }
 `
@@ -205,15 +234,54 @@ export type ArticleSort = 'RELEVANCE' | 'DATE' | 'TRENDING' | 'VIEWS'
 export interface EntityFacetGraphQL {
   value: string
   count: number
+  /** Id canônico (`Q…`/`dgb_…`) quando o facet já está canonicalizado. */
+  entityId?: string | null
+  /** Rótulo de exibição (canonical_name) quando disponível. */
+  label?: string | null
 }
 
 export interface EntitySuggestionsQueryData {
   entitySuggestions: EntityFacetGraphQL[]
 }
 
+/** Entidade canônica (nó do registry) resolvida por `entity(id)`. */
+export interface EntityNodeGraphQL {
+  entityId: string
+  canonicalName: string | null
+  type: string | null
+  aliases: string[]
+  wikidataId: string | null
+  wikidataUrl: string | null
+  description: string | null
+  agencyKey: string | null
+}
+
+export interface EntityQueryData {
+  entity: EntityNodeGraphQL | null
+}
+
+/** Menção de entidade no artigo (camelCase, graphql-api). */
+export interface ArticleEntityGraphQL {
+  text: string
+  type: string
+  count: number
+  canonicalId?: string | null
+  salience?: number | null
+}
+
+/** Anotação de span inline (lente semântica), com offsets char no `content`. */
+export interface ContentAnnotationGraphQL {
+  start: number
+  end: number
+  type: string
+  text: string
+  canonicalId?: string | null
+}
+
 /** Features computadas, como vêm do graphql-api (camelCase). Só no detalhe. */
 export interface ArticleFeaturesGraphQL {
-  entities: Array<{ text: string; type: string; count: number }>
+  entities: ArticleEntityGraphQL[]
+  contentAnnotations?: ContentAnnotationGraphQL[] | null
   viewCount: number | null
   uniqueSessions: number | null
   trendingScore: number | null

--- a/src/lib/graphql/queries/entities.ts
+++ b/src/lib/graphql/queries/entities.ts
@@ -1,0 +1,100 @@
+/**
+ * Operações GraphQL do grafo de entidades (Fase 6d).
+ *
+ * Alimentam a página `/entidades/[id]`:
+ *   - `relatedEntities(id, limit)`: vizinhos por co-menção (1-hop), ordenados por
+ *     peso (nº de artigos em co-menção). Origem da seção "Entidades relacionadas".
+ *   - `entityNetwork(id, depth, limit)`: ego-network (nós + arestas) da entidade,
+ *     consumida pela visualização de rede (`EntityNetwork.tsx`).
+ *
+ * IDs são `String` (scalar do schema, não `ID`). As listas e o `EntityNetwork`
+ * são non-null no retorno; o arg `id` é obrigatório, `limit`/`depth` têm default.
+ *
+ * Schema de referência: `src/lib/graphql/schema.graphql`.
+ */
+
+import { gql } from '@urql/core'
+
+// ---------- Queries ----------
+
+/**
+ * Entidades relacionadas a `id` por co-menção (1-hop), ordenadas por `weight`
+ * desc. Cada item é o nó vizinho + o peso/tipo da aresta. Roda sobre Postgres
+ * (`entity_edges`), sem dependência de Neo4j.
+ */
+export const RELATED_ENTITIES_QUERY = gql`
+  query RelatedEntities($id: String!, $limit: Int!) {
+    relatedEntities(id: $id, limit: $limit) {
+      canonicalId
+      canonicalName
+      type
+      wikidataId
+      weight
+      kind
+    }
+  }
+`
+
+/**
+ * Rede ego-centrada na entidade `id` (nós + arestas) até `depth` saltos. Usada
+ * pela visualização de rede. `depth<=2` roda via CTE recursiva em `entity_edges`.
+ */
+export const ENTITY_NETWORK_QUERY = gql`
+  query EntityNetwork($id: String!, $depth: Int!, $limit: Int!) {
+    entityNetwork(id: $id, depth: $depth, limit: $limit) {
+      nodes {
+        entityId
+        canonicalName
+        type
+        wikidataId
+      }
+      edges {
+        src
+        dst
+        weight
+        kind
+      }
+    }
+  }
+`
+
+// ---------- TypeScript shapes ----------
+
+/** Entidade relacionada (vizinho de co-menção) como vem do graphql-api. */
+export interface RelatedEntityGraphQL {
+  canonicalId: string
+  canonicalName: string | null
+  type: string | null
+  wikidataId: string | null
+  weight: number
+  kind: string
+}
+
+export interface RelatedEntitiesQueryData {
+  relatedEntities: RelatedEntityGraphQL[]
+}
+
+/** Nó da rede de entidades (camelCase, graphql-api). */
+export interface EntityNetworkNodeGraphQL {
+  entityId: string
+  canonicalName: string | null
+  type: string | null
+  wikidataId: string | null
+}
+
+/** Aresta da rede de entidades (par direcionado src→dst + peso/tipo). */
+export interface EntityNetworkEdgeGraphQL {
+  src: string
+  dst: string
+  weight: number
+  kind: string
+}
+
+export interface EntityNetworkGraphQL {
+  nodes: EntityNetworkNodeGraphQL[]
+  edges: EntityNetworkEdgeGraphQL[]
+}
+
+export interface EntityNetworkQueryData {
+  entityNetwork: EntityNetworkGraphQL
+}

--- a/src/lib/graphql/queries/entities.ts
+++ b/src/lib/graphql/queries/entities.ts
@@ -98,3 +98,36 @@ export interface EntityNetworkGraphQL {
 export interface EntityNetworkQueryData {
   entityNetwork: EntityNetworkGraphQL
 }
+
+/**
+ * Top entidades NER com maior crescimento de cobertura (pré-computado pelo DAG
+ * `compute_entity_trending`). Lê `entity_trending_scores` ordenado por score DESC.
+ */
+export const TRENDING_ENTITIES_QUERY = gql`
+  query TrendingEntities($limit: Int) {
+    trendingEntities(limit: $limit) {
+      entityId
+      canonicalName
+      type
+      trendingScore
+      volumeRatio
+      windowCount
+      computedAt
+    }
+  }
+`
+
+/** Entidade em alta como vem do graphql-api. */
+export interface TrendingEntityGraphQL {
+  entityId: string
+  canonicalName: string | null
+  type: string | null
+  trendingScore: number
+  volumeRatio: number
+  windowCount: number
+  computedAt: string | null
+}
+
+export interface TrendingEntitiesQueryData {
+  trendingEntities: TrendingEntityGraphQL[]
+}

--- a/src/lib/graphql/queries/entities.ts
+++ b/src/lib/graphql/queries/entities.ts
@@ -100,6 +100,48 @@ export interface EntityNetworkQueryData {
 }
 
 /**
+ * Artigos de uma entidade canônica via Postgres (`news_entities` → `news`).
+ * Não depende do campo `entityCanonical` no Typesense — funciona sem reprocessamento.
+ */
+export const ENTITY_ARTICLES_QUERY = gql`
+  query EntityArticles($entityId: String!, $page: Int, $limit: Int) {
+    entityArticles(entityId: $entityId, page: $page, limit: $limit) {
+      articles {
+        uniqueId
+        title
+        url
+        image
+        videoUrl
+        agency
+        agencyName
+        publishedAt
+        extractedAt
+        theme1Level1Code
+        theme1Level1Label
+        theme1Level2Code
+        theme1Level2Label
+        theme1Level3Code
+        theme1Level3Label
+        mostSpecificThemeCode
+        mostSpecificThemeLabel
+      }
+      found
+      page
+    }
+  }
+`
+
+export interface EntityArticlesGraphQL {
+  articles: import('./articles').ArticleGraphQL[]
+  found: number
+  page: number
+}
+
+export interface EntityArticlesQueryData {
+  entityArticles: EntityArticlesGraphQL
+}
+
+/**
  * Top entidades NER com maior crescimento de cobertura (pré-computado pelo DAG
  * `compute_entity_trending`). Lê `entity_trending_scores` ordenado por score DESC.
  */

--- a/src/lib/graphql/schema.graphql
+++ b/src/lib/graphql/schema.graphql
@@ -89,6 +89,34 @@ type Article {
   theme1Level3Label: String
   mostSpecificThemeCode: String
   mostSpecificThemeLabel: String
+  features: ArticleFeatures
+}
+
+type ArticleFeatures {
+  entities: [EntityType!]!
+  viewCount: Int
+  uniqueSessions: Int
+  trendingScore: Float
+  wordCount: Int
+  readabilityFlesch: Float
+}
+
+type EntityType {
+  text: String!
+  type: String!
+  count: Int!
+}
+
+type EntityFacet {
+  value: String!
+  count: Int!
+}
+
+enum ArticleSort {
+  RELEVANCE
+  DATE
+  TRENDING
+  VIEWS
 }
 
 input ArticleFilter {
@@ -99,6 +127,8 @@ input ArticleFilter {
   endDate: String = null
   themeLabel: String = null
   dedup: Boolean = null
+  entities: [String!] = null
+  sentiment: [String!] = null
 }
 
 type ArticlesResult {
@@ -490,6 +520,7 @@ type Query {
     page: Int! = 1
     limit: Int! = 10
     filter: ArticleFilter = null
+    sort: ArticleSort = null
   ): ArticlesResult!
 
   """
@@ -507,6 +538,7 @@ type Query {
     semantic: Boolean! = false
     alpha: Float = null
     dedup: Boolean! = false
+    sort: ArticleSort = null
   ): ArticlesResult!
 
   """
@@ -659,6 +691,15 @@ type Query {
   Artigos relacionados a `uniqueId`, baseados no theme-code (Typesense). Replica a logica do portal: usa most_specific_theme_code quando presente, senao theme_1_level_1_code; exclui o proprio artigo; ordena por publishedAt desc; deduplica por content_hash. PUBLICO. (Distinto do `similarArticles` interno, baseado em embedding postgres.)
   """
   relatedArticles(uniqueId: String!, limit: Int! = 4): [Article!]!
+
+  """
+  Sugestoes de entidades (facet) para o filtro de busca e as paginas de entidade. `type` (ORG/PER/LOC) restringe ao campo tipado; ausente usa o campo combinado. `query` filtra por prefixo. PUBLICO.
+  """
+  entitySuggestions(
+    query: String! = ""
+    type: String = null
+    limit: Int! = 10
+  ): [EntityFacet!]!
 
   """
   Contagem de artigos por code de tema (nivel `level`) nos ultimos `days` dias. `label` e None (o portal mapeia pela config). PUBLICO.

--- a/src/lib/graphql/schema.graphql
+++ b/src/lib/graphql/schema.graphql
@@ -94,6 +94,7 @@ type Article {
 
 type ArticleFeatures {
   entities: [EntityType!]!
+  contentAnnotations: [ContentAnnotation!]!
   viewCount: Int
   uniqueSessions: Int
   trendingScore: Float
@@ -101,15 +102,38 @@ type ArticleFeatures {
   readabilityFlesch: Float
 }
 
+type ContentAnnotation {
+  start: Int!
+  end: Int!
+  type: String!
+  text: String!
+  canonicalId: String
+}
+
 type EntityType {
   text: String!
   type: String!
   count: Int!
+  canonicalId: String
+  salience: Float
 }
 
 type EntityFacet {
   value: String!
   count: Int!
+  entityId: String
+  label: String
+}
+
+type EntityNode {
+  entityId: String!
+  canonicalName: String
+  type: String
+  aliases: [String!]!
+  wikidataId: String
+  wikidataUrl: String
+  description: String
+  agencyKey: String
 }
 
 enum ArticleSort {
@@ -129,6 +153,7 @@ input ArticleFilter {
   dedup: Boolean = null
   entities: [String!] = null
   sentiment: [String!] = null
+  entityCanonical: [String!] = null
 }
 
 type ArticlesResult {
@@ -700,6 +725,11 @@ type Query {
     type: String = null
     limit: Int! = 10
   ): [EntityFacet!]!
+
+  """
+  Resolve uma entidade canonica pelo seu id (QID Wikidata ou dgb_<ulid>) do entity_registry. Retorna None se o id nao existe. PUBLICO.
+  """
+  entity(id: String!): EntityNode
 
   """
   Contagem de artigos por code de tema (nivel `level`) nos ultimos `days` dias. `label` e None (o portal mapeia pela config). PUBLICO.

--- a/src/lib/graphql/schema.graphql
+++ b/src/lib/graphql/schema.graphql
@@ -136,6 +136,34 @@ type EntityNode {
   agencyKey: String
 }
 
+type RelatedEntity {
+  canonicalId: String!
+  canonicalName: String
+  type: String
+  wikidataId: String
+  weight: Int!
+  kind: String!
+}
+
+type EntityNetworkNode {
+  entityId: String!
+  canonicalName: String
+  type: String
+  wikidataId: String
+}
+
+type EntityNetworkEdge {
+  src: String!
+  dst: String!
+  weight: Int!
+  kind: String!
+}
+
+type EntityNetwork {
+  nodes: [EntityNetworkNode!]!
+  edges: [EntityNetworkEdge!]!
+}
+
 enum ArticleSort {
   RELEVANCE
   DATE
@@ -730,6 +758,16 @@ type Query {
   Resolve uma entidade canonica pelo seu id (QID Wikidata ou dgb_<ulid>) do entity_registry. Retorna None se o id nao existe. PUBLICO.
   """
   entity(id: String!): EntityNode
+
+  """
+  Entidades relacionadas a `id` por co-mencao (1-hop), ordenadas por `weight` (numero de artigos em co-mencao) desc. Le `entity_edges` (Postgres); nao depende de Neo4j. PUBLICO.
+  """
+  relatedEntities(id: String!, limit: Int! = 12): [RelatedEntity!]!
+
+  """
+  Rede ego-centrada na entidade `id` (nos + arestas) ate `depth` saltos. `depth<=2` roda via CTE recursiva em `entity_edges`; `limit` capa o numero de nos para legibilidade. PUBLICO.
+  """
+  entityNetwork(id: String!, depth: Int! = 1, limit: Int! = 50): EntityNetwork!
 
   """
   Contagem de artigos por code de tema (nivel `level`) nos ultimos `days` dias. `label` e None (o portal mapeia pela config). PUBLICO.

--- a/src/lib/graphql/schema.graphql
+++ b/src/lib/graphql/schema.graphql
@@ -3,6 +3,19 @@ type Agency {
   label: String!
 }
 
+type AgencyPeriodMetrics {
+  period: String!
+  agencyKey: String!
+  agencyName: String
+  articleCount: Int!
+  avgSentimentScore: Float
+  pctPositive: Float
+  pctNegative: Float
+  avgReadabilityFlesch: Float
+  avgWordCount: Float
+  topThemes: [ThemeStats!]!
+}
+
 """
 Agency statistics with article count
 """
@@ -89,6 +102,10 @@ type Article {
   theme1Level3Label: String
   mostSpecificThemeCode: String
   mostSpecificThemeLabel: String
+
+  """
+  Features computadas da notícia (entidades, popularidade/trending, leitura/legibilidade). Carregado sob demanda do Postgres (news_features) por unique_id via DataLoader; None quando não há features. Não onera listas/busca que não selecionam este campo.
+  """
   features: ArticleFeatures
 }
 
@@ -102,86 +119,6 @@ type ArticleFeatures {
   readabilityFlesch: Float
 }
 
-type ContentAnnotation {
-  start: Int!
-  end: Int!
-  type: String!
-  text: String!
-  canonicalId: String
-}
-
-type EntityType {
-  text: String!
-  type: String!
-  count: Int!
-  canonicalId: String
-  salience: Float
-}
-
-type EntityFacet {
-  value: String!
-  count: Int!
-  entityId: String
-  label: String
-}
-
-type EntityNode {
-  entityId: String!
-  canonicalName: String
-  type: String
-  aliases: [String!]!
-  wikidataId: String
-  wikidataUrl: String
-  description: String
-  agencyKey: String
-}
-
-type RelatedEntity {
-  canonicalId: String!
-  canonicalName: String
-  type: String
-  wikidataId: String
-  weight: Int!
-  kind: String!
-}
-
-type EntityNetworkNode {
-  entityId: String!
-  canonicalName: String
-  type: String
-  wikidataId: String
-}
-
-type EntityNetworkEdge {
-  src: String!
-  dst: String!
-  weight: Int!
-  kind: String!
-}
-
-type EntityNetwork {
-  nodes: [EntityNetworkNode!]!
-  edges: [EntityNetworkEdge!]!
-}
-
-type TrendingEntityResult {
-  entityId: String!
-  canonicalName: String!
-  type: String!
-  trendingScore: Float!
-  volumeRatio: Float!
-  windowCount: Int!
-  windowAgencies: Int!
-  computedAt: String
-}
-
-enum ArticleSort {
-  RELEVANCE
-  DATE
-  TRENDING
-  VIEWS
-}
-
 input ArticleFilter {
   agencies: [String!] = null
   themes: [String!] = null
@@ -193,6 +130,21 @@ input ArticleFilter {
   entities: [String!] = null
   sentiment: [String!] = null
   entityCanonical: [String!] = null
+}
+
+enum ArticleSort {
+  RELEVANCE
+  DATE
+  TRENDING
+  VIEWS
+}
+
+type ArticleSummary {
+  uniqueId: String!
+  title: String!
+  agencyName: String
+  publishedAt: String
+  trendingScore: Float
 }
 
 type ArticlesResult {
@@ -292,6 +244,14 @@ input ClippingInput {
   deliveryChannels: DeliveryChannelsInput = null
 }
 
+type ContentAnnotation {
+  start: Int!
+  end: Int!
+  type: String!
+  text: String!
+  canonicalId: String
+}
+
 """
 Daily article count
 """
@@ -326,6 +286,82 @@ input DeliveryChannelsInput {
   webhook: Boolean! = false
 }
 
+type EntityCoveragePoint {
+  period: String!
+  agencyKey: String!
+  agencyName: String
+  articleCount: Int!
+  totalMentions: Int!
+  avgSentimentScore: Float
+}
+
+type EntityFacet {
+  value: String!
+  count: Int!
+  entityId: String
+  label: String
+}
+
+enum EntityKind {
+  ORG
+  PER
+  LOC
+  EVENT
+  POLICY
+  LAW
+}
+
+type EntityNetwork {
+  nodes: [EntityNetworkNode!]!
+  edges: [EntityNetworkEdge!]!
+}
+
+type EntityNetworkEdge {
+  src: String!
+  dst: String!
+  weight: Int!
+  kind: String!
+}
+
+type EntityNetworkNode {
+  entityId: String!
+  canonicalName: String
+  type: String
+  wikidataId: String
+}
+
+type EntityNode {
+  entityId: String!
+  canonicalName: String
+  type: String
+  aliases: [String!]!
+  wikidataId: String
+  wikidataUrl: String
+  description: String
+  agencyKey: String
+}
+
+type EntitySearchResult {
+  entityId: String!
+  canonicalName: String!
+  type: String!
+  description: String
+  wikidataUrl: String
+  agencyKey: String
+  aliases: [String!]!
+  articleCount: Int!
+  confidence: Float!
+  matchType: String!
+}
+
+type EntityType {
+  text: String!
+  type: String!
+  count: Int!
+  canonicalId: String
+  salience: Float
+}
+
 type EstimateResult {
   totalEstimate: Int!
 }
@@ -355,6 +391,12 @@ type FollowedListing {
   extraEmails: [String!]!
   webhookUrl: String
   followedAt: DateTime
+}
+
+enum Granularity {
+  DAY
+  WEEK
+  MONTH
 }
 
 type IntegrityCandidateType {
@@ -409,6 +451,13 @@ type MarketplaceRecorte {
   themes: [String!]!
   agencies: [String!]!
   keywords: [String!]!
+}
+
+enum MetricType {
+  VOLUME
+  SENTIMENT
+  READABILITY
+  THEMES
 }
 
 type Mutation {
@@ -578,7 +627,7 @@ type Query {
   ping: String!
 
   """
-  Lista artigos com filtros e paginação
+  Lista artigos com filtros, paginação e ordenação
   """
   articles(
     page: Int! = 1
@@ -644,6 +693,29 @@ type Query {
   Daily article counts for the given date range
   """
   articlesTimeline(range: DateRange!): [DailyCount!]!
+
+  """
+  Métricas de publicação por agência e período
+  """
+  agencyAnalytics(
+    agencies: [String!]!
+    dateFrom: String!
+    dateTo: String!
+    granularity: Granularity! = MONTH
+    metrics: [MetricType!] = null
+  ): [AgencyPeriodMetrics!]!
+
+  """
+  Temas em crescimento comparando janela recente com baseline histórico
+  """
+  trendingThemes(
+    windowDays: Int! = 7
+    baselineDays: Int! = 28
+    minArticles: Int! = 3
+    growthThreshold: Float! = 1.5
+    agencyKey: String = null
+    limit: Int! = 10
+  ): [TrendingThemeResult!]!
 
   """
   Lista todos os clippings do usuario autenticado (autorados + inscritos)
@@ -752,12 +824,12 @@ type Query {
   integrityBatch(batchSize: Int! = 50): [IntegrityCandidateType!]!
 
   """
-  Artigos relacionados a `uniqueId`, baseados no theme-code (Typesense). Replica a logica do portal: usa most_specific_theme_code quando presente, senao theme_1_level_1_code; exclui o proprio artigo; ordena por publishedAt desc; deduplica por content_hash. PUBLICO. (Distinto do `similarArticles` interno, baseado em embedding postgres.)
+  Artigos relacionados a `uniqueId` por similaridade semântica (embedding pgvector via news.content_embedding). O SQL exclui o próprio artigo, aplica threshold de similaridade e ordena por similaridade desc; os vizinhos são hidratados do índice Typesense preservando essa ordem. Retorna [] se o artigo não tiver embedding ou vizinhos. PÚBLICO. (Distinto do `similarArticles` interno, que devolve apenas unique_id/score.)
   """
   relatedArticles(uniqueId: String!, limit: Int! = 4): [Article!]!
 
   """
-  Sugestoes de entidades (facet) para o filtro de busca e as paginas de entidade. `type` (ORG/PER/LOC) restringe ao campo tipado; ausente usa o campo combinado. `query` filtra por prefixo. PUBLICO.
+  Sugestões de entidades (facet) para o filtro de busca e as páginas de entidade. `type` (ORG/PER/LOC/EVENT/POLICY) restringe ao campo tipado; ausente usa o campo combinado `entities`. `type: CANONICAL` ativa o modo canônico: faceta `entity_canonical` e retorna `{value/entityId = canonical_id, label = canonical_name, count}` (label resolvido do entity_registry; None se ausente). `query` filtra por prefixo. Ordenado por nº de artigos desc. PÚBLICO.
   """
   entitySuggestions(
     query: String! = ""
@@ -766,17 +838,17 @@ type Query {
   ): [EntityFacet!]!
 
   """
-  Resolve uma entidade canonica pelo seu id (QID Wikidata ou dgb_<ulid>) do entity_registry. Retorna None se o id nao existe. PUBLICO.
+  Entidade canônica do entity_registry por `id` (entity_id: QID Wikidata 'Q216330' ou 'dgb_<ulid>'). None quando não existe. PÚBLICO.
   """
   entity(id: String!): EntityNode
 
   """
-  Entidades relacionadas a `id` por co-mencao (1-hop), ordenadas por `weight` (numero de artigos em co-mencao) desc. Le `entity_edges` (Postgres); nao depende de Neo4j. PUBLICO.
+  Entidades relacionadas a `id` (entity_id) por co-menção (Fase 6c). Lê a rede de co-menção materializada (`entity_edges`, 1-hop), retorna os vizinhos hidratados do entity_registry, ordenados por `weight` (nº de artigos em co-menção) desc, até `limit`. Retorna [] sem Postgres ou sem vizinhos. PÚBLICO.
   """
   relatedEntities(id: String!, limit: Int! = 12): [RelatedEntity!]!
 
   """
-  Rede ego-centrada na entidade `id` (nos + arestas) ate `depth` saltos. `depth<=2` roda via CTE recursiva em `entity_edges`; `limit` capa o numero de nos para legibilidade. PUBLICO.
+  Ego-network (nós + arestas) ao redor de `id` (entity_id) para a visualização de rede (Fase 6c). Travessia não-direcionada na rede de co-menção (`entity_edges`) via CTE recursiva até `depth` saltos (CLAMPado a no máx 2; profundidades maiores ficam para o Neo4j futuro). `limit` limita o nº de arestas (cap de tamanho do grafo). Retorna {nodes:[], edges:[]} sem Postgres. PÚBLICO.
   """
   entityNetwork(id: String!, depth: Int! = 1, limit: Int! = 50): EntityNetwork!
 
@@ -801,7 +873,35 @@ type Query {
   ): Int!
 
   """
-  Entidades NER com maior crescimento de cobertura (pre-computado pelo DAG compute_entity_trending). Le entity_trending_scores ordenado por score DESC. PUBLICO.
+  Série temporal de cobertura de uma entidade por agência
+  """
+  entityCoverage(
+    entityId: String!
+    dateFrom: String = null
+    dateTo: String = null
+    granularity: Granularity! = MONTH
+  ): [EntityCoveragePoint!]!
+
+  """
+  Busca fuzzy de entidades por nome ou alias
+  """
+  entitySearch(
+    query: String!
+    entityType: EntityKind = null
+    limit: Int! = 5
+  ): [EntitySearchResult!]!
+
+  """
+  Artigos de uma entidade canônica via news_entities (Postgres direto). Não depende do campo entityCanonical no Typesense.
+  """
+  entityArticles(
+    entityId: String!
+    page: Int! = 1
+    limit: Int! = 10
+  ): ArticlesResult!
+
+  """
+  Entidades NER com maior crescimento de cobertura (pré-computado)
   """
   trendingEntities(limit: Int! = 10): [TrendingEntityResult!]!
 }
@@ -819,6 +919,15 @@ input RecorteInput {
   themes: [String!]! = []
   agencies: [String!]! = []
   keywords: [String!]! = []
+}
+
+type RelatedEntity {
+  canonicalId: String!
+  canonicalName: String
+  type: String
+  wikidataId: String
+  weight: Int!
+  kind: String!
 }
 
 type Release {
@@ -887,6 +996,26 @@ Theme statistics with article count
 type ThemeStats {
   label: String!
   count: Int!
+}
+
+type TrendingEntityResult {
+  entityId: String!
+  canonicalName: String!
+  type: String!
+  trendingScore: Float!
+  volumeRatio: Float!
+  windowCount: Int!
+  windowAgencies: Int!
+  computedAt: String
+}
+
+type TrendingThemeResult {
+  themeLabel: String!
+  themeCode: String
+  windowCount: Int!
+  baselineDailyAvg: Float!
+  growthScore: Float!
+  topArticles: [ArticleSummary!]!
 }
 
 type TypesenseDocRecordType {

--- a/src/lib/graphql/schema.graphql
+++ b/src/lib/graphql/schema.graphql
@@ -164,6 +164,17 @@ type EntityNetwork {
   edges: [EntityNetworkEdge!]!
 }
 
+type TrendingEntityResult {
+  entityId: String!
+  canonicalName: String!
+  type: String!
+  trendingScore: Float!
+  volumeRatio: Float!
+  windowCount: Int!
+  windowAgencies: Int!
+  computedAt: String
+}
+
 enum ArticleSort {
   RELEVANCE
   DATE
@@ -788,6 +799,11 @@ type Query {
     keywords: [String!]!
     sinceHours: Int! = 24
   ): Int!
+
+  """
+  Entidades NER com maior crescimento de cobertura (pre-computado pelo DAG compute_entity_trending). Le entity_trending_scores ordenado por score DESC. PUBLICO.
+  """
+  trendingEntities(limit: Int! = 10): [TrendingEntityResult!]!
 }
 
 type Recorte {

--- a/src/services/content/__tests__/graphql.test.ts
+++ b/src/services/content/__tests__/graphql.test.ts
@@ -243,6 +243,90 @@ describe('createGraphQLContentService', () => {
     })
   })
 
+  describe('getEntity', () => {
+    it('envia a query entity com id e mapeia o nó canônico', async () => {
+      const { client, queries } = makeClientStub({
+        onQuery: () => ({
+          entity: {
+            entityId: 'Q216330',
+            canonicalName: 'Ministério da Saúde',
+            type: 'ORG',
+            aliases: ['MS', 'Ministério da Saúde'],
+            wikidataId: 'Q216330',
+            wikidataUrl: 'https://www.wikidata.org/wiki/Q216330',
+            description: 'Órgão do governo federal',
+            agencyKey: 'ministerio-da-saude',
+          },
+        }),
+      })
+      const svc = createGraphQLContentService(client)
+      const res = await svc.getEntity('Q216330')
+      expect(queries[0].query).toContain('query Entity')
+      expect(queries[0].vars).toEqual({ id: 'Q216330' })
+      expect(res).toEqual({
+        entityId: 'Q216330',
+        canonicalName: 'Ministério da Saúde',
+        type: 'ORG',
+        aliases: ['MS', 'Ministério da Saúde'],
+        wikidataId: 'Q216330',
+        wikidataUrl: 'https://www.wikidata.org/wiki/Q216330',
+        description: 'Órgão do governo federal',
+        agencyKey: 'ministerio-da-saude',
+      })
+    })
+
+    it('retorna null quando o id não existe', async () => {
+      const { client } = makeClientStub({ onQuery: () => ({ entity: null }) })
+      const svc = createGraphQLContentService(client)
+      expect(await svc.getEntity('Q0')).toBeNull()
+    })
+
+    it('degrada para null quando a query falha (canonicalização pendente)', async () => {
+      const { client } = makeClientStub({
+        queryError: { graphQLErrors: [{ message: 'no entity resolver' }] },
+      })
+      const svc = createGraphQLContentService(client)
+      expect(await svc.getEntity('Q1')).toBeNull()
+    })
+  })
+
+  describe('getEntitySuggestions', () => {
+    it('faz passthrough de entityId/label quando presentes', async () => {
+      const { client, queries } = makeClientStub({
+        onQuery: () => ({
+          entitySuggestions: [
+            {
+              value: 'Ministério da Saúde',
+              count: 12,
+              entityId: 'Q216330',
+              label: 'Ministério da Saúde',
+            },
+          ],
+        }),
+      })
+      const svc = createGraphQLContentService(client)
+      const res = await svc.getEntitySuggestions('mini', 'ORG', 5)
+      expect(queries[0].query).toContain('query EntitySuggestions')
+      expect(queries[0].vars).toEqual({ query: 'mini', type: 'ORG', limit: 5 })
+      expect(res).toEqual([
+        {
+          value: 'Ministério da Saúde',
+          count: 12,
+          entityId: 'Q216330',
+          label: 'Ministério da Saúde',
+        },
+      ])
+    })
+
+    it('degrada para [] em erro (Fase 0 pendente)', async () => {
+      const { client } = makeClientStub({
+        queryError: { graphQLErrors: [{ message: 'no field entities' }] },
+      })
+      const svc = createGraphQLContentService(client)
+      expect(await svc.getEntitySuggestions('x')).toEqual([])
+    })
+  })
+
   describe('getReleaseArticles', () => {
     it('envia id e mapeia a lista', async () => {
       const { client, queries } = makeClientStub({

--- a/src/services/content/__tests__/graphql.test.ts
+++ b/src/services/content/__tests__/graphql.test.ts
@@ -138,6 +138,7 @@ describe('createGraphQLContentService', () => {
         alpha: 0.5,
         dedup: true,
         filter: { themes: ['01'] },
+        sort: null,
       })
       expect(res.page).toBe(3)
       expect(res.found).toBe(7)
@@ -157,6 +158,7 @@ describe('createGraphQLContentService', () => {
         alpha: null,
         dedup: false,
         filter: null,
+        sort: null,
       })
     })
   })

--- a/src/services/content/__tests__/graphql.test.ts
+++ b/src/services/content/__tests__/graphql.test.ts
@@ -380,4 +380,98 @@ describe('createGraphQLContentService', () => {
       })
     })
   })
+
+  describe('getRelatedEntities', () => {
+    it('envia id/limit e mapeia os vizinhos', async () => {
+      const { client, queries } = makeClientStub({
+        onQuery: () => ({
+          relatedEntities: [
+            {
+              canonicalId: 'Q2',
+              canonicalName: 'MCTI',
+              type: 'ORG',
+              wikidataId: 'Q2',
+              weight: 7,
+              kind: 'co_mention',
+            },
+          ],
+        }),
+      })
+      const svc = createGraphQLContentService(client)
+      const rels = await svc.getRelatedEntities('Q1', 5)
+      expect(queries[0].query).toContain('query RelatedEntities')
+      expect(queries[0].vars).toEqual({ id: 'Q1', limit: 5 })
+      expect(rels).toEqual([
+        {
+          canonicalId: 'Q2',
+          canonicalName: 'MCTI',
+          type: 'ORG',
+          wikidataId: 'Q2',
+          weight: 7,
+          kind: 'co_mention',
+        },
+      ])
+    })
+
+    it('usa limit default 12', async () => {
+      const { client, queries } = makeClientStub({
+        onQuery: () => ({ relatedEntities: [] }),
+      })
+      const svc = createGraphQLContentService(client)
+      await svc.getRelatedEntities('Q1')
+      expect(queries[0].vars).toEqual({ id: 'Q1', limit: 12 })
+    })
+
+    it('degrada para [] em erro (grafo ainda não populado)', async () => {
+      const { client } = makeClientStub({ queryError: new Error('boom') })
+      const svc = createGraphQLContentService(client)
+      expect(await svc.getRelatedEntities('Q1')).toEqual([])
+    })
+  })
+
+  describe('getEntityNetwork', () => {
+    it('envia id/depth/limit e mapeia nós + arestas', async () => {
+      const { client, queries } = makeClientStub({
+        onQuery: () => ({
+          entityNetwork: {
+            nodes: [
+              {
+                entityId: 'Q1',
+                canonicalName: 'Finep',
+                type: 'ORG',
+                wikidataId: 'Q1',
+              },
+            ],
+            edges: [{ src: 'Q1', dst: 'Q2', weight: 3, kind: 'co_mention' }],
+          },
+        }),
+      })
+      const svc = createGraphQLContentService(client)
+      const net = await svc.getEntityNetwork('Q1', 2, 30)
+      expect(queries[0].query).toContain('query EntityNetwork')
+      expect(queries[0].vars).toEqual({ id: 'Q1', depth: 2, limit: 30 })
+      expect(net.nodes).toHaveLength(1)
+      expect(net.edges).toEqual([
+        { src: 'Q1', dst: 'Q2', weight: 3, kind: 'co_mention' },
+      ])
+    })
+
+    it('usa depth=1/limit=50 default', async () => {
+      const { client, queries } = makeClientStub({
+        onQuery: () => ({ entityNetwork: { nodes: [], edges: [] } }),
+      })
+      const svc = createGraphQLContentService(client)
+      await svc.getEntityNetwork('Q1')
+      expect(queries[0].vars).toEqual({ id: 'Q1', depth: 1, limit: 50 })
+    })
+
+    it('degrada para rede vazia em erro', async () => {
+      const { client } = makeClientStub({ queryError: new Error('boom') })
+      const svc = createGraphQLContentService(client)
+      expect(await svc.getEntityNetwork('Q1')).toEqual({
+        nodes: [],
+        edges: [],
+      })
+    })
+  })
 })

--- a/src/services/content/__tests__/mapper.test.ts
+++ b/src/services/content/__tests__/mapper.test.ts
@@ -168,3 +168,81 @@ describe('mapGraphqlArticleToRow', () => {
     expect(row.most_specific_theme_label).toBeNull()
   })
 })
+
+describe('mapGraphqlArticleToRow — features (entidades + lente)', () => {
+  it('mapeia canonicalId/salience das entidades e contentAnnotations', () => {
+    const row = mapGraphqlArticleToRow({
+      ...fullArticle(),
+      features: {
+        entities: [
+          {
+            text: 'Ministério da Saúde',
+            type: 'ORG',
+            count: 3,
+            canonicalId: 'Q216330',
+            salience: 0.82,
+          },
+        ],
+        contentAnnotations: [
+          {
+            start: 10,
+            end: 29,
+            type: 'ORG',
+            text: 'Ministério da Saúde',
+            canonicalId: 'Q216330',
+          },
+        ],
+        viewCount: 12,
+        uniqueSessions: 8,
+        trendingScore: 1.7,
+        wordCount: 420,
+        readabilityFlesch: 55.5,
+      },
+    })
+
+    expect(row.features?.entities[0]).toEqual({
+      text: 'Ministério da Saúde',
+      type: 'ORG',
+      count: 3,
+      canonical_id: 'Q216330',
+      salience: 0.82,
+    })
+    expect(row.features?.content_annotations).toEqual([
+      {
+        start: 10,
+        end: 29,
+        type: 'ORG',
+        text: 'Ministério da Saúde',
+        canonical_id: 'Q216330',
+      },
+    ])
+  })
+
+  it('campos canônicos ausentes → null; contentAnnotations ausente → []', () => {
+    const row = mapGraphqlArticleToRow({
+      ...fullArticle(),
+      features: {
+        entities: [{ text: 'Lula', type: 'PER', count: 5 }],
+        viewCount: null,
+        uniqueSessions: null,
+        trendingScore: null,
+        wordCount: null,
+        readabilityFlesch: null,
+      },
+    })
+
+    expect(row.features?.entities[0]).toEqual({
+      text: 'Lula',
+      type: 'PER',
+      count: 5,
+      canonical_id: null,
+      salience: null,
+    })
+    expect(row.features?.content_annotations).toEqual([])
+  })
+
+  it('features ausentes → null', () => {
+    const row = mapGraphqlArticleToRow(fullArticle())
+    expect(row.features).toBeNull()
+  })
+})

--- a/src/services/content/graphql.ts
+++ b/src/services/content/graphql.ts
@@ -21,6 +21,8 @@ import {
   type ArticleGraphQL,
   type ArticleQueryData,
   type ArticlesQueryData,
+  ENTITY_SUGGESTIONS_QUERY,
+  type EntitySuggestionsQueryData,
   ESTIMATE_RECORTE_COUNT_QUERY,
   type EstimateRecorteCountQueryData,
   RELATED_ARTICLES_QUERY,
@@ -103,6 +105,21 @@ export function mapGraphqlArticleToRow(article: ArticleGraphQL): ArticleRow {
     tags: article.tags ?? null,
     // Alias de compatibilidade (espelha o label de nível 1).
     theme_1_level_1: article.theme1Level1Label ?? null,
+    // Features só vêm no detalhe (ARTICLE_QUERY); ausentes nas demais ops → null.
+    features: article.features
+      ? {
+          entities: (article.features.entities ?? []).map((e) => ({
+            text: e.text,
+            type: e.type,
+            count: e.count,
+          })),
+          view_count: article.features.viewCount ?? null,
+          unique_sessions: article.features.uniqueSessions ?? null,
+          trending_score: article.features.trendingScore ?? null,
+          word_count: article.features.wordCount ?? null,
+          readability_flesch: article.features.readabilityFlesch ?? null,
+        }
+      : null,
   }
 }
 
@@ -178,6 +195,7 @@ export function createGraphQLContentService(
         alpha: args.alpha ?? null,
         dedup: args.dedup ?? false,
         filter: args.filter ?? null,
+        sort: args.sort ?? null,
       }
       const result = await client
         .query<SearchQueryData>(SEARCH_QUERY, vars)
@@ -244,6 +262,26 @@ export function createGraphQLContentService(
         code: t.code,
         label: t.label ?? null,
         count: t.count,
+      }))
+    },
+
+    async getEntitySuggestions(query: string, type = null, limit = 10) {
+      // Degrada para [] enquanto a Fase 0 (reindex Typesense) não rodar: os
+      // campos `entities`/`entity_org`/… ainda não existem, então o resolver
+      // retorna erro. Não propagamos — o typeahead/página fica vazio, não quebra.
+      const result = await client
+        .query<EntitySuggestionsQueryData>(ENTITY_SUGGESTIONS_QUERY, {
+          query,
+          type,
+          limit,
+        })
+        .toPromise()
+      if (result.error) {
+        return []
+      }
+      return (result.data?.entitySuggestions ?? []).map((e) => ({
+        value: e.value,
+        count: e.count,
       }))
     },
 

--- a/src/services/content/graphql.ts
+++ b/src/services/content/graphql.ts
@@ -21,7 +21,9 @@ import {
   type ArticleGraphQL,
   type ArticleQueryData,
   type ArticlesQueryData,
+  ENTITY_QUERY,
   ENTITY_SUGGESTIONS_QUERY,
+  type EntityQueryData,
   type EntitySuggestionsQueryData,
   ESTIMATE_RECORTE_COUNT_QUERY,
   type EstimateRecorteCountQueryData,
@@ -112,7 +114,18 @@ export function mapGraphqlArticleToRow(article: ArticleGraphQL): ArticleRow {
             text: e.text,
             type: e.type,
             count: e.count,
+            canonical_id: e.canonicalId ?? null,
+            salience: e.salience ?? null,
           })),
+          content_annotations: (article.features.contentAnnotations ?? []).map(
+            (a) => ({
+              start: a.start,
+              end: a.end,
+              type: a.type,
+              text: a.text,
+              canonical_id: a.canonicalId ?? null,
+            }),
+          ),
           view_count: article.features.viewCount ?? null,
           unique_sessions: article.features.uniqueSessions ?? null,
           trending_score: article.features.trendingScore ?? null,
@@ -282,7 +295,33 @@ export function createGraphQLContentService(
       return (result.data?.entitySuggestions ?? []).map((e) => ({
         value: e.value,
         count: e.count,
+        entityId: e.entityId ?? null,
+        label: e.label ?? null,
       }))
+    },
+
+    async getEntity(id: string) {
+      // Degrada para null enquanto a canonicalização não rodar: o `entity(id)`
+      // pode não existir ou retornar erro — a página de entidade cai no
+      // fallback de texto fuzzy. Não propagamos o erro.
+      const result = await client
+        .query<EntityQueryData>(ENTITY_QUERY, { id })
+        .toPromise()
+      if (result.error) {
+        return null
+      }
+      const node = result.data?.entity ?? null
+      if (!node) return null
+      return {
+        entityId: node.entityId,
+        canonicalName: node.canonicalName ?? null,
+        type: node.type ?? null,
+        aliases: node.aliases ?? [],
+        wikidataId: node.wikidataId ?? null,
+        wikidataUrl: node.wikidataUrl ?? null,
+        description: node.description ?? null,
+        agencyKey: node.agencyKey ?? null,
+      }
     },
 
     async getReleaseArticles(id: string) {

--- a/src/services/content/graphql.ts
+++ b/src/services/content/graphql.ts
@@ -39,7 +39,9 @@ import {
   type ThemeArticleCountsQueryData,
 } from '@/lib/graphql/queries/articles'
 import {
+  ENTITY_ARTICLES_QUERY,
   ENTITY_NETWORK_QUERY,
+  type EntityArticlesQueryData,
   type EntityNetworkQueryData,
   RELATED_ENTITIES_QUERY,
   type RelatedEntitiesQueryData,
@@ -423,6 +425,25 @@ export function createGraphQLContentService(
         volumeRatio: e.volumeRatio,
         windowCount: e.windowCount,
       }))
+    },
+
+    async getArticlesByEntity(entityId: string, page = 1, limit = 10) {
+      const result = await client
+        .query<EntityArticlesQueryData>(ENTITY_ARTICLES_QUERY, {
+          entityId,
+          page,
+          limit,
+        })
+        .toPromise()
+      if (result.error) {
+        throw unwrapError(result.error, 'Erro ao carregar artigos da entidade')
+      }
+      const data = result.data?.entityArticles
+      return {
+        articles: (data?.articles ?? []).map(mapGraphqlArticleToRow),
+        found: data?.found ?? 0,
+        page: data?.page ?? page,
+      }
     },
   }
 }

--- a/src/services/content/graphql.ts
+++ b/src/services/content/graphql.ts
@@ -43,6 +43,8 @@ import {
   type EntityNetworkQueryData,
   RELATED_ENTITIES_QUERY,
   type RelatedEntitiesQueryData,
+  TRENDING_ENTITIES_QUERY,
+  type TrendingEntitiesQueryData,
 } from '@/lib/graphql/queries/entities'
 import type { ArticleRow } from '@/types/article'
 import type {
@@ -403,6 +405,24 @@ export function createGraphQLContentService(
           kind: e.kind,
         })),
       }
+    },
+
+    async getTrendingEntities(limit = 6) {
+      // Degrada para [] enquanto entity_trending_scores não existir / DAG não rodou.
+      const result = await client
+        .query<TrendingEntitiesQueryData>(TRENDING_ENTITIES_QUERY, { limit })
+        .toPromise()
+      if (result.error) {
+        return []
+      }
+      return (result.data?.trendingEntities ?? []).map((e) => ({
+        entityId: e.entityId,
+        canonicalName: e.canonicalName ?? '',
+        type: e.type ?? '',
+        trendingScore: e.trendingScore,
+        volumeRatio: e.volumeRatio,
+        windowCount: e.windowCount,
+      }))
     },
   }
 }

--- a/src/services/content/graphql.ts
+++ b/src/services/content/graphql.ts
@@ -38,6 +38,12 @@ import {
   THEME_ARTICLE_COUNTS_QUERY,
   type ThemeArticleCountsQueryData,
 } from '@/lib/graphql/queries/articles'
+import {
+  ENTITY_NETWORK_QUERY,
+  type EntityNetworkQueryData,
+  RELATED_ENTITIES_QUERY,
+  type RelatedEntitiesQueryData,
+} from '@/lib/graphql/queries/entities'
 import type { ArticleRow } from '@/types/article'
 import type {
   ContentService,
@@ -347,6 +353,56 @@ export function createGraphQLContentService(
         throw unwrapError(result.error, 'Erro ao estimar contagem')
       }
       return result.data?.estimateRecorteCount ?? 0
+    },
+
+    async getRelatedEntities(id: string, limit = 12) {
+      // Degrada para [] enquanto o grafo (`entity_edges`) não estiver populado:
+      // o resolver pode retornar vazio/erro — a seção "Entidades relacionadas"
+      // simplesmente não aparece. Não propagamos o erro.
+      const result = await client
+        .query<RelatedEntitiesQueryData>(RELATED_ENTITIES_QUERY, { id, limit })
+        .toPromise()
+      if (result.error) {
+        return []
+      }
+      return (result.data?.relatedEntities ?? []).map((e) => ({
+        canonicalId: e.canonicalId,
+        canonicalName: e.canonicalName ?? null,
+        type: e.type ?? null,
+        wikidataId: e.wikidataId ?? null,
+        weight: e.weight,
+        kind: e.kind,
+      }))
+    },
+
+    async getEntityNetwork(id: string, depth = 1, limit = 50) {
+      // Degrada para uma rede vazia quando o grafo não estiver disponível — a
+      // visualização não renderiza nós. Não propagamos o erro.
+      const result = await client
+        .query<EntityNetworkQueryData>(ENTITY_NETWORK_QUERY, {
+          id,
+          depth,
+          limit,
+        })
+        .toPromise()
+      if (result.error) {
+        return { nodes: [], edges: [] }
+      }
+      const network = result.data?.entityNetwork
+      return {
+        nodes: (network?.nodes ?? []).map((n) => ({
+          entityId: n.entityId,
+          canonicalName: n.canonicalName ?? null,
+          type: n.type ?? null,
+          wikidataId: n.wikidataId ?? null,
+        })),
+        edges: (network?.edges ?? []).map((e) => ({
+          src: e.src,
+          dst: e.dst,
+          weight: e.weight,
+          kind: e.kind,
+        })),
+      }
     },
   }
 }

--- a/src/services/content/types.ts
+++ b/src/services/content/types.ts
@@ -9,6 +9,9 @@
 
 import type { ArticleRow } from '@/types/article'
 
+/** Valores do enum `ArticleSort` do schema, usados na ordenação de busca. */
+export type ArticleSort = 'RELEVANCE' | 'DATE' | 'TRENDING' | 'VIEWS'
+
 /** Filtro de artigos/busca (espelha `ArticleFilter` do schema). */
 export interface ArticleFilterInput {
   agencies?: string[] | null
@@ -18,6 +21,10 @@ export interface ArticleFilterInput {
   endDate?: string | null
   themeLabel?: string | null
   dedup?: boolean | null
+  /** Textos canônicos de entidades (NER). Depende da Fase 0 (reindex). */
+  entities?: string[] | null
+  /** Sentimentos: `positive` / `neutral` / `negative`. */
+  sentiment?: string[] | null
 }
 
 export interface ListArticlesArgs {
@@ -34,6 +41,8 @@ export interface SearchArticlesArgs {
   semantic?: boolean
   alpha?: number | null
   dedup?: boolean
+  /** Ordenação dos resultados. Ausente → RELEVANCE (default do schema). */
+  sort?: ArticleSort | null
 }
 
 export interface ArticlesPage {
@@ -55,6 +64,12 @@ export interface SearchSuggestion {
 export interface ThemeCount {
   code: string
   label: string | null
+  count: number
+}
+
+/** Facet de entidade: texto canônico + contagem de artigos. */
+export interface EntityFacet {
+  value: string
   count: number
 }
 
@@ -83,6 +98,17 @@ export interface ContentService {
 
   /** Contagens de artigos por tema nos últimos N dias. */
   getThemeArticleCounts(days?: number, level?: number): Promise<ThemeCount[]>
+
+  /**
+   * Sugestões de entidades (facets) por prefixo, para o typeahead do filtro e
+   * para resolver o texto canônico nas páginas de entidade. `type` (ORG/PER/LOC)
+   * restringe ao campo tipado. Degrada para `[]` enquanto a Fase 0 não rodar.
+   */
+  getEntitySuggestions(
+    query: string,
+    type?: string | null,
+    limit?: number,
+  ): Promise<EntityFacet[]>
 
   /** Artigos que compõem uma release de clipping. */
   getReleaseArticles(id: string): Promise<ArticleRow[]>

--- a/src/services/content/types.ts
+++ b/src/services/content/types.ts
@@ -25,6 +25,11 @@ export interface ArticleFilterInput {
   entities?: string[] | null
   /** Sentimentos: `positive` / `neutral` / `negative`. */
   sentiment?: string[] | null
+  /**
+   * Ids canônicos de entidades (`Q…`/`dgb_…`) — facet dedup'd por `entity_id`.
+   * Usado pelas páginas `/entidades/[id-canônico]`. Depende da canonicalização.
+   */
+  entityCanonical?: string[] | null
 }
 
 export interface ListArticlesArgs {
@@ -71,6 +76,25 @@ export interface ThemeCount {
 export interface EntityFacet {
   value: string
   count: number
+  /** Id canônico (`Q…`/`dgb_…`) quando o facet já está canonicalizado. */
+  entityId?: string | null
+  /** Rótulo de exibição (canonical_name) quando disponível. */
+  label?: string | null
+}
+
+/**
+ * Entidade canônica (nó do registry) resolvida por `entity(id)` — cabeçalho das
+ * páginas `/entidades/[id-canônico]`.
+ */
+export interface EntityNode {
+  entityId: string
+  canonicalName: string | null
+  type: string | null
+  aliases: string[]
+  wikidataId: string | null
+  wikidataUrl: string | null
+  description: string | null
+  agencyKey: string | null
 }
 
 export interface EstimateRecorteCountArgs {
@@ -109,6 +133,13 @@ export interface ContentService {
     type?: string | null,
     limit?: number,
   ): Promise<EntityFacet[]>
+
+  /**
+   * Resolve uma entidade canônica pelo seu id (`Q…`/`dgb_…`). Retorna `null`
+   * quando o id não existe. Degrada para `null` enquanto o `entity(id)` não
+   * estiver disponível (canonicalização pendente).
+   */
+  getEntity(id: string): Promise<EntityNode | null>
 
   /** Artigos que compõem uma release de clipping. */
   getReleaseArticles(id: string): Promise<ArticleRow[]>

--- a/src/services/content/types.ts
+++ b/src/services/content/types.ts
@@ -135,6 +135,18 @@ export interface EntityNetwork {
   edges: EntityNetworkEdge[]
 }
 
+/** Entidade NER em alta — alimenta a seção "Entidades em Alta" da homepage. */
+export interface TrendingEntity {
+  entityId: string
+  canonicalName: string
+  type: string
+  trendingScore: number
+  /** Multiplicador de volume: window_daily / baseline_daily. Ex: 3.2 → "↑3.2×" */
+  volumeRatio: number
+  /** Artigos na janela de 7 dias. */
+  windowCount: number
+}
+
 export interface EstimateRecorteCountArgs {
   themes: string[]
   agencies: string[]
@@ -200,4 +212,11 @@ export interface ContentService {
     depth?: number,
     limit?: number,
   ): Promise<EntityNetwork>
+
+  /**
+   * Top entidades NER com maior crescimento de cobertura (pré-computado). Lê
+   * `entity_trending_scores` via graphql-api. Degrada para `[]` enquanto a
+   * tabela não existir / o DAG não tiver rodado ainda.
+   */
+  getTrendingEntities(limit?: number): Promise<TrendingEntity[]>
 }

--- a/src/services/content/types.ts
+++ b/src/services/content/types.ts
@@ -97,6 +97,44 @@ export interface EntityNode {
   agencyKey: string | null
 }
 
+/**
+ * Entidade relacionada (vizinho de co-menção, 1-hop) — alimenta a seção
+ * "Entidades relacionadas" da página `/entidades/[id]`.
+ */
+export interface RelatedEntity {
+  /** Id canônico do vizinho (`Q…`/`dgb_…`) — destino do link da página. */
+  canonicalId: string
+  canonicalName: string | null
+  type: string | null
+  wikidataId: string | null
+  /** Peso da aresta (nº de artigos em co-menção). */
+  weight: number
+  /** Tipo da aresta: `co_mention` | `subordinate_to` | `is_agency`. */
+  kind: string
+}
+
+/** Nó da rede ego-centrada (`entityNetwork`). */
+export interface EntityNetworkNode {
+  entityId: string
+  canonicalName: string | null
+  type: string | null
+  wikidataId: string | null
+}
+
+/** Aresta da rede ego-centrada (par direcionado `src`→`dst`). */
+export interface EntityNetworkEdge {
+  src: string
+  dst: string
+  weight: number
+  kind: string
+}
+
+/** Rede de entidades (nós + arestas) consumida pela visualização. */
+export interface EntityNetwork {
+  nodes: EntityNetworkNode[]
+  edges: EntityNetworkEdge[]
+}
+
 export interface EstimateRecorteCountArgs {
   themes: string[]
   agencies: string[]
@@ -146,4 +184,20 @@ export interface ContentService {
 
   /** Estima a contagem de artigos para um recorte. */
   estimateRecorteCount(args: EstimateRecorteCountArgs): Promise<number>
+
+  /**
+   * Entidades relacionadas (co-menção, 1-hop) a uma entidade canônica, por peso.
+   * Degrada para `[]` enquanto o grafo (`entity_edges`) não estiver populado.
+   */
+  getRelatedEntities(id: string, limit?: number): Promise<RelatedEntity[]>
+
+  /**
+   * Rede ego-centrada (nós + arestas) de uma entidade canônica, até `depth`
+   * saltos. Degrada para uma rede vazia quando o grafo não estiver disponível.
+   */
+  getEntityNetwork(
+    id: string,
+    depth?: number,
+    limit?: number,
+  ): Promise<EntityNetwork>
 }

--- a/src/services/content/types.ts
+++ b/src/services/content/types.ts
@@ -219,4 +219,14 @@ export interface ContentService {
    * tabela não existir / o DAG não tiver rodado ainda.
    */
   getTrendingEntities(limit?: number): Promise<TrendingEntity[]>
+
+  /**
+   * Artigos de uma entidade canônica via Postgres (`news_entities`). Não depende
+   * do campo `entityCanonical` no Typesense — funciona sem reprocessamento.
+   */
+  getArticlesByEntity(
+    entityId: string,
+    page?: number,
+    limit?: number,
+  ): Promise<SearchArticlesResult>
 }

--- a/src/types/article.ts
+++ b/src/types/article.ts
@@ -1,13 +1,32 @@
-/** Entidade nomeada extraída do conteúdo (NER). type: ORG/PER/LOC/MISC/EVENT/… */
+/** Entidade nomeada extraída do conteúdo (NER). type: ORG/PER/LOC/EVENT/POLICY/… */
 export type ArticleEntity = {
   text: string
   type: string
   count: number
+  /** Id canônico (`Q…`/`dgb_…`) da entidade; `null` até canonicalizar. */
+  canonical_id?: string | null
+  /** Saliência [0,1] emitida pelo LLM; `null` quando ausente. */
+  salience?: number | null
+}
+
+/**
+ * Anotação de span inline (lente semântica). Offsets char em `content`,
+ * derivados deterministicamente no feature-worker. `canonical_id` liga ao
+ * `entity_registry` quando disponível.
+ */
+export type ContentAnnotation = {
+  start: number
+  end: number
+  type: string
+  text: string
+  canonical_id?: string | null
 }
 
 /** Features computadas (news_features), expostas no detalhe do artigo. */
 export type ArticleFeatures = {
   entities: ArticleEntity[]
+  /** Spans inline para a lente semântica (vazio até a derivação rodar). */
+  content_annotations?: ContentAnnotation[]
   view_count: number | null
   unique_sessions: number | null
   trending_score: number | null

--- a/src/types/article.ts
+++ b/src/types/article.ts
@@ -1,3 +1,20 @@
+/** Entidade nomeada extraída do conteúdo (NER). type: ORG/PER/LOC/MISC/EVENT/… */
+export type ArticleEntity = {
+  text: string
+  type: string
+  count: number
+}
+
+/** Features computadas (news_features), expostas no detalhe do artigo. */
+export type ArticleFeatures = {
+  entities: ArticleEntity[]
+  view_count: number | null
+  unique_sessions: number | null
+  trending_score: number | null
+  word_count: number | null
+  readability_flesch: number | null
+}
+
 export type ArticleRow = {
   unique_id: string
   agency: string | null
@@ -26,6 +43,8 @@ export type ArticleRow = {
   tags: string[] | null
   // Manter theme_1_level_1 como alias para compatibilidade
   theme_1_level_1?: string | null
+  // Features computadas — presentes apenas no detalhe do artigo (ARTICLE_QUERY).
+  features?: ArticleFeatures | null
 }
 
 export type TagFacet = {

--- a/src/types/next-auth.d.ts
+++ b/src/types/next-auth.d.ts
@@ -12,6 +12,8 @@ declare module 'next-auth' {
     }
     /** Access token (JWT Keycloak) para chamadas autenticadas ao graphql-api. */
     accessToken?: string
+    /** Erro de refresh do token (ex: 'RefreshAccessTokenError') — força re-login. */
+    error?: string
   }
 
   interface User {

--- a/src/types/search.ts
+++ b/src/types/search.ts
@@ -15,6 +15,8 @@ export type QueryArticlesArgs = {
   sentiment?: string[]
   /** Textos canônicos de entidades (depende da Fase 0). */
   entities?: string[]
+  /** Ids canônicos de entidades (`Q…`/`dgb_…`); depende da canonicalização. */
+  entityCanonical?: string[]
 }
 
 export type QueryArticlesResult = {

--- a/src/types/search.ts
+++ b/src/types/search.ts
@@ -1,3 +1,4 @@
+import type { ArticleSort } from '@/services/content/types'
 import type { ArticleRow } from './article'
 
 export type QueryArticlesArgs = {
@@ -8,6 +9,12 @@ export type QueryArticlesArgs = {
   agencies?: string[]
   themes?: string[]
   semantic?: boolean
+  /** Ordenação: RELEVANCE (default) / DATE / TRENDING / VIEWS. */
+  sort?: ArticleSort
+  /** Sentimentos: `positive` / `neutral` / `negative`. */
+  sentiment?: string[]
+  /** Textos canônicos de entidades (depende da Fase 0). */
+  entities?: string[]
 }
 
 export type QueryArticlesResult = {


### PR DESCRIPTION
Promove `development` → `main` (produção). Acumula 9 commits desde o último release (11/jun → 24/jun).

## Destaques

### 🐛 Correções
- **fix: 500 em `/minha-conta/clipping`** (#269) — `listFollowedListings()` sem `try/catch` derrubava o SSR com `UNAUTHENTICATED` (token Keycloak expirado). Degradação graciosa + re-login automático quando o refresh do token falha.
- **fix: página `/entidades`** (#268) — passa a buscar artigos via Postgres (sem depender do Typesense).
- **fix: CI** (#252) — permite `workflow_dispatch` sem release tag.

### ✨ Features — Entidades (NER v2 / canonicalização)
- **feature: tela da notícia enriquecida** (#264) — entidades na notícia, filtros/ordenação na busca, páginas de entidade.
- **feature: entidades canônicas** (#265) — grupos Eventos/Políticas e lente semântica.
- **feature: entidades relacionadas + visualização de rede** (#266, Fase 6d) — `relatedEntities` + `entityNetwork`, toggle de rede, botão Maximizar no grafo.
- **feature: "Entidades em Alta" na homepage `/noticias`** (#267).

### ✅ Testes
- spec E2E Fase 6 (`relatedEntities` + `entityNetwork` + toggle rede).

## Validação
Todas as PRs acima já foram validadas em staging individualmente antes do merge em `development`. Os checks de `development` (Unit & Integration Tests, build) estão verdes.

> Env vars são geridas pelo Terraform (repo `infra/`) — este merge só atualiza a imagem via CI/CD.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
