### PR TITLE
fix: /busca sem filtro lista notícias em vez de erro

### DIFF
--- a/e2e/graphql/public-content.spec.ts
+++ b/e2e/graphql/public-content.spec.ts
@@ -244,6 +244,33 @@ test.describe('Conteúdo público via GraphQL', () => {
     ).toBeGreaterThan(0)
   })
 
+  test('busca /busca SEM query nem filtro navega notícias (não erra)', async ({
+    page,
+  }) => {
+    // Regressão: `/busca` sem `q` e sem filtro disparava `search` com query
+    // vazia (rejeitada pelo resolver) → "Ocorreu um erro ao carregar os
+    // resultados.". Deve navegar cronologicamente via `articles` (listArticles).
+    await page.goto('/busca')
+
+    // Cabeçalho do modo navegação (sem termo).
+    await expect(
+      page.getByRole('heading', { name: 'Explorar notícias' }),
+    ).toBeVisible({ timeout: 20_000 })
+
+    // NÃO deve aparecer a mensagem de erro.
+    await expect(
+      page.getByText('Ocorreu um erro ao carregar os resultados.'),
+    ).not.toBeVisible()
+
+    // Deve listar notícias (ordem cronológica desc, sem filtro).
+    const cards = articleLinks(page)
+    await expect(cards.first()).toBeVisible({ timeout: 20_000 })
+    expect(
+      await cards.count(),
+      '/busca sem query deveria listar notícias recentes',
+    ).toBeGreaterThan(0)
+  })
+
   test('detalhe /artigos/[uniqueId] renderiza título e relacionados', async ({
     page,
   }) => {

--- a/src/app/(public)/busca/QueryPageClient.tsx
+++ b/src/app/(public)/busca/QueryPageClient.tsx
@@ -358,7 +358,7 @@ export default function QueryPageClient({
       {/* Cabeçalho institucional */}
       <div className="container mx-auto px-4 text-center mb-12">
         <h2 className="text-3xl font-bold text-primary">
-          Resultados para "{query}"
+          {query ? `Resultados para "${query}"` : 'Explorar notícias'}
         </h2>
 
         {/* Linha divisória SVG */}
@@ -368,7 +368,9 @@ export default function QueryPageClient({
 
         {/* Frase de apoio */}
         <p className="mt-4 text-base text-primary/80">
-          Veja os artigos e publicações que correspondem à sua busca no portal.
+          {query
+            ? 'Veja os artigos e publicações que correspondem à sua busca no portal.'
+            : 'Navegue pelas notícias mais recentes ou refine com os filtros ao lado.'}
         </p>
 
         <div className="mt-4">

--- a/src/app/(public)/busca/__tests__/actions.test.ts
+++ b/src/app/(public)/busca/__tests__/actions.test.ts
@@ -13,10 +13,12 @@ import type { ArticleRow } from '@/types/article'
 // ---------- Mocks ----------
 
 const searchArticles = vi.fn()
+const listArticles = vi.fn()
 const getSearchSuggestions = vi.fn()
 
 const fakeService = {
   searchArticles,
+  listArticles,
   getSearchSuggestions,
 } as unknown as ContentService
 
@@ -90,19 +92,21 @@ describe('queryArticles', () => {
     })
   })
 
-  it('passa filtros nulos e query vazia quando não fornecidos; semantic default true', async () => {
-    searchArticles.mockResolvedValue({ articles: [], found: 0, page: 1 })
+  it('navega cronologicamente (listArticles) quando não há texto NEM filtro', async () => {
+    listArticles.mockResolvedValue({ articles: [row()], found: 7 })
 
     const result = await queryArticles({ page: 1 })
 
-    const arg = searchArticles.mock.calls[0][0]
-    expect(arg.query).toBe('')
-    expect(arg.semantic).toBe(true)
-    expect(arg.filter.agencies).toBeNull()
-    expect(arg.filter.themes).toBeNull()
-    expect(arg.filter.startDate).toBeNull()
-    expect(arg.filter.endDate).toBeNull()
-    expect(result.page).toBe(2)
+    // Não dispara a busca vazia (que o resolver `search` rejeita).
+    expect(searchArticles).not.toHaveBeenCalled()
+    expect(listArticles).toHaveBeenCalledTimes(1)
+    const arg = listArticles.mock.calls[0][0]
+    expect(arg.page).toBe(1)
+    expect(arg.dedup).toBe(true)
+    expect(arg.limit).toBeGreaterThan(0)
+
+    // Contrato preservado: page é o cursor da PRÓXIMA página (page + 1).
+    expect(result).toEqual({ articles: [row()], page: 2, found: 7 })
   })
 
   it('respeita semantic:false explícito', async () => {
@@ -129,10 +133,11 @@ describe('queryArticles', () => {
     expect(searchArticles.mock.calls[0][0].query).toBe('*')
   })
 
-  it('mantém query vazia quando não há texto NEM filtro algum', async () => {
-    searchArticles.mockResolvedValue({ articles: [], found: 0, page: 1 })
-    await queryArticles({ page: 1 })
-    expect(searchArticles.mock.calls[0][0].query).toBe('')
+  it('não usa o wildcard "*" quando não há texto NEM filtro (navega via listArticles)', async () => {
+    listArticles.mockResolvedValue({ articles: [], found: 0 })
+    await queryArticles({ page: 1, semantic: false })
+    expect(searchArticles).not.toHaveBeenCalled()
+    expect(listArticles).toHaveBeenCalledTimes(1)
   })
 
   it('prioriza o texto sobre o wildcard quando há texto E filtro', async () => {

--- a/src/app/(public)/busca/actions.ts
+++ b/src/app/(public)/busca/actions.ts
@@ -176,6 +176,9 @@ export async function getCombinedSearchResults(
   }
 }
 
+/** Tamanho de página no modo navegação (sem texto nem filtro). */
+const BROWSE_PAGE_SIZE = 12
+
 export async function queryArticles(
   args: QueryArticlesArgs,
 ): Promise<QueryArticlesResult> {
@@ -201,10 +204,6 @@ export async function queryArticles(
   const startIso = startDate ? new Date(startDate).toISOString() : null
   const endIso = endDate ? new Date(endDate + 86400000).toISOString() : null
 
-  // O resolver `search` do graphql-api rejeita query vazia. Quando NÃO há
-  // texto mas HÁ ao menos um filtro (entidade/sentimento/agência/tema/data),
-  // usamos `'*'` — o wildcard filter-only aceito. Sem texto E sem filtro
-  // algum, mantemos `''` (não disparamos uma busca "tudo").
   const hasAnyFilter =
     (agencies?.length ?? 0) > 0 ||
     (themes?.length ?? 0) > 0 ||
@@ -213,7 +212,28 @@ export async function queryArticles(
     (entityCanonical?.length ?? 0) > 0 ||
     startIso != null ||
     endIso != null
-  const effectiveQuery = normalizedQuery ?? (hasAnyFilter ? '*' : '')
+
+  // Sem texto E sem filtro algum: o resolver `search` rejeita query vazia, então
+  // disparar a busca aqui dava erro ("Ocorreu um erro ao carregar os resultados").
+  // Em vez disso, navegamos cronologicamente — `articles` (Postgres) já ordena
+  // por published_at desc e dedup por content_hash, o mesmo caminho do feed
+  // /noticias. Isso carrega as notícias mais recentes sem filtro.
+  if (!normalizedQuery && !hasAnyFilter) {
+    const result = await content().listArticles({
+      page,
+      limit: BROWSE_PAGE_SIZE,
+      dedup: true,
+    })
+    return {
+      articles: result.articles,
+      page: page + 1,
+      found: result.found,
+    }
+  }
+
+  // Quando NÃO há texto mas HÁ ao menos um filtro (entidade/sentimento/agência/
+  // tema/data), usamos `'*'` — o wildcard filter-only aceito pelo resolver.
+  const effectiveQuery = normalizedQuery ?? '*'
 
   const result = await content().searchArticles({
     query: effectiveQuery,


### PR DESCRIPTION
## Problema

A tela de busca (`/busca`) **sem `q` e sem nenhum filtro** exibia *"Ocorreu um erro ao carregar os resultados."* em vez de carregar as notícias.

## Causa raiz

`queryArticles` montava `effectiveQuery = ''` nesse caso e chamava o resolver `search` do graphql-api, que **rejeita query vazia**. Confirmado contra o backend real:

```
search(query:"") → erro: "Query must not be empty"
```

## Correção

- **`busca/actions.ts`**: quando não há texto **nem** filtro algum, navega cronologicamente via `listArticles` (query `articles`, Postgres — já ordena por `published_at desc` + dedup por `content_hash`), o **mesmo caminho do feed `/noticias`**. O caso "filtro sem texto" continua usando o wildcard `'*'` (intacto).
- **`QueryPageClient.tsx`**: cabeçalho passa a "Explorar notícias" quando não há query (em vez de `Resultados para ""`).

## Validação

- **Backend real (prod)**: `articles(page:1, limit:12, filter:{dedup:true})` → sem erro, 122k+ artigos, `publishedAt` em ordem **decrescente** confirmada.
- **Browser (Chromium, portal local → graphql-api Cloud Run)**: `/busca` → "Explorar notícias", **sem erro**, 12 cards; `/busca?q=governo` segue OK (20 cards).
- **Unit**: 17/17 (`busca/__tests__/actions.test.ts`).
- **E2E**: novo teste de regressão em `e2e/graphql/public-content.spec.ts` (`/busca` sem query renderiza notícias e não mostra o erro).
- `tsc`: zero erros novos; lint limpo.